### PR TITLE
refactor: move VM keep-alive ping to VirtualMachineImpl

### DIFF
--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -11,9 +11,6 @@ defmodule Shire.Agent.Coordinator do
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
-  @ping_interval 2_000
-  @default_ping_duration :timer.minutes(30)
-
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
@@ -49,7 +46,6 @@ defmodule Shire.Agent.Coordinator do
   end
 
   def send_message(agent_name, text) do
-    GenServer.cast(__MODULE__, :start_ping)
     AgentManager.send_message(agent_name, text, :user)
   end
 
@@ -89,9 +85,7 @@ defmodule Shire.Agent.Coordinator do
 
     state = %{
       monitors: %{},
-      statuses: %{},
-      ping_timer: nil,
-      ping_until: nil
+      statuses: %{}
     }
 
     {:ok, state, {:continue, :deploy_and_scan}}
@@ -280,30 +274,6 @@ defmodule Shire.Agent.Coordinator do
 
       {:error, reason} ->
         {:reply, {:error, reason}, state}
-    end
-  end
-
-  @impl true
-  def handle_cast(:start_ping, state) do
-    ping_until = System.monotonic_time(:millisecond) + @default_ping_duration
-    state = %{state | ping_until: ping_until}
-
-    if state.ping_timer do
-      {:noreply, state}
-    else
-      {:noreply, schedule_ping(state)}
-    end
-  end
-
-  @impl true
-  def handle_info(:ping_vm, state) do
-    now = System.monotonic_time(:millisecond)
-
-    if state.ping_until && now < state.ping_until do
-      Task.start(fn -> @vm.cmd("echo", ["ping"], []) end)
-      {:noreply, schedule_ping(state)}
-    else
-      {:noreply, %{state | ping_timer: nil, ping_until: nil}}
     end
   end
 
@@ -541,11 +511,6 @@ defmodule Shire.Agent.Coordinator do
       {:error, reason} ->
         {:reply, {:error, reason}, state}
     end
-  end
-
-  defp schedule_ping(state) do
-    timer = Process.send_after(self(), :ping_vm, @ping_interval)
-    %{state | ping_timer: timer}
   end
 
   defp start_agent_manager(agent_name, monitors) do

--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -20,6 +20,8 @@ defmodule Shire.VirtualMachineImpl do
   @default_cmd_timeout 30_000
   @ready_retries 6
   @ready_backoff 5_000
+  @ping_interval 2_000
+  @keepalive_duration :timer.minutes(30)
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -152,7 +154,7 @@ defmodule Shire.VirtualMachineImpl do
       case init_shared_vm(token) do
         {:ok, sprite, fs} ->
           Logger.info("Shared VM #{get_sprite_name()} ready")
-          {:ok, %{sprite: sprite, fs: fs}}
+          {:ok, %{sprite: sprite, fs: fs, ping_timer: nil, ping_until: nil}}
 
         {:error, reason} ->
           Logger.error("Failed to initialize shared VM: #{inspect(reason)}")
@@ -160,7 +162,7 @@ defmodule Shire.VirtualMachineImpl do
       end
     else
       Logger.warning("No SPRITES_TOKEN configured — VM features disabled")
-      {:ok, %{sprite: nil, fs: nil}}
+      {:ok, %{sprite: nil, fs: nil, ping_timer: nil, ping_until: nil}}
     end
   end
 
@@ -191,7 +193,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call({:read, _path}, _from, %{fs: nil} = state) do
@@ -209,7 +211,7 @@ defmodule Shire.VirtualMachineImpl do
           err
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call({:write, _path, _content}, _from, %{fs: nil} = state) do
@@ -227,7 +229,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call({:mkdir_p, _path}, _from, %{fs: nil} = state) do
@@ -245,7 +247,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call({:rm, _path}, _from, %{fs: nil} = state) do
@@ -263,7 +265,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call({:rm_rf, _path}, _from, %{fs: nil} = state) do
@@ -281,7 +283,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call({:ls, _path}, _from, %{fs: nil} = state) do
@@ -299,7 +301,7 @@ defmodule Shire.VirtualMachineImpl do
           err
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call({:stat, _path}, _from, %{fs: nil} = state) do
@@ -317,11 +319,34 @@ defmodule Shire.VirtualMachineImpl do
           err
       end
 
-    {:reply, result, state}
+    {:reply, result, touch_keepalive(state)}
   end
 
   def handle_call(:get_sprite, _from, state) do
-    {:reply, state.sprite, state}
+    {:reply, state.sprite, touch_keepalive(state)}
+  end
+
+  @impl GenServer
+  def handle_info(:ping_vm, %{sprite: nil} = state) do
+    {:noreply, %{state | ping_timer: nil, ping_until: nil}}
+  end
+
+  def handle_info(:ping_vm, state) do
+    now = System.monotonic_time(:millisecond)
+
+    if state.ping_until && now < state.ping_until do
+      Task.start(fn ->
+        try do
+          Sprites.cmd(state.sprite, "echo", ["ping"], timeout: 5_000)
+        rescue
+          _ -> :ok
+        end
+      end)
+
+      {:noreply, schedule_ping(state)}
+    else
+      {:noreply, %{state | ping_timer: nil, ping_until: nil}}
+    end
   end
 
   @impl GenServer
@@ -392,5 +417,21 @@ defmodule Shire.VirtualMachineImpl do
   # GenServer call timeout: use the command timeout + 5s buffer
   defp call_timeout(opts) do
     (Keyword.get(opts, :timeout, @default_cmd_timeout) || @default_cmd_timeout) + 5_000
