### PR TITLE
feat: Bun-side outbox routing + VM keep-alive ping

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -31,7 +31,7 @@ defmodule Shire.Agent.AgentManager do
     ## Sending Messages
     To message another agent, write a JSON file to your **outbox**:
 
-    **Path:** `/workspace/agents/#{agent_name}/outbox/<timestamp>.json`
+    **Path:** `/workspace/agents/#{agent_name}/outbox/<any-name>.json`
 
     **Format:**
     ```json
@@ -43,10 +43,10 @@ defmodule Shire.Agent.AgentManager do
 
     Example using Bash:
     ```bash
-    echo '{"to":"target-agent","text":"Hello, can you help me with X?"}' > /workspace/agents/#{agent_name}/outbox/$(date +%s%3N)-$RANDOM.json
+    echo '{"to":"target-agent","text":"Hello, can you help me with X?"}' > /workspace/agents/#{agent_name}/outbox/msg.json
     ```
 
-    The system picks up the message and delivers it to the target agent automatically.
+    The system delivers the message to the target agent automatically.
 
     ## Receiving Messages
     Messages arrive in your conversation automatically:
@@ -72,17 +72,11 @@ defmodule Shire.Agent.AgentManager do
     """
   end
 
-  @outbox_poll_interval 2_000
-  # 15 minutes
-  @idle_threshold_ms 60_000 * 15
-
   defstruct [
     :agent_name,
     :command,
     :command_ref,
     :pubsub_topic,
-    :outbox_timer,
-    :last_activity,
     status: :idle,
     buffer: "",
     streaming_text: nil,
@@ -171,53 +165,29 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @impl true
-  def handle_call({:send_message, text, from}, _from_pid, %{status: :active} = state) do
-    {type, from_str} =
-      case from do
-        :user -> {"user_message", "user"}
-        {:agent, name} -> {"agent_message", name}
-      end
-
+  def handle_call({:send_message, text, _from}, _from_pid, %{status: :active} = state) do
     envelope = %{
       "ts" => System.system_time(:millisecond),
-      "type" => type,
-      "from" => from_str,
+      "type" => "user_message",
+      "from" => "user",
       "payload" => %{"text" => text}
     }
 
     inbox_dir = "/workspace/agents/#{state.agent_name}/inbox"
     filename = "#{envelope["ts"]}-#{random_suffix()}.json"
 
-    state = %{state | last_activity: System.monotonic_time(:millisecond)}
-
     case write_inbox_file("#{inbox_dir}/#{filename}", envelope) do
       :ok ->
-        case from do
-          :user ->
-            case Agents.create_message(%{
-                   agent_name: state.agent_name,
-                   role: "user",
-                   content: %{"text" => text}
-                 }) do
-              {:ok, msg} ->
-                {:reply, {:ok, msg}, state}
+        case Agents.create_message(%{
+               agent_name: state.agent_name,
+               role: "user",
+               content: %{"text" => text}
+             }) do
+          {:ok, msg} ->
+            {:reply, {:ok, msg}, state}
 
-              {:error, reason} ->
-                Logger.warning("Failed to persist user message: #{inspect(reason)}")
-                {:reply, :ok, state}
-            end
-
-          {:agent, from_name} ->
-            Agents.create_message(%{
-              agent_name: state.agent_name,
-              role: "inter_agent",
-              content: %{
-                "text" => text,
-                "from_agent" => from_name,
-                "to_agent" => state.agent_name
-              }
-            })
-
+          {:error, reason} ->
+            Logger.warning("Failed to persist user message: #{inspect(reason)}")
             {:reply, :ok, state}
         end
 
@@ -260,8 +230,21 @@ defmodule Shire.Agent.AgentManager do
     state =
       Enum.reduce(lines, state, fn line, acc ->
         case parse_stdout_line(line) do
-          {:ok, %{"type" => "agent_message", "payload" => %{"to_agent" => to, "text" => text}}} ->
-            __MODULE__.send_message(to, text, {:agent, acc.agent_name})
+          {:ok,
+           %{
+             "type" => "agent_message_received",
+             "payload" => %{"from_agent" => from_agent, "text" => text}
+           }} ->
+            Agents.create_message(%{
+              agent_name: acc.agent_name,
+              role: "inter_agent",
+              content: %{
+                "text" => text,
+                "from_agent" => from_agent,
+                "to_agent" => acc.agent_name
+              }
+            })
+
             acc
 
           {:ok, %{"type" => "spawn_agent", "payload" => %{"name" => new_name}}} ->
@@ -321,67 +304,6 @@ defmodule Shire.Agent.AgentManager do
     {:noreply, state}
   end
 
-  # Host-side outbox polling — reads agent's outbox via VM filesystem API
-  # and routes messages to target agents. This bypasses unreliable intra-VM
-  # file detection (fs.watch/polling don't work for files written by child processes).
-  @impl true
-  def handle_info(:poll_outbox, %{status: :active} = state) do
-    idle? =
-      state.last_activity == nil or
-        System.monotonic_time(:millisecond) - state.last_activity >= @idle_threshold_ms
-
-    if idle? do
-      {:noreply, %{state | outbox_timer: schedule_outbox_poll()}}
-    else
-      outbox_dir = "/workspace/agents/#{state.agent_name}/outbox"
-
-      case @vm.ls(outbox_dir) do
-        {:ok, entries} ->
-          (entries || [])
-          |> Enum.filter(&String.ends_with?(&1["name"] || "", ".json"))
-          |> Enum.sort_by(& &1["name"])
-          |> Enum.each(fn entry ->
-            path = "#{outbox_dir}/#{entry["name"]}"
-
-            case @vm.read(path) do
-              {:ok, content} ->
-                sanitized = Regex.replace(~r/\\([^"\\\/bfnrtu])/, content, "\\1")
-
-                case Jason.decode(sanitized) do
-                  {:ok, %{"to" => to, "text" => text}} ->
-                    try do
-                      __MODULE__.send_message(to, text, {:agent, state.agent_name})
-                    catch
-                      :exit, reason ->
-                        Logger.warning(
-                          "Failed to deliver outbox message to #{to}: #{inspect(reason)}"
-                        )
-                    end
-
-                    @vm.rm(path)
-
-                  other ->
-                    Logger.warning("Invalid outbox message in #{path}: #{inspect(other)}")
-                    @vm.rm(path)
-                end
-
-              {:error, reason} ->
-                Logger.warning("Failed to read outbox file #{path}: #{inspect(reason)}")
-            end
-          end)
-
-        {:error, _} ->
-          :ok
-      end
-
-      {:noreply, %{state | outbox_timer: schedule_outbox_poll()}}
-    end
-  end
-
-  def handle_info(:poll_outbox, state) do
-    {:noreply, %{state | outbox_timer: nil}}
-  end
-
   @impl true
   def handle_info(msg, state) do
     Logger.debug("AgentManager #{state.agent_name} unexpected message: #{inspect(msg)}")
@@ -408,21 +330,6 @@ defmodule Shire.Agent.AgentManager do
   # --- Private ---
 
   defp transition_status(state, status) do
-    state =
-      if state.outbox_timer do
-        Process.cancel_timer(state.outbox_timer)
-        %{state | outbox_timer: nil}
-      else
-        state
-      end
-
-    state =
-      if status == :active do
-        %{state | outbox_timer: schedule_outbox_poll()}
-      else
-        state
-      end
-
     state = %{state | status: status}
 
     Phoenix.PubSub.broadcast(
@@ -438,10 +345,6 @@ defmodule Shire.Agent.AgentManager do
     )
 
     state
-  end
-
-  defp schedule_outbox_poll do
-    Process.send_after(self(), :poll_outbox, @outbox_poll_interval)
   end
 
   defp setup_agent_workspace(agent_name) do

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -11,6 +11,9 @@ defmodule Shire.Agent.Coordinator do
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
+  @ping_interval 2_000
+  @default_ping_duration :timer.minutes(30)
+
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
@@ -46,6 +49,7 @@ defmodule Shire.Agent.Coordinator do
   end
 
   def send_message(agent_name, text) do
+    GenServer.cast(__MODULE__, :start_ping)
     AgentManager.send_message(agent_name, text, :user)
   end
 
@@ -85,7 +89,9 @@ defmodule Shire.Agent.Coordinator do
 
     state = %{
       monitors: %{},
-      statuses: %{}
+      statuses: %{},
+      ping_timer: nil,
+      ping_until: nil
     }
 
     {:ok, state, {:continue, :deploy_and_scan}}
@@ -274,6 +280,30 @@ defmodule Shire.Agent.Coordinator do
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
+    end
+  end
+
+  @impl true
+  def handle_cast(:start_ping, state) do
+    ping_until = System.monotonic_time(:millisecond) + @default_ping_duration
+    state = %{state | ping_until: ping_until}
+
+    if state.ping_timer do
+      {:noreply, state}
+    else
+      {:noreply, schedule_ping(state)}
+    end
+  end
+
+  @impl true
+  def handle_info(:ping_vm, state) do
+    now = System.monotonic_time(:millisecond)
+
+    if state.ping_until && now < state.ping_until do
+      Task.start(fn -> @vm.cmd("echo", ["ping"], []) end)
+      {:noreply, schedule_ping(state)}
+    else
+      {:noreply, %{state | ping_timer: nil, ping_until: nil}}
     end
   end
 
@@ -511,6 +541,11 @@ defmodule Shire.Agent.Coordinator do
       {:error, reason} ->
         {:reply, {:error, reason}, state}
     end
+  end
+
+  defp schedule_ping(state) do
+    timer = Process.send_after(self(), :ping_vm, @ping_interval)
+    %{state | ping_timer: timer}
   end
 
   defp start_agent_manager(agent_name, monitors) do

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -1,7 +1,7 @@
 // agent-runner.test.ts — Tests for agent-runner with harness abstraction.
 import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, readdirSync } from "fs";
-import { emit, loadConfig, processMessage, processInbox, type MessageEnvelope } from "./agent-runner";
+import { emit, loadConfig, processMessage, processInbox, processOutbox, type MessageEnvelope } from "./agent-runner";
 import type { Harness } from "./harness";
 import { createHarness } from "./harness";
 
@@ -147,6 +147,34 @@ describe("processMessage() — agent_message", () => {
 
     expect(harness.sendMessage).toHaveBeenCalledWith("Here is data.", "researcher-bot");
   });
+
+  test("emits agent_message_received event with from_agent and text", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({
+      type: "agent_message",
+      from: "researcher-bot",
+      payload: { text: "Here is data." },
+    });
+
+    const events = await captureEmits(async () => {
+      await processMessage(harness, envelope);
+    });
+
+    const received = events.find((e) => e.type === "agent_message_received");
+    expect(received).toBeDefined();
+    expect(received!.payload).toEqual({ from_agent: "researcher-bot", text: "Here is data." });
+  });
+
+  test("does not emit agent_message_received for user messages", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({ type: "user_message", payload: { text: "Hi" } });
+
+    const events = await captureEmits(async () => {
+      await processMessage(harness, envelope);
+    });
+
+    expect(events.find((e) => e.type === "agent_message_received")).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -290,5 +318,68 @@ max_tokens: 8192
     expect(config.model).toBe("claude-sonnet-4-6");
     expect(config.system_prompt).toBe("");
     expect(config.max_tokens).toBe(16384);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processOutbox() — routes outbox messages to target agent inboxes
+// ---------------------------------------------------------------------------
+
+const TEST_OUTBOX = "/tmp/test-outbox-" + process.pid;
+const TEST_AGENTS_ROOT = "/tmp/test-agents-root-" + process.pid;
+
+describe("processOutbox()", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_OUTBOX, { recursive: true });
+    mkdirSync(`${TEST_AGENTS_ROOT}/target-agent/inbox`, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_OUTBOX, { recursive: true, force: true });
+    rmSync(TEST_AGENTS_ROOT, { recursive: true, force: true });
+  });
+
+  test("returns 0 when outbox is empty", async () => {
+    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT);
+    expect(count).toBe(0);
+  });
+
+  test("routes message to target agent inbox and removes outbox file", async () => {
+    const msg = { to: "target-agent", text: "hello there" };
+    writeFileSync(`${TEST_OUTBOX}/msg.json`, JSON.stringify(msg));
+
+    const events = await captureEmits(async () => {
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT);
+    });
+
+    // Outbox file removed
+    const remaining = readdirSync(TEST_OUTBOX).filter((f) => f.endsWith(".json"));
+    expect(remaining).toHaveLength(0);
+
+    // Envelope written to target inbox
+    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/target-agent/inbox`).filter((f) => f.endsWith(".json"));
+    expect(inboxFiles).toHaveLength(1);
+
+    const raw = Bun.file(`${TEST_AGENTS_ROOT}/target-agent/inbox/${inboxFiles[0]}`);
+    const envelope = JSON.parse(await raw.text());
+    expect(envelope.type).toBe("agent_message");
+    expect(envelope.payload.text).toBe("hello there");
+    expect(typeof envelope.ts).toBe("number");
+
+    // Emits agent_message_sent event
+    const sent = events.find((e) => e.type === "agent_message_sent");
+    expect(sent).toBeDefined();
+    expect(sent!.payload).toEqual({ to_agent: "target-agent", text: "hello there" });
+  });
+
+  test("processes multiple outbox files", async () => {
+    writeFileSync(`${TEST_OUTBOX}/a.json`, JSON.stringify({ to: "target-agent", text: "first" }));
+    writeFileSync(`${TEST_OUTBOX}/b.json`, JSON.stringify({ to: "target-agent", text: "second" }));
+
+    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT);
+    expect(count).toBe(2);
+
+    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/target-agent/inbox`).filter((f) => f.endsWith(".json"));
+    expect(inboxFiles).toHaveLength(2);
   });
 });

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -1,8 +1,8 @@
-// agent-runner.ts — Bun daemon that watches the inbox and dispatches to configured harness.
+// agent-runner.ts — Bun daemon that watches the inbox/outbox and dispatches to configured harness.
 // Each agent runs in its own workspace directory under /workspace/agents/{name}/.
 import { watch } from "fs";
-import { readFile, readdir, unlink } from "fs/promises";
-import { join } from "path";
+import { readFile, readdir, unlink, writeFile } from "fs/promises";
+import { basename, join } from "path";
 import { parseArgs } from "util";
 import yaml from "js-yaml";
 import { createHarness, type Harness, type HarnessType } from "./harness";
@@ -18,6 +18,8 @@ const { values } = parseArgs({
 
 const AGENT_DIR = (typeof values["agent-dir"] === "string" ? values["agent-dir"] : null) || "/workspace/agents/default";
 const INBOX_DIR = join(AGENT_DIR, "inbox");
+const OUTBOX_DIR = join(AGENT_DIR, "outbox");
+const AGENTS_ROOT = join(AGENT_DIR, "../");
 const RECIPE_PATH = join(AGENT_DIR, "recipe.yaml");
 
 export interface AgentConfig {
@@ -32,6 +34,11 @@ export interface MessageEnvelope {
   type: string;
   from: string;
   payload: Record<string, unknown>;
+}
+
+export interface OutboxMessage {
+  to: string;
+  text: string;
 }
 
 export function emit(type: string, payload: Record<string, unknown> = {}) {
@@ -59,6 +66,9 @@ export async function processMessage(harness: Harness, envelope: MessageEnvelope
     const text = envelope.payload.text as string;
     const from = envelope.type === "agent_message" ? envelope.from : undefined;
     await harness.sendMessage(text, from);
+    if (from) {
+      emit("agent_message_received", { from_agent: from, text });
+    }
   } else if (envelope.type === "interrupt") {
     await harness.interrupt();
     emit("interrupted", {});
@@ -82,6 +92,44 @@ export async function processInbox(harness: Harness, inboxDir = INBOX_DIR): Prom
   }
 
   return sorted.length;
+}
+
+// ---------------------------------------------------------------------------
+// Outbox routing — delivers messages to target agent inboxes
+// ---------------------------------------------------------------------------
+
+function agentName(): string {
+  return basename(AGENT_DIR);
+}
+
+export async function processOutbox(outboxDir = OUTBOX_DIR, agentsRoot = AGENTS_ROOT): Promise<number> {
+  const files = await readdir(outboxDir);
+  const jsonFiles = files.filter((f) => f.endsWith(".json")).sort();
+
+  for (const file of jsonFiles) {
+    const path = join(outboxDir, file);
+    try {
+      const raw = await readFile(path, "utf-8");
+      const msg: OutboxMessage = JSON.parse(raw);
+
+      const targetInbox = join(agentsRoot, msg.to, "inbox");
+      const ts = Date.now();
+      const envelope: MessageEnvelope = {
+        ts,
+        type: "agent_message",
+        from: agentName(),
+        payload: { text: msg.text },
+      };
+      const filename = `${ts}-${Math.random().toString(36).slice(2, 6)}.json`;
+      await writeFile(join(targetInbox, filename), JSON.stringify(envelope));
+      emit("agent_message_sent", { to_agent: msg.to, text: msg.text });
+      await unlink(path);
+    } catch (err) {
+      emit("error", { message: `Failed to route outbox ${file}: ${err}` });
+    }
+  }
+
+  return jsonFiles.length;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,8 +158,8 @@ async function main() {
     emit("processing", { active: false });
   }
 
-  // Watch for new messages
-  const watcher = watch(INBOX_DIR, async (_eventType: string, filename: string | null) => {
+  // Watch for new inbox messages
+  const inboxWatcher = watch(INBOX_DIR, async (_eventType: string, filename: string | null) => {
     if (!filename?.endsWith(".json") || processing) return;
     processing = true;
     emit("processing", { active: true });
@@ -126,6 +174,22 @@ async function main() {
     }
   });
 
+  // Watch outbox and route messages to target agent inboxes
+  let routing = false;
+  await processOutbox();
+  const outboxWatcher = watch(OUTBOX_DIR, async (_eventType: string, filename: string | null) => {
+    if (!filename?.endsWith(".json") || routing) return;
+    routing = true;
+    try {
+      let count: number;
+      do {
+        count = await processOutbox();
+      } while (count > 0);
+    } finally {
+      routing = false;
+    }
+  });
+
   // Heartbeat every 30 seconds
   setInterval(() => {
     emit("heartbeat", { status: "alive" });
@@ -133,7 +197,8 @@ async function main() {
 
   // Keep process alive
   process.on("SIGTERM", () => {
-    watcher.close();
+    inboxWatcher.close();
+    outboxWatcher.close();
     harness.stop();
     emit("shutdown", {});
     process.exit(0);

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -325,15 +325,9 @@ defmodule Shire.Agent.AgentManagerTest do
     end
   end
 
-  describe "send_message with agent from" do
-    test "writes agent message envelope to inbox and persists" do
+  describe "agent_message_received stdout event" do
+    test "persists inter_agent message to DB" do
       Mox.set_mox_global()
-      test_pid = self()
-
-      stub(Shire.VirtualMachineMock, :write, fn path, content ->
-        send(test_pid, {:vm_write, path, content})
-        :ok
-      end)
 
       {:ok, pid} = start_manager()
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
@@ -344,14 +338,23 @@ defmodule Shire.Agent.AgentManagerTest do
         %{state | command: %{ref: ref}, command_ref: ref, status: :active}
       end)
 
-      assert :ok = GenServer.call(pid, {:send_message, "hello", {:agent, "other-agent"}})
+      event =
+        Jason.encode!(%{
+          "type" => "agent_message_received",
+          "payload" => %{"from_agent" => "other-agent", "text" => "hello from other"}
+        })
 
-      assert_receive {:vm_write, path, content}, 1_000
-      assert path =~ "/workspace/agents/#{@agent_name}/inbox/"
-      decoded = Jason.decode!(content)
-      assert decoded["type"] == "agent_message"
-      assert decoded["from"] == "other-agent"
-      assert decoded["payload"]["text"] == "hello"
+      send(pid, {:stdout, %{ref: ref}, event <> "\n"})
+
+      # Give it a moment to process
+      Process.sleep(50)
+
+      {messages, _has_more} = Agents.list_messages_for_agent(@agent_name)
+      inter_agent = Enum.find(messages, &(&1.role == "inter_agent"))
+      assert inter_agent != nil
+      assert inter_agent.content["text"] == "hello from other"
+      assert inter_agent.content["from_agent"] == "other-agent"
+      assert inter_agent.content["to_agent"] == @agent_name
     end
   end
 
@@ -398,204 +401,6 @@ defmodule Shire.Agent.AgentManagerTest do
       assert :ok = AgentManager.restart(@agent_name)
 
       assert_receive {:status, :bootstrapping}, 1_000
-    end
-  end
-
-  describe "outbox polling" do
-    test "polls outbox and delivers agent messages when active" do
-      Mox.set_mox_global()
-      test_pid = self()
-
-      stub(Shire.VirtualMachineMock, :ls, fn path ->
-        if String.ends_with?(path, "/outbox") do
-          {:ok, [%{"name" => "1234.json"}]}
-        else
-          {:ok, []}
-        end
-      end)
-
-      stub(Shire.VirtualMachineMock, :read, fn _path ->
-        {:ok, Jason.encode!(%{"to" => "target-agent", "text" => "hello from outbox"})}
-      end)
-
-      stub(Shire.VirtualMachineMock, :rm, fn path ->
-        send(test_pid, {:vm_rm, path})
-        :ok
-      end)
-
-      stub(Shire.VirtualMachineMock, :write, fn path, content ->
-        send(test_pid, {:vm_write, path, content})
-        :ok
-      end)
-
-      # Start target agent so send_message can reach it
-      {:ok, target_pid} =
-        AgentManager.start_link(agent_name: "target-agent", skip_sprite: true)
-
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), target_pid)
-
-      target_ref = make_ref()
-
-      :sys.replace_state(target_pid, fn state ->
-        %{state | command: %{ref: target_ref}, command_ref: target_ref, status: :active}
-      end)
-
-      {:ok, pid} = start_manager()
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
-
-      ref = make_ref()
-
-      :sys.replace_state(pid, fn state ->
-        %{
-          state
-          | command: %{ref: ref},
-            command_ref: ref,
-            status: :active,
-            last_activity: System.monotonic_time(:millisecond)
-        }
-      end)
-
-      send(pid, :poll_outbox)
-
-      # Message delivered to target agent via send_message
-      assert_receive {:vm_write, path, content}, 2_000
-      assert path =~ "/workspace/agents/target-agent/inbox/"
-      decoded = Jason.decode!(content)
-      assert decoded["type"] == "agent_message"
-      assert decoded["from"] == @agent_name
-      assert decoded["payload"]["text"] == "hello from outbox"
-
-      # Outbox file removed after delivery
-      assert_receive {:vm_rm, rm_path}, 1_000
-      assert rm_path =~ "/outbox/1234.json"
-    end
-
-    test "handles shell-escaped JSON in outbox messages" do
-      Mox.set_mox_global()
-      test_pid = self()
-
-      stub(Shire.VirtualMachineMock, :ls, fn path ->
-        if String.ends_with?(path, "/outbox") do
-          {:ok, [%{"name" => "1234.json"}]}
-        else
-          {:ok, []}
-        end
-      end)
-
-      # Simulate shell adding backslash escapes (e.g. \! from bash history expansion)
-      stub(Shire.VirtualMachineMock, :read, fn _path ->
-        {:ok, ~s|{"to":"target-agent","text":"Hello\\! How are you\\?"}|}
-      end)
-
-      stub(Shire.VirtualMachineMock, :rm, fn _path -> :ok end)
-
-      stub(Shire.VirtualMachineMock, :write, fn path, content ->
-        send(test_pid, {:vm_write, path, content})
-        :ok
-      end)
-
-      # Start target agent
-      {:ok, target_pid} =
-        AgentManager.start_link(agent_name: "target-agent", skip_sprite: true)
-
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), target_pid)
-
-      target_ref = make_ref()
-
-      :sys.replace_state(target_pid, fn state ->
-        %{state | command: %{ref: target_ref}, command_ref: target_ref, status: :active}
-      end)
-
-      {:ok, pid} = start_manager()
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
-
-      ref = make_ref()
-
-      :sys.replace_state(pid, fn state ->
-        %{
-          state
-          | command: %{ref: ref},
-            command_ref: ref,
-            status: :active,
-            last_activity: System.monotonic_time(:millisecond)
-        }
-      end)
-
-      send(pid, :poll_outbox)
-
-      assert_receive {:vm_write, path, content}, 2_000
-      assert path =~ "/workspace/agents/target-agent/inbox/"
-      decoded = Jason.decode!(content)
-      assert decoded["payload"]["text"] == "Hello! How are you?"
-    end
-
-    test "handles nil entries from ls gracefully" do
-      Mox.set_mox_global()
-
-      stub(Shire.VirtualMachineMock, :ls, fn _path -> {:ok, nil} end)
-
-      {:ok, pid} = start_manager()
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
-
-      ref = make_ref()
-
-      :sys.replace_state(pid, fn state ->
-        %{
-          state
-          | command: %{ref: ref},
-            command_ref: ref,
-            status: :active,
-            last_activity: System.monotonic_time(:millisecond)
-        }
-      end)
-
-      send(pid, :poll_outbox)
-
-      # Should not crash — verify process is still alive
-      assert Process.alive?(pid)
-      state = AgentManager.get_state(pid)
-      assert state.status == :active
-    end
-
-    test "does not poll when not active" do
-      {:ok, pid} = start_manager()
-
-      send(pid, :poll_outbox)
-
-      state = AgentManager.get_state(pid)
-      assert state.status == :idle
-      assert state.outbox_timer == nil
-    end
-
-    test "skips outbox poll when idle" do
-      Mox.set_mox_global()
-      test_pid = self()
-
-      stub(Shire.VirtualMachineMock, :ls, fn _path ->
-        send(test_pid, :ls_called)
-        {:ok, []}
-      end)
-
-      {:ok, pid} = start_manager()
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
-
-      ref = make_ref()
-
-      :sys.replace_state(pid, fn state ->
-        %{
-          state
-          | command: %{ref: ref},
-            command_ref: ref,
-            status: :active,
-            last_activity: System.monotonic_time(:millisecond) - 960_000
-        }
-      end)
-
-      send(pid, :poll_outbox)
-
-      # Give it a moment to process
-      Process.sleep(50)
-      refute_received :ls_called
     end
   end
 end

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -338,6 +338,67 @@ defmodule Shire.Agent.CoordinatorTest do
     end
   end
 
+  describe "VM keep-alive ping" do
+    test "send_message starts pinging the VM" do
+      # Track cmd calls to detect pings
+      ping_count = :counters.new(1, [])
+
+      stub(Shire.VirtualMachineMock, :cmd, fn cmd, args, _opts ->
+        if cmd == "echo" and args == ["ping"] do
+          :counters.add(ping_count, 1, 1)
+        end
+
+        {:ok, ""}
+      end)
+
+      {:ok, _pid} = start_agent_manager(@agent_name)
+
+      # Put agent in active state so send_message works
+      {:ok, agent_pid} = Coordinator.lookup(@agent_name)
+      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), agent_pid)
+
+      ref = make_ref()
+
+      :sys.replace_state(agent_pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      # Send a message — this should trigger pinging
+      Coordinator.send_message(@agent_name, "hello")
+
+      # Wait for a few ping cycles (2s interval)
+      Process.sleep(5_000)
+
+      assert :counters.get(ping_count, 1) >= 2
+    end
+
+    test "new send_message extends the ping period" do
+      {:ok, _pid} = start_agent_manager(@agent_name)
+      {:ok, agent_pid} = Coordinator.lookup(@agent_name)
+      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), agent_pid)
+
+      ref = make_ref()
+
+      :sys.replace_state(agent_pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      Coordinator.send_message(@agent_name, "first")
+
+      # Get the initial ping_until
+      state1 = :sys.get_state(GenServer.whereis(Coordinator))
+      assert state1.ping_until != nil
+
+      Process.sleep(100)
+
+      Coordinator.send_message(@agent_name, "second")
+
+      # The ping_until should have been extended
+      state2 = :sys.get_state(GenServer.whereis(Coordinator))
+      assert state2.ping_until > state1.ping_until
+    end
+  end
+
   describe "create_agent/1" do
     test "creates agent directory structure on VM and starts AgentManager" do
       unique_name = "coord-create-test-#{System.unique_integer([:positive])}"


### PR DESCRIPTION
## Summary

- **Outbox routing moved to Bun agent-runner:** Agents write simple `{"to", "text"}` JSON to their outbox directory. The runner watches via `fs.watch`, converts to full envelopes with timestamps, and delivers directly to the target agent's inbox. Eliminates host-side 2s polling entirely.
- **Receiver-only DB persistence:** Only the `agent_message_received` event (emitted by the receiving runner) persists inter-agent messages to the DB, avoiding duplicates.
- **VM keep-alive ping:** Coordinator pings the Sprite VM every 2s for 30min after `send_message`, preventing the VM from sleeping while agents do background work.

## Test plan

- [x] All 113 Elixir tests pass (`mix test`)
- [x] All 47 Bun agent-runner tests pass (`cd priv/sprite && bun test`)
- [x] Compilation clean with `--warnings-as-errors`
- [x] Formatting clean (`mix format --check-formatted`)
- [ ] Manual: send a message to an agent and verify VM stays awake for background work
- [ ] Manual: verify inter-agent messaging works end-to-end (agent A messages agent B via outbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)