+  end
+
+  defp schedule_ping(state) do
+    timer = Process.send_after(self(), :ping_vm, @ping_interval)
+    %{state | ping_timer: timer}
+  end
+
+  defp touch_keepalive(state) do
+    ping_until = System.monotonic_time(:millisecond) + @keepalive_duration
+    state = %{state | ping_until: ping_until}
+
+    if state.ping_timer do
+      state
+    else
+      schedule_ping(state)
+    end
   end
 end

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -338,67 +338,6 @@ defmodule Shire.Agent.CoordinatorTest do
     end
   end
 
-  describe "VM keep-alive ping" do
-    test "send_message starts pinging the VM" do
-      # Track cmd calls to detect pings
-      ping_count = :counters.new(1, [])
-
-      stub(Shire.VirtualMachineMock, :cmd, fn cmd, args, _opts ->
-        if cmd == "echo" and args == ["ping"] do
-          :counters.add(ping_count, 1, 1)
-        end
-
-        {:ok, ""}
-      end)
-
-      {:ok, _pid} = start_agent_manager(@agent_name)
-
-      # Put agent in active state so send_message works
-      {:ok, agent_pid} = Coordinator.lookup(@agent_name)
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), agent_pid)
-
-      ref = make_ref()
-
-      :sys.replace_state(agent_pid, fn state ->
-        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
-      end)
-
-      # Send a message — this should trigger pinging
-      Coordinator.send_message(@agent_name, "hello")
-
-      # Wait for a few ping cycles (2s interval)
-      Process.sleep(5_000)
-
-      assert :counters.get(ping_count, 1) >= 2
-    end
-
-    test "new send_message extends the ping period" do
-      {:ok, _pid} = start_agent_manager(@agent_name)
-      {:ok, agent_pid} = Coordinator.lookup(@agent_name)
-      Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), agent_pid)
-
-      ref = make_ref()
-
-      :sys.replace_state(agent_pid, fn state ->
-        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
-      end)
-
-      Coordinator.send_message(@agent_name, "first")
-
-      # Get the initial ping_until
-      state1 = :sys.get_state(GenServer.whereis(Coordinator))
-      assert state1.ping_until != nil
-
-      Process.sleep(100)
-
-      Coordinator.send_message(@agent_name, "second")
-
-      # The ping_until should have been extended
-      state2 = :sys.get_state(GenServer.whereis(Coordinator))
-      assert state2.ping_until > state1.ping_until
-    end
-  end
-
   describe "create_agent/1" do
     test "creates agent directory structure on VM and starts AgentManager" do
       unique_name = "coord-create-test-#{System.unique_integer([:positive])}"

--- a/test/shire/virtual_machine_test.exs
+++ b/test/shire/virtual_machine_test.exs
@@ -69,6 +69,58 @@ defmodule Shire.VirtualMachineImplTest do
     end
   end
 
+  describe "VM keep-alive ping" do
+    test "handle_info(:ping_vm) stops when ping_until has expired" do
+      state = %{
+        sprite: nil,
+        fs: nil,
+        ping_timer: make_ref(),
+        ping_until: System.monotonic_time(:millisecond) - 1_000
+      }
+
+      assert {:noreply, new_state} = VM.handle_info(:ping_vm, state)
+      assert new_state.ping_timer == nil
+      assert new_state.ping_until == nil
+    end
+
+    test "handle_info(:ping_vm) stops when sprite is nil" do
+      state = %{
+        sprite: nil,
+        fs: nil,
+        ping_timer: make_ref(),
+        ping_until: System.monotonic_time(:millisecond) + 60_000
+      }
+
+      assert {:noreply, new_state} = VM.handle_info(:ping_vm, state)
+      assert new_state.ping_timer == nil
+      assert new_state.ping_until == nil
+    end
+
+    test "touch_keepalive is triggered by VM calls (via get_sprite)" do
+      pid = start_supervised!({VM, []}, id: :keepalive_test_vm)
+
+      _sprite = GenServer.call(pid, :get_sprite)
+
+      state = :sys.get_state(pid)
+      assert state.ping_until != nil
+      assert state.ping_timer != nil
+    end
+
+    test "subsequent VM calls extend ping_until" do
+      pid = start_supervised!({VM, []}, id: :keepalive_extend_vm)
+
+      GenServer.call(pid, :get_sprite)
+      state1 = :sys.get_state(pid)
+
+      Process.sleep(10)
+
+      GenServer.call(pid, :get_sprite)
+      state2 = :sys.get_state(pid)
+
+      assert state2.ping_until > state1.ping_until
+    end
+  end
+
   describe "resize/3" do
     test "returns :ok even when process is dead (SDK silently succeeds)" do
       dead_pid = spawn(fn -> :ok end)


### PR DESCRIPTION
## Summary

- **Removes ping logic from Coordinator** — it was the wrong place (Coordinator manages agent lifecycle, not VM sleep)
- **Adds automatic keep-alive in VirtualMachineImpl** — any VM call (`cmd`, `read`, `write`, etc.) resets a 30min keep-alive window. The VM pings itself every 2s while within the window.
- **No opt-in needed** — every VM interaction automatically keeps the VM awake, not just `send_message`

## Test plan

- [x] 115 Elixir tests pass (`mix test`)
- [x] Compilation clean with `--warnings-as-errors`
- [x] Formatting clean (`mix format --check-formatted`)
- [x] New tests: ping expiry, nil-sprite guard, keepalive triggered by VM calls, deadline extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)