### PR TITLE
feat: multi-project support (each project = own VM)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ npm-debug.log
 /docs/superpowers/
 
 /.superpowers
+
+# Git worktrees
+/.worktrees

--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -4,9 +4,11 @@ import AgentForm from "./AgentForm";
 import ChatHeader from "./ChatHeader";
 import ChatPanel, { type Message } from "./ChatPanel";
 import WelcomePanel from "./WelcomePanel";
-import { type Agent } from "./types";
+import { type Agent, type Project } from "./types";
 
 interface AgentDashboardProps {
+  project: string;
+  projects: Project[];
   agents: Agent[];
   selectedAgent: Agent | null;
   messages?: Message[];
@@ -17,6 +19,8 @@ interface AgentDashboardProps {
 }
 
 export default function AgentDashboard({
+  project,
+  projects,
   agents,
   selectedAgent,
   messages = [],
@@ -70,6 +74,8 @@ export default function AgentDashboard({
   return (
     <div className="flex h-screen bg-background">
       <AgentSidebar
+        project={project}
+        projects={projects}
         agents={agents}
         selectedAgentName={selectedAgent?.name ?? null}
         onSelectAgent={handleSelectAgent}

--- a/assets/react-components/AgentShow.tsx
+++ b/assets/react-components/AgentShow.tsx
@@ -19,9 +19,11 @@ import { ChevronLeft, Pencil } from "lucide-react";
 import { type Agent, statusVariant, harnessLabel } from "./types";
 
 export default function AgentShow({
+  project,
   agent,
   pushEvent,
 }: {
+  project: string;
   agent: Agent;
   pushEvent: (event: string, payload: Record<string, unknown>) => void;
 }) {
@@ -32,7 +34,12 @@ export default function AgentShow({
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" aria-label="Back" onClick={() => window.location.assign("/")}>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Back"
+              onClick={() => window.location.assign(`/projects/${project}`)}
+            >
               <ChevronLeft className="h-5 w-5" />
             </Button>
             <h1 className="text-2xl font-bold">{agent.name}</h1>

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -16,7 +16,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
-import { type Agent, type AgentStatus } from "./types";
+import ProjectSwitcher from "./ProjectSwitcher";
+import { type Agent, type AgentStatus, type Project } from "./types";
 
 function statusDotColor(status: AgentStatus): string {
   switch (status) {
@@ -34,6 +35,8 @@ function statusDotColor(status: AgentStatus): string {
 }
 
 interface AgentSidebarProps {
+  project: string;
+  projects: Project[];
   agents: Agent[];
   selectedAgentName: string | null;
   onSelectAgent: (name: string) => void;
@@ -42,6 +45,8 @@ interface AgentSidebarProps {
 }
 
 export default function AgentSidebar({
+  project,
+  projects,
   agents,
   selectedAgentName,
   onSelectAgent,
@@ -59,6 +64,10 @@ export default function AgentSidebar({
 
   return (
     <div className="w-64 border-r border-border bg-muted/30 flex flex-col h-full">
+      <div className="p-3 border-b border-border">
+        <ProjectSwitcher projects={projects} currentProject={project} />
+      </div>
+
       <div className="p-4 border-b border-border">
         <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Agents</h2>
       </div>
@@ -91,7 +100,7 @@ export default function AgentSidebar({
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => window.location.assign(`/agents/${agent.name}`)}>
+                <DropdownMenuItem onClick={() => window.location.assign(`/projects/${project}/agents/${agent.name}`)}>
                   Settings
                 </DropdownMenuItem>
                 <DropdownMenuItem
@@ -114,7 +123,7 @@ export default function AgentSidebar({
         <button
           type="button"
           className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
-          onClick={() => window.location.assign("/settings")}
+          onClick={() => window.location.assign(`/projects/${project}/settings`)}
         >
           <svg
             width="16"
@@ -134,7 +143,7 @@ export default function AgentSidebar({
         <button
           type="button"
           className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
-          onClick={() => window.location.assign("/shared")}
+          onClick={() => window.location.assign(`/projects/${project}/shared`)}
         >
           <svg
             width="16"

--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+import { Button } from "./components/ui/button";
+import { Input } from "./components/ui/input";
+import { Card, CardContent } from "./components/ui/card";
+import { Badge } from "./components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "./components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./components/ui/alert-dialog";
+import AppLayout from "./components/AppLayout";
+import type { Project } from "./types";
+
+interface ProjectDashboardProps {
+  projects: Project[];
+  pushEvent: (event: string, payload: Record<string, unknown>) => void;
+}
+
+function projectStatusVariant(status: string): "default" | "secondary" | "destructive" {
+  switch (status) {
+    case "running":
+      return "default";
+    case "starting":
+      return "secondary";
+    case "error":
+      return "destructive";
+    default:
+      return "secondary";
+  }
+}
+
+const PROJECT_NAME_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboardProps) {
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [projectName, setProjectName] = React.useState("");
+  const [deleteProject, setDeleteProject] = React.useState<Project | null>(null);
+
+  const nameValid = PROJECT_NAME_REGEX.test(projectName);
+
+  const handleCreate = () => {
+    if (!nameValid) return;
+    pushEvent("create-project", { name: projectName });
+    setProjectName("");
+    setCreateOpen(false);
+  };
+
+  const handleDelete = () => {
+    if (!deleteProject) return;
+    pushEvent("delete-project", { name: deleteProject.name });
+    setDeleteProject(null);
+  };
+
+  return (
+    <AppLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">Projects</h1>
+          <Button onClick={() => setCreateOpen(true)}>+ New Project</Button>
+        </div>
+
+        {projects.length === 0 ? (
+          <div className="text-center py-16">
+            <p className="text-muted-foreground mb-4">No projects yet. Create one to get started.</p>
+            <Button onClick={() => setCreateOpen(true)}>Create Project</Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {projects.map((project) => (
+              <Card
+                key={project.name}
+                className="cursor-pointer hover:border-primary/50 transition-colors"
+                onClick={() => window.location.assign(`/projects/${project.name}`)}
+              >
+                <CardContent className="pt-6">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-semibold text-lg">{project.name}</h3>
+                    <Badge variant={projectStatusVariant(project.status)}>{project.status}</Badge>
+                  </div>
+                  <div className="mt-4 flex justify-end">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive hover:text-destructive"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeleteProject(project);
+                      }}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Project</DialogTitle>
+            <DialogDescription>Create a new project with its own isolated VM.</DialogDescription>
+          </DialogHeader>
+          <div className="py-4 space-y-2">
+            <Input
+              placeholder="my-project"
+              value={projectName}
+              onChange={(e) => setProjectName(e.target.value.toLowerCase())}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleCreate();
+              }}
+              autoFocus
+            />
+            {projectName && !nameValid && (
+              <p className="text-sm text-destructive">
+                Use lowercase letters, numbers, and hyphens only. Must start and end with a letter or number.
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={!nameValid}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={!!deleteProject} onOpenChange={(open) => !open && setDeleteProject(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Project</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete &ldquo;{deleteProject?.name}&rdquo;? This will destroy the VM and all its
+              data. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDelete}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AppLayout>
+  );
+}

--- a/assets/react-components/ProjectSwitcher.tsx
+++ b/assets/react-components/ProjectSwitcher.tsx
@@ -1,0 +1,34 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./components/ui/select";
+import type { Project } from "./types";
+
+interface ProjectSwitcherProps {
+  projects: Project[];
+  currentProject: string;
+}
+
+export default function ProjectSwitcher({ projects, currentProject }: ProjectSwitcherProps) {
+  return (
+    <Select
+      value={currentProject}
+      onValueChange={(value) => {
+        if (value === "__all__") {
+          window.location.assign("/");
+        } else {
+          window.location.assign(`/projects/${value}`);
+        }
+      }}
+    >
+      <SelectTrigger className="w-full text-sm">
+        <SelectValue placeholder="Select project" />
+      </SelectTrigger>
+      <SelectContent>
+        {projects.map((project) => (
+          <SelectItem key={project.name} value={project.name}>
+            {project.name}
+          </SelectItem>
+        ))}
+        <SelectItem value="__all__">All Projects</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/assets/react-components/SettingsPage.tsx
+++ b/assets/react-components/SettingsPage.tsx
@@ -34,6 +34,7 @@ interface ScriptDraft {
 }
 
 interface SettingsPageProps {
+  project: string;
   env_content: string;
   scripts: Script[];
   messages: InterAgentMessage[];
@@ -66,6 +67,7 @@ function serializeEnv(rows: EnvRow[]): string {
 }
 
 export default function SettingsPage({
+  project,
   env_content,
   scripts,
   messages,
@@ -136,7 +138,12 @@ export default function SettingsPage({
     <AppLayout>
       <div className="space-y-6">
         <div className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" aria-label="Back" onClick={() => window.location.assign("/")}>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Back"
+            onClick={() => window.location.assign(`/projects/${project}`)}
+          >
             <ChevronLeft className="h-5 w-5" />
           </Button>
           <h1 className="text-2xl font-bold">Settings</h1>

--- a/assets/react-components/SharedDrive.tsx
+++ b/assets/react-components/SharedDrive.tsx
@@ -30,6 +30,7 @@ export interface SharedDriveFile {
 }
 
 interface SharedDriveProps {
+  project: string;
   files: SharedDriveFile[];
   current_path: string;
   pushEvent: (event: string, payload: Record<string, unknown>) => void;
@@ -65,7 +66,7 @@ function Breadcrumbs({ path, onNavigate }: { path: string; onNavigate: (path: st
   );
 }
 
-export default function SharedDrive({ files, current_path, pushEvent }: SharedDriveProps) {
+export default function SharedDrive({ project, files, current_path, pushEvent }: SharedDriveProps) {
   const [newFolderOpen, setNewFolderOpen] = React.useState(false);
   const [newFolderName, setNewFolderName] = React.useState("");
   const [deleteTarget, setDeleteTarget] = React.useState<SharedDriveFile | null>(null);
@@ -175,7 +176,10 @@ export default function SharedDrive({ files, current_path, pushEvent }: SharedDr
                       <div className="flex items-center justify-end gap-1">
                         {file.type === "file" && (
                           <Button variant="ghost" size="sm" asChild>
-                            <a href={`/shared/download?path=${encodeURIComponent(file.path)}`} download>
+                            <a
+                              href={`/projects/${project}/shared/download?path=${encodeURIComponent(file.path)}`}
+                              download
+                            >
                               Download
                             </a>
                           </Button>

--- a/assets/react-components/index.ts
+++ b/assets/react-components/index.ts
@@ -1,7 +1,8 @@
 import AgentDashboard from "./AgentDashboard";
 import AgentForm from "./AgentForm";
 import AgentShow from "./AgentShow";
+import ProjectDashboard from "./ProjectDashboard";
 import SettingsPage from "./SettingsPage";
 import SharedDrive from "./SharedDrive";
 
-export default { AgentDashboard, AgentForm, AgentShow, SettingsPage, SharedDrive };
+export default { AgentDashboard, AgentForm, AgentShow, ProjectDashboard, SettingsPage, SharedDrive };

--- a/assets/react-components/types.ts
+++ b/assets/react-components/types.ts
@@ -1,3 +1,8 @@
+export interface Project {
+  name: string;
+  status: "running" | "starting" | "error";
+}
+
 export type HarnessType = "pi" | "claude_code";
 
 export type AgentStatus = "created" | "starting" | "bootstrapping" | "active" | "sleeping" | "failed" | "crashed";

--- a/assets/test/AgentDashboard.test.tsx
+++ b/assets/test/AgentDashboard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import AgentDashboard from "../react-components/AgentDashboard";
-import { type Agent } from "../react-components/types";
+import { type Agent, type Project } from "../react-components/types";
 
 const agents: Agent[] = [
   {
@@ -18,9 +18,21 @@ const agents: Agent[] = [
   },
 ];
 
+const projects: Project[] = [
+  { name: "test-project", status: "running" },
+  { name: "other-project", status: "running" },
+];
+
+const defaultProps = {
+  project: "test-project",
+  projects,
+  editAgent: null,
+  pushEvent: vi.fn(),
+};
+
 describe("AgentDashboard", () => {
   it("renders sidebar with agents and welcome panel when none selected", () => {
-    render(<AgentDashboard agents={agents} selectedAgent={null} editAgent={null} pushEvent={vi.fn()} />);
+    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
     // Sidebar shows agents
     expect(screen.getByText("Agent One")).toBeInTheDocument();
     expect(screen.getByText("Agent Two")).toBeInTheDocument();
@@ -32,11 +44,10 @@ describe("AgentDashboard", () => {
   it("renders chat panel when agent is selected", () => {
     render(
       <AgentDashboard
+        {...defaultProps}
         agents={agents}
         selectedAgent={agents[0]}
         messages={[{ id: 1, role: "user", text: "Hello", ts: "2026-03-17T00:00:00Z" }]}
-        editAgent={null}
-        pushEvent={vi.fn()}
       />,
     );
     // Chat header shows
@@ -49,14 +60,14 @@ describe("AgentDashboard", () => {
 
   it("calls pushEvent with select-agent when clicking sidebar agent", async () => {
     const pushEvent = vi.fn();
-    render(<AgentDashboard agents={agents} selectedAgent={null} editAgent={null} pushEvent={pushEvent} />);
+    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} pushEvent={pushEvent} />);
 
     await userEvent.click(screen.getByText("Agent One"));
     expect(pushEvent).toHaveBeenCalledWith("select-agent", { name: "Agent One" });
   });
 
   it("opens new agent dialog from sidebar", async () => {
-    render(<AgentDashboard agents={agents} selectedAgent={null} editAgent={null} pushEvent={vi.fn()} />);
+    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
 
     // Click the sidebar "+ New Agent" button
     await userEvent.click(screen.getAllByText("+ New Agent")[0]);
@@ -64,7 +75,7 @@ describe("AgentDashboard", () => {
   });
 
   it("opens new agent dialog from welcome panel", async () => {
-    render(<AgentDashboard agents={[]} selectedAgent={null} editAgent={null} pushEvent={vi.fn()} />);
+    render(<AgentDashboard {...defaultProps} agents={[]} selectedAgent={null} />);
 
     // Both sidebar and welcome panel have "+ New Agent" — click the welcome panel one
     const buttons = screen.getAllByText("+ New Agent");

--- a/assets/test/AgentShow.test.tsx
+++ b/assets/test/AgentShow.test.tsx
@@ -22,7 +22,7 @@ const agent: Agent = {
 
 describe("AgentShow", () => {
   it("renders agent details", () => {
-    render(<AgentShow agent={agent} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={agent} pushEvent={vi.fn()} />);
     expect(screen.getByRole("heading", { name: "Test Agent" })).toBeInTheDocument();
     expect(screen.getByText("claude-sonnet-4-6")).toBeInTheDocument();
     expect(screen.getByText("You are a helpful assistant.")).toBeInTheDocument();
@@ -30,32 +30,38 @@ describe("AgentShow", () => {
   });
 
   it("shows fallback for missing model and system prompt", () => {
-    render(<AgentShow agent={{ ...agent, model: undefined, system_prompt: undefined }} pushEvent={vi.fn()} />);
+    render(
+      <AgentShow
+        project="test-project"
+        agent={{ ...agent, model: undefined, system_prompt: undefined }}
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getAllByText("Not set")).toHaveLength(2);
   });
 
   it("shows Start and Delete buttons for created agent", () => {
-    render(<AgentShow agent={{ ...agent, status: "created" }} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "created" }} pushEvent={vi.fn()} />);
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
   it("shows Restart and Delete buttons for active agent", () => {
-    render(<AgentShow agent={{ ...agent, status: "active" }} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "active" }} pushEvent={vi.fn()} />);
     expect(screen.getByText("Restart Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
   it("calls pushEvent with start-agent", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow agent={{ ...agent, status: "created" }} pushEvent={pushEvent} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "created" }} pushEvent={pushEvent} />);
     await userEvent.click(screen.getByText("Start Agent"));
     expect(pushEvent).toHaveBeenCalledWith("start-agent", {});
   });
 
   it("calls pushEvent with restart-agent after confirming", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow agent={{ ...agent, status: "active" }} pushEvent={pushEvent} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "active" }} pushEvent={pushEvent} />);
     await userEvent.click(screen.getByText("Restart Agent"));
     await userEvent.click(screen.getByText("Restart"));
     expect(pushEvent).toHaveBeenCalledWith("restart-agent", {});
@@ -63,51 +69,51 @@ describe("AgentShow", () => {
 
   it("calls pushEvent with delete-agent after confirming", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow agent={{ ...agent, status: "active" }} pushEvent={pushEvent} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "active" }} pushEvent={pushEvent} />);
     await userEvent.click(screen.getByText("Delete Agent"));
     await userEvent.click(screen.getByText("Delete"));
     expect(pushEvent).toHaveBeenCalledWith("delete-agent", {});
   });
 
   it("shows Start and Delete buttons for crashed agent", () => {
-    render(<AgentShow agent={{ ...agent, status: "crashed" }} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "crashed" }} pushEvent={vi.fn()} />);
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
   it("shows Restart and Delete buttons for bootstrapping agent", () => {
-    render(<AgentShow agent={{ ...agent, status: "bootstrapping" }} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "bootstrapping" }} pushEvent={vi.fn()} />);
     expect(screen.getByText("Restart Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
     expect(screen.queryByText("Start Agent")).not.toBeInTheDocument();
   });
 
   it("shows Delete button for failed agent", () => {
-    render(<AgentShow agent={{ ...agent, status: "failed" }} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "failed" }} pushEvent={vi.fn()} />);
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
   });
 
   it("calls pushEvent with delete-agent for created agent after confirming", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow agent={{ ...agent, status: "created" }} pushEvent={pushEvent} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, status: "created" }} pushEvent={pushEvent} />);
     await userEvent.click(screen.getByText("Delete Agent"));
     await userEvent.click(screen.getByText("Delete"));
     expect(pushEvent).toHaveBeenCalledWith("delete-agent", {});
   });
 
   it("displays harness badge", () => {
-    render(<AgentShow agent={agent} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={agent} pushEvent={vi.fn()} />);
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
   });
 
   it("displays Pi harness", () => {
-    render(<AgentShow agent={{ ...agent, harness: "pi" }} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={{ ...agent, harness: "pi" }} pushEvent={vi.fn()} />);
     expect(screen.getByText("Pi")).toBeInTheDocument();
   });
 
   it("shows Edit button and opens edit form dialog", async () => {
-    render(<AgentShow agent={agent} pushEvent={vi.fn()} />);
+    render(<AgentShow project="test-project" agent={agent} pushEvent={vi.fn()} />);
     const editBtn = screen.getByRole("button", { name: /edit/i });
     expect(editBtn).toBeInTheDocument();
     await userEvent.click(editBtn);

--- a/assets/test/AgentSidebar.test.tsx
+++ b/assets/test/AgentSidebar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import AgentSidebar from "../react-components/AgentSidebar";
-import { type Agent } from "../react-components/types";
+import { type Agent, type Project } from "../react-components/types";
 
 const agents: Agent[] = [
   {
@@ -23,46 +23,36 @@ const agents: Agent[] = [
   },
 ];
 
+const projects: Project[] = [
+  { name: "test-project", status: "running" },
+  { name: "other-project", status: "running" },
+];
+
+const defaultProps = {
+  project: "test-project",
+  projects,
+  selectedAgentName: null as string | null,
+  onSelectAgent: vi.fn(),
+  onNewAgent: vi.fn(),
+  onDeleteAgent: vi.fn(),
+};
+
 describe("AgentSidebar", () => {
   it("renders agent list with names", () => {
-    render(
-      <AgentSidebar
-        agents={agents}
-        selectedAgentName={null}
-        onSelectAgent={vi.fn()}
-        onNewAgent={vi.fn()}
-        onDeleteAgent={vi.fn()}
-      />,
-    );
+    render(<AgentSidebar {...defaultProps} agents={agents} />);
     expect(screen.getByText("Active Agent")).toBeInTheDocument();
     expect(screen.getByText("Created Agent")).toBeInTheDocument();
     expect(screen.getByText("Failed Agent")).toBeInTheDocument();
   });
 
   it("renders empty state when no agents", () => {
-    render(
-      <AgentSidebar
-        agents={[]}
-        selectedAgentName={null}
-        onSelectAgent={vi.fn()}
-        onNewAgent={vi.fn()}
-        onDeleteAgent={vi.fn()}
-      />,
-    );
+    render(<AgentSidebar {...defaultProps} agents={[]} />);
     expect(screen.getByText("No agents yet")).toBeInTheDocument();
   });
 
   it("calls onSelectAgent with name when clicking an agent", async () => {
     const onSelectAgent = vi.fn();
-    render(
-      <AgentSidebar
-        agents={agents}
-        selectedAgentName={null}
-        onSelectAgent={onSelectAgent}
-        onNewAgent={vi.fn()}
-        onDeleteAgent={vi.fn()}
-      />,
-    );
+    render(<AgentSidebar {...defaultProps} agents={agents} onSelectAgent={onSelectAgent} />);
 
     await userEvent.click(screen.getByText("Active Agent"));
     expect(onSelectAgent).toHaveBeenCalledWith("Active Agent");
@@ -70,43 +60,19 @@ describe("AgentSidebar", () => {
 
   it("calls onNewAgent when clicking New Agent button", async () => {
     const onNewAgent = vi.fn();
-    render(
-      <AgentSidebar
-        agents={agents}
-        selectedAgentName={null}
-        onSelectAgent={vi.fn()}
-        onNewAgent={onNewAgent}
-        onDeleteAgent={vi.fn()}
-      />,
-    );
+    render(<AgentSidebar {...defaultProps} agents={agents} onNewAgent={onNewAgent} />);
 
     await userEvent.click(screen.getByText("+ New Agent"));
     expect(onNewAgent).toHaveBeenCalled();
   });
 
   it("renders Settings link", () => {
-    render(
-      <AgentSidebar
-        agents={agents}
-        selectedAgentName={null}
-        onSelectAgent={vi.fn()}
-        onNewAgent={vi.fn()}
-        onDeleteAgent={vi.fn()}
-      />,
-    );
+    render(<AgentSidebar {...defaultProps} agents={agents} />);
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
   it("shows status dots with correct colors", () => {
-    const { container } = render(
-      <AgentSidebar
-        agents={agents}
-        selectedAgentName={null}
-        onSelectAgent={vi.fn()}
-        onNewAgent={vi.fn()}
-        onDeleteAgent={vi.fn()}
-      />,
-    );
+    const { container } = render(<AgentSidebar {...defaultProps} agents={agents} />);
 
     const dots = container.querySelectorAll(".rounded-full");
     expect(dots[0]).toHaveClass("bg-green-500"); // active
@@ -119,15 +85,7 @@ describe("AgentSidebar", () => {
       { ...agents[0], busy: true },
       { ...agents[1], busy: false },
     ];
-    const { container } = render(
-      <AgentSidebar
-        agents={busyAgents}
-        selectedAgentName={null}
-        onSelectAgent={vi.fn()}
-        onNewAgent={vi.fn()}
-        onDeleteAgent={vi.fn()}
-      />,
-    );
+    const { container } = render(<AgentSidebar {...defaultProps} agents={busyAgents} />);
 
     const dots = container.querySelectorAll(".rounded-full");
     expect(dots[0]).toHaveClass("animate-pulse"); // active + busy

--- a/assets/test/ProjectDashboard.test.tsx
+++ b/assets/test/ProjectDashboard.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import ProjectDashboard from "../react-components/ProjectDashboard";
+import type { Project } from "../react-components/types";
+
+const projects: Project[] = [
+  { name: "test-project", status: "running" },
+  { name: "other-project", status: "running" },
+];
+
+describe("ProjectDashboard", () => {
+  it("renders Projects heading", () => {
+    render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: "Projects" })).toBeInTheDocument();
+  });
+
+  it("renders project cards", () => {
+    render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
+    expect(screen.getByText("test-project")).toBeInTheDocument();
+    expect(screen.getByText("other-project")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no projects", () => {
+    render(<ProjectDashboard projects={[]} pushEvent={vi.fn()} />);
+    expect(screen.getByText("No projects yet. Create one to get started.")).toBeInTheDocument();
+  });
+
+  it("shows status badges on project cards", () => {
+    const mixedProjects: Project[] = [
+      { name: "running-project", status: "running" },
+      { name: "error-project", status: "error" },
+    ];
+    render(<ProjectDashboard projects={mixedProjects} pushEvent={vi.fn()} />);
+    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(screen.getByText("error")).toBeInTheDocument();
+  });
+
+  it("opens create dialog when clicking + New Project", async () => {
+    render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
+    await userEvent.click(screen.getByText("+ New Project"));
+    expect(screen.getByText("Create a new project with its own isolated VM.")).toBeInTheDocument();
+  });
+
+  it("creates a project via dialog", async () => {
+    const user = userEvent.setup();
+    const pushEvent = vi.fn();
+    render(<ProjectDashboard projects={projects} pushEvent={pushEvent} />);
+
+    await user.click(screen.getByText("+ New Project"));
+    await user.paste("my-new-project");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(pushEvent).toHaveBeenCalledWith("create-project", { name: "my-new-project" });
+  });
+
+  it("shows validation error for invalid project name", async () => {
+    const user = userEvent.setup();
+    render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
+
+    await user.click(screen.getByText("+ New Project"));
+    await user.paste("INVALID NAME!");
+
+    expect(
+      screen.getByText("Use lowercase letters, numbers, and hyphens only. Must start and end with a letter or number."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation when clicking Delete on a project card", async () => {
+    render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
+    const deleteButtons = screen.getAllByText("Delete");
+    await userEvent.click(deleteButtons[0]);
+    expect(screen.getByText(/destroy the VM and all its data/)).toBeInTheDocument();
+  });
+
+  it("calls pushEvent with delete-project after confirming", async () => {
+    const pushEvent = vi.fn();
+    render(<ProjectDashboard projects={projects} pushEvent={pushEvent} />);
+
+    // Click Delete on first project card
+    const deleteButtons = screen.getAllByText("Delete");
+    await userEvent.click(deleteButtons[0]);
+
+    // Confirm in alert dialog
+    const confirmDelete = screen.getAllByText("Delete").find((el) => el.closest("[role='alertdialog']"));
+    await userEvent.click(confirmDelete!);
+
+    expect(pushEvent).toHaveBeenCalledWith("delete-project", { name: "test-project" });
+  });
+});

--- a/assets/test/ProjectSwitcher.test.tsx
+++ b/assets/test/ProjectSwitcher.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ProjectSwitcher from "../react-components/ProjectSwitcher";
+import type { Project } from "../react-components/types";
+
+const projects: Project[] = [
+  { name: "test-project", status: "running" },
+  { name: "other-project", status: "running" },
+];
+
+describe("ProjectSwitcher", () => {
+  it("renders with current project selected", () => {
+    render(<ProjectSwitcher projects={projects} currentProject="test-project" />);
+    expect(screen.getByText("test-project")).toBeInTheDocument();
+  });
+
+  it("renders as a select trigger", () => {
+    render(<ProjectSwitcher projects={projects} currentProject="test-project" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("navigates to / when All Projects is selected", async () => {
+    const assignMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { assign: assignMock },
+      writable: true,
+    });
+
+    render(<ProjectSwitcher projects={projects} currentProject="test-project" />);
+    // The select component renders the current value; full interaction testing
+    // of Radix Select in jsdom is limited, so we verify the component renders
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+});

--- a/assets/test/SettingsPage.test.tsx
+++ b/assets/test/SettingsPage.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../react-components/Terminal", () => ({
 }));
 
 const defaultProps = {
+  project: "test-project",
   env_content: "",
   scripts: [] as { name: string; content: string }[],
   messages: [] as { id: number; from_agent: string; to_agent: string; text: string; ts: string }[],

--- a/assets/test/SharedDrive.test.tsx
+++ b/assets/test/SharedDrive.test.tsx
@@ -5,6 +5,7 @@ import SharedDrive from "../react-components/SharedDrive";
 import type { SharedDriveFile } from "../react-components/SharedDrive";
 
 const defaultProps = {
+  project: "test-project",
   files: [] as SharedDriveFile[],
   current_path: "/",
   pushEvent: vi.fn(),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,16 +28,19 @@ config :shire, ShireWeb.Endpoint, http: [port: String.to_integer(System.get_env(
 
 # Sprites — optional in dev, required in prod
 sprites_token = System.get_env("SPRITES_TOKEN")
-sprite_vm_name = System.get_env("SPRITE_VM_NAME")
+sprite_vm_prefix = System.get_env("SPRITE_VM_PREFIX")
 
 if config_env() == :prod && is_nil(sprites_token) do
   raise "environment variable SPRITES_TOKEN is missing."
 end
 
-# Don't connect to real VMs in test — Coordinator will run with sprite: nil
+# Don't connect to real VMs in test — ProjectManager will skip discovery
 if config_env() != :test do
   config :shire, :sprites_token, sprites_token
-  config :shire, :sprite_vm_name, sprite_vm_name
+
+  if sprite_vm_prefix do
+    config :shire, :sprite_vm_prefix, sprite_vm_prefix
+  end
 end
 
 if config_env() == :prod do

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -1,6 +1,6 @@
 defmodule Shire.Agent.AgentManager do
   @moduledoc """
-  GenServer managing a single agent's lifecycle on the shared Sprite VM.
+  GenServer managing a single agent's lifecycle on a project's Sprite VM.
   One AgentManager per active agent. Uses Shire.VirtualMachine for all
   VM operations — does not hold sprite/fs references.
   """
@@ -74,6 +74,7 @@ defmodule Shire.Agent.AgentManager do
 
   defstruct [
     :agent_name,
+    :project_name,
     :command,
     :command_ref,
     :pubsub_topic,
@@ -86,12 +87,13 @@ defmodule Shire.Agent.AgentManager do
   # --- Public API ---
 
   def start_link(opts) do
+    project_name = Keyword.fetch!(opts, :project_name)
     agent_name = Keyword.fetch!(opts, :agent_name)
-    GenServer.start_link(__MODULE__, opts, name: via(agent_name))
+    GenServer.start_link(__MODULE__, opts, name: via(project_name, agent_name))
   end
 
-  def send_message(agent_name, text, from \\ :user) do
-    GenServer.call(via(agent_name), {:send_message, text, from}, 60_000)
+  def send_message(project_name, agent_name, text, from \\ :user) do
+    GenServer.call(via(project_name, agent_name), {:send_message, text, from}, 60_000)
   end
 
   @spec get_state(atom() | pid() | {atom(), any()} | {:via, atom(), any()}) :: any()
@@ -99,24 +101,26 @@ defmodule Shire.Agent.AgentManager do
     GenServer.call(server, :get_state, 60_000)
   end
 
-  def restart(agent_name) do
-    GenServer.call(via(agent_name), :restart, 60_000)
+  def restart(project_name, agent_name) do
+    GenServer.call(via(project_name, agent_name), :restart, 60_000)
   end
 
-  defp via(agent_name) do
-    {:via, Registry, {Shire.AgentRegistry, agent_name, agent_name}}
+  defp via(project_name, agent_name) do
+    {:via, Registry, {Shire.AgentRegistry, {project_name, agent_name}, agent_name}}
   end
 
   # --- Callbacks ---
 
   @impl true
   def init(opts) do
+    project_name = Keyword.fetch!(opts, :project_name)
     agent_name = Keyword.fetch!(opts, :agent_name)
     skip_sprite = Keyword.get(opts, :skip_sprite, false)
 
     state = %__MODULE__{
+      project_name: project_name,
       agent_name: agent_name,
-      pubsub_topic: "agent:#{agent_name}",
+      pubsub_topic: "project:#{project_name}:agent:#{agent_name}",
       status: :idle
     }
 
@@ -132,8 +136,8 @@ defmodule Shire.Agent.AgentManager do
     state = transition_status(state, :bootstrapping)
 
     Task.start_link(fn ->
-      result = setup_agent_workspace(state.agent_name)
-      GenServer.cast(via(state.agent_name), {:bootstrap_complete, result})
+      result = setup_agent_workspace(state.project_name, state.agent_name)
+      GenServer.cast(via(state.project_name, state.agent_name), {:bootstrap_complete, result})
     end)
 
     {:noreply, state}
@@ -142,10 +146,11 @@ defmodule Shire.Agent.AgentManager do
   @impl true
   def handle_continue(:spawn_runner, state) do
     agent_dir = "/workspace/agents/#{state.agent_name}"
-    kill_existing_runner(state.agent_name)
-    env = load_env_vars()
+    kill_existing_runner(state.project_name, state.agent_name)
+    env = load_env_vars(state.project_name)
 
     case @vm.spawn_command(
+           state.project_name,
            "bun",
            ["run", "/workspace/.runner/agent-runner.ts", "--agent-dir", agent_dir],
            env: env,
@@ -176,9 +181,10 @@ defmodule Shire.Agent.AgentManager do
     inbox_dir = "/workspace/agents/#{state.agent_name}/inbox"
     filename = "#{envelope["ts"]}-#{random_suffix()}.json"
 
-    case write_inbox_file("#{inbox_dir}/#{filename}", envelope) do
+    case write_inbox_file(state.project_name, "#{inbox_dir}/#{filename}", envelope) do
       :ok ->
         case Agents.create_message(%{
+               project_name: state.project_name,
                agent_name: state.agent_name,
                role: "user",
                content: %{"text" => text}
@@ -208,15 +214,15 @@ defmodule Shire.Agent.AgentManager do
 
   @impl true
   def handle_call(:restart, _from, state) do
-    kill_existing_runner(state.agent_name)
+    kill_existing_runner(state.project_name, state.agent_name)
 
     state =
       %{state | command: nil, command_ref: nil}
       |> transition_status(:bootstrapping)
 
     Task.start_link(fn ->
-      result = setup_agent_workspace(state.agent_name)
-      GenServer.cast(via(state.agent_name), {:bootstrap_complete, result})
+      result = setup_agent_workspace(state.project_name, state.agent_name)
+      GenServer.cast(via(state.project_name, state.agent_name), {:bootstrap_complete, result})
     end)
 
     {:reply, :ok, state}
@@ -236,6 +242,7 @@ defmodule Shire.Agent.AgentManager do
              "payload" => %{"from_agent" => from_agent, "text" => text}
            }} ->
             Agents.create_message(%{
+              project_name: acc.project_name,
               agent_name: acc.agent_name,
               role: "inter_agent",
               content: %{
@@ -248,19 +255,19 @@ defmodule Shire.Agent.AgentManager do
             acc
 
           {:ok, %{"type" => "spawn_agent", "payload" => %{"name" => new_name}}} ->
-            Shire.Agent.Coordinator.restart_agent(new_name)
+            Shire.Agent.Coordinator.restart_agent(acc.project_name, new_name)
             acc
 
           {:ok, %{"type" => "processing", "payload" => %{"active" => active}}} ->
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "agents:lobby",
+              "project:#{acc.project_name}:agents:lobby",
               {:agent_busy, acc.agent_name, active}
             )
 
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "agent:#{acc.agent_name}",
+              "project:#{acc.project_name}:agent:#{acc.agent_name}",
               {:agent_busy, acc.agent_name, active}
             )
 
@@ -311,8 +318,8 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @impl true
-  def terminate(_reason, %{agent_name: agent_name} = _state) do
-    kill_existing_runner(agent_name)
+  def terminate(_reason, %{project_name: project_name, agent_name: agent_name} = _state) do
+    kill_existing_runner(project_name, agent_name)
     :ok
   end
 
@@ -334,29 +341,29 @@ defmodule Shire.Agent.AgentManager do
 
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
-      "agent:#{state.agent_name}",
+      "project:#{state.project_name}:agent:#{state.agent_name}",
       {:status, status}
     )
 
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
-      "agents:lobby",
+      "project:#{state.project_name}:agents:lobby",
       {:agent_status, state.agent_name, status}
     )
 
     state
   end
 
-  defp setup_agent_workspace(agent_name) do
+  defp setup_agent_workspace(project_name, agent_name) do
     agent_dir = "/workspace/agents/#{agent_name}"
 
     # Create agent directory structure
     for subdir <- ["inbox", "outbox", "scripts", "documents", ".claude/skills"] do
-      @vm.cmd("mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
+      @vm.cmd(project_name, "mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
     end
 
     # Read recipe to determine harness type
-    recipe = read_recipe(agent_name)
+    recipe = read_recipe(project_name, agent_name)
     harness = recipe["harness"] || "claude_code"
 
     # Write comms instructions to the file the harness reads
@@ -366,10 +373,10 @@ defmodule Shire.Agent.AgentManager do
         _ -> "AGENTS.md"
       end
 
-    @vm.write("#{agent_dir}/#{comms_file}", comms_prompt(agent_name))
+    @vm.write(project_name, "#{agent_dir}/#{comms_file}", comms_prompt(agent_name))
 
     # Deploy skills from recipe
-    deploy_skills(recipe, agent_dir)
+    deploy_skills(project_name, recipe, agent_dir)
 
     :ok
   rescue
@@ -381,10 +388,10 @@ defmodule Shire.Agent.AgentManager do
       {:error, e}
   end
 
-  defp read_recipe(agent_name) do
+  defp read_recipe(project_name, agent_name) do
     path = "/workspace/agents/#{agent_name}/recipe.yaml"
 
-    case @vm.cmd("cat", [path], []) do
+    case @vm.cmd(project_name, "cat", [path], []) do
       {:ok, content} ->
         case YamlElixir.read_from_string(content) do
           {:ok, %{} = recipe} -> recipe
@@ -396,7 +403,7 @@ defmodule Shire.Agent.AgentManager do
     end
   end
 
-  defp deploy_skills(%{"skills" => [_ | _] = skills} = recipe, agent_dir) do
+  defp deploy_skills(project_name, %{"skills" => [_ | _] = skills} = recipe, agent_dir) do
     harness = recipe["harness"] || "claude_code"
 
     skill_base =
@@ -406,24 +413,24 @@ defmodule Shire.Agent.AgentManager do
       end
 
     # Clean stale skills from previous recipe versions
-    @vm.cmd("rm", ["-rf", skill_base], [])
+    @vm.cmd(project_name, "rm", ["-rf", skill_base], [])
 
     for skill <- skills do
       skill_dir = "#{skill_base}/#{skill["name"]}"
-      @vm.cmd("mkdir", ["-p", skill_dir], [])
+      @vm.cmd(project_name, "mkdir", ["-p", skill_dir], [])
 
       skill_md = build_skill_md(skill)
-      @vm.write("#{skill_dir}/SKILL.md", skill_md)
+      @vm.write(project_name, "#{skill_dir}/SKILL.md", skill_md)
 
       for ref <- skill["references"] || [] do
-        @vm.write("#{skill_dir}/#{ref["name"]}", ref["content"])
+        @vm.write(project_name, "#{skill_dir}/#{ref["name"]}", ref["content"])
       end
     end
 
     :ok
   end
 
-  defp deploy_skills(_recipe, _agent_dir), do: :ok
+  defp deploy_skills(_project_name, _recipe, _agent_dir), do: :ok
 
   defp build_skill_md(skill) do
     """
@@ -436,17 +443,17 @@ defmodule Shire.Agent.AgentManager do
     """
   end
 
-  defp write_inbox_file(path, envelope) do
-    @vm.write(path, Jason.encode!(envelope))
+  defp write_inbox_file(project_name, path, envelope) do
+    @vm.write(project_name, path, Jason.encode!(envelope))
   end
 
   defp random_suffix do
     :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
   end
 
-  defp kill_existing_runner(agent_name) do
-    # Kill only this agent's runner process, not all runners on the shared VM
+  defp kill_existing_runner(project_name, agent_name) do
     @vm.cmd(
+      project_name,
       "pkill",
       ["-f", "agent-runner.ts --agent-dir /workspace/agents/#{agent_name}"],
       []
@@ -479,8 +486,8 @@ defmodule Shire.Agent.AgentManager do
     Phoenix.PubSub.broadcast(Shire.PubSub, state.pubsub_topic, message)
   end
 
-  defp load_env_vars do
-    case @vm.cmd("cat", ["/workspace/.env"], []) do
+  defp load_env_vars(project_name) do
+    case @vm.cmd(project_name, "cat", ["/workspace/.env"], []) do
       {:ok, content} ->
         content
         |> String.split("\n", trim: true)
@@ -518,6 +525,7 @@ defmodule Shire.Agent.AgentManager do
     input = Map.get(payload, "input", %{})
 
     case Agents.create_message(%{
+           project_name: state.project_name,
            agent_name: state.agent_name,
            role: "tool_use",
            content: %{
@@ -554,6 +562,7 @@ defmodule Shire.Agent.AgentManager do
         tool = Map.get(payload, "tool", "unknown")
 
         case Agents.create_message(%{
+               project_name: state.project_name,
                agent_name: state.agent_name,
                role: "tool_use",
                content: %{
@@ -608,6 +617,7 @@ defmodule Shire.Agent.AgentManager do
     state = flush_and_broadcast_streaming(state)
 
     case Agents.create_message(%{
+           project_name: state.project_name,
            agent_name: state.agent_name,
            role: "agent",
            content: %{"text" => text}
@@ -641,6 +651,7 @@ defmodule Shire.Agent.AgentManager do
 
   defp flush_and_broadcast_streaming(state) do
     case Agents.create_message(%{
+           project_name: state.project_name,
            agent_name: state.agent_name,
            role: "agent",
            content: %{"text" => state.streaming_text}

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -1,8 +1,8 @@
 defmodule Shire.Agent.Coordinator do
   @moduledoc """
-  Manages agent lifecycle on the shared Sprite VM.
-  Starts/stops AgentManagers via DynamicSupervisor.
-  VM initialization is handled by Shire.VirtualMachine.
+  Manages agent lifecycle on a project's Sprite VM.
+  Each project gets its own Coordinator, registered via ProjectRegistry.
+  Starts/stops AgentManagers via the project-scoped DynamicSupervisor.
   """
   use GenServer
   require Logger
@@ -12,55 +12,60 @@ defmodule Shire.Agent.Coordinator do
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    project_name = Keyword.fetch!(opts, :project_name)
+    GenServer.start_link(__MODULE__, opts, name: via(project_name))
+  end
+
+  defp via(project_name) do
+    {:via, Registry, {Shire.ProjectRegistry, {:coordinator, project_name}}}
   end
 
   # --- Public API ---
 
   @doc "Returns the current status for an agent (defaults to :created if not tracked)."
-  def agent_status(agent_name) do
-    GenServer.call(__MODULE__, {:agent_status, agent_name})
+  def agent_status(project_name, agent_name) do
+    GenServer.call(via(project_name), {:agent_status, agent_name})
   end
 
   @doc "Returns a map of `%{agent_name => status}` for the given agent names."
-  def agent_statuses(agent_names) do
-    GenServer.call(__MODULE__, {:agent_statuses, agent_names})
+  def agent_statuses(project_name, agent_names) do
+    GenServer.call(via(project_name), {:agent_statuses, agent_names})
   end
 
   @doc "Creates a new agent: writes recipe.yaml on VM and starts runner."
-  def create_agent(attrs) do
-    GenServer.call(__MODULE__, {:create_agent, attrs}, 60_000)
+  def create_agent(project_name, attrs) do
+    GenServer.call(via(project_name), {:create_agent, attrs}, 60_000)
   end
 
   @doc "Updates an agent's recipe.yaml on the VM."
-  def update_agent(agent_name, attrs) do
-    GenServer.call(__MODULE__, {:update_agent, agent_name, attrs}, 30_000)
+  def update_agent(project_name, agent_name, attrs) do
+    GenServer.call(via(project_name), {:update_agent, agent_name, attrs}, 30_000)
   end
 
-  def delete_agent(agent_name) do
-    GenServer.call(__MODULE__, {:delete_agent, agent_name}, 30_000)
+  def delete_agent(project_name, agent_name) do
+    GenServer.call(via(project_name), {:delete_agent, agent_name}, 30_000)
   end
 
-  def restart_agent(agent_name) do
-    GenServer.call(__MODULE__, {:restart_agent, agent_name}, 60_000)
+  def restart_agent(project_name, agent_name) do
+    GenServer.call(via(project_name), {:restart_agent, agent_name}, 60_000)
   end
 
-  def send_message(agent_name, text) do
-    AgentManager.send_message(agent_name, text, :user)
+  def send_message(project_name, agent_name, text) do
+    AgentManager.send_message(project_name, agent_name, text, :user)
   end
 
-  @doc "Look up a running agent's pid by name."
-  def lookup(agent_name) do
-    case Registry.lookup(Shire.AgentRegistry, agent_name) do
+  @doc "Look up a running agent's pid by name within a project."
+  def lookup(project_name, agent_name) do
+    case Registry.lookup(Shire.AgentRegistry, {project_name, agent_name}) do
       [{pid, _}] -> {:ok, pid}
       [] -> {:error, :not_found}
     end
   end
 
-  @doc "Returns all running agent names."
-  def list_running do
+  @doc "Returns all running agent names for a project."
+  def list_running(project_name) do
     Registry.select(Shire.AgentRegistry, [
-      {{:"$1", :"$2", :_}, [{:is_binary, :"$1"}], [:"$1"]}
+      {{{project_name, :"$1"}, :"$2", :_}, [], [:"$1"]}
     ])
   end
 
@@ -68,22 +73,25 @@ defmodule Shire.Agent.Coordinator do
   Lists agents by scanning `/workspace/agents/` on the VM.
   Returns `[%{name: name, ...}]` for each agent directory with a recipe.yaml.
   """
-  def list_agents do
-    GenServer.call(__MODULE__, :list_agents, 30_000)
+  def list_agents(project_name) do
+    GenServer.call(via(project_name), :list_agents, 30_000)
   end
 
   @doc "Reads an agent's recipe.yaml from the VM."
-  def get_agent(agent_name) do
-    GenServer.call(__MODULE__, {:get_agent, agent_name}, 15_000)
+  def get_agent(project_name, agent_name) do
+    GenServer.call(via(project_name), {:get_agent, agent_name}, 15_000)
   end
 
   # --- Callbacks ---
 
   @impl true
-  def init(_opts) do
-    Phoenix.PubSub.subscribe(Shire.PubSub, "agents:lobby")
+  def init(opts) do
+    project_name = Keyword.fetch!(opts, :project_name)
+
+    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_name}:agents:lobby")
 
     state = %{
+      project_name: project_name,
       monitors: %{},
       statuses: %{}
     }
@@ -93,27 +101,30 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_continue(:deploy_and_scan, state) do
-    case Shire.WorkspaceSettings.bootstrap_workspace() do
+    case Shire.WorkspaceSettings.bootstrap_workspace(state.project_name) do
       :ok -> :ok
       {:error, reason} -> Logger.error("Bootstrap failed: #{inspect(reason)}")
     end
 
-    case deploy_runner() do
+    case deploy_runner(state.project_name) do
       :ok -> :ok
       {:error, reason} -> Logger.error("Runner deployment failed: #{inspect(reason)}")
     end
 
-    {:ok, agent_names} = scan_agent_dirs()
+    {:ok, agent_names} = scan_agent_dirs(state.project_name)
 
     monitors =
       Enum.reduce(agent_names, state.monitors, fn name, acc ->
-        case start_agent_manager(name, acc) do
+        case start_agent_manager(state.project_name, name, acc) do
           {:ok, _pid, updated_monitors} -> updated_monitors
           {:error, _} -> acc
         end
       end)
 
-    Logger.info("Scanned and started #{length(agent_names)} agents")
+    Logger.info(
+      "Project #{state.project_name}: scanned and started #{length(agent_names)} agents"
+    )
+
     {:noreply, %{state | monitors: monitors}}
   end
 
@@ -121,8 +132,12 @@ defmodule Shire.Agent.Coordinator do
   def handle_call({:create_agent, %{"name" => name, "recipe_yaml" => recipe_yaml}}, _from, state) do
     agent_dir = "/workspace/agents/#{name}"
 
-    # Check if agent already exists (exit codes unreliable via Sprites, use echo)
-    case @vm.cmd("bash", ["-c", "test -d #{agent_dir} && echo exists || echo missing"], []) do
+    case @vm.cmd(
+           state.project_name,
+           "bash",
+           ["-c", "test -d #{agent_dir} && echo exists || echo missing"],
+           []
+         ) do
       {:error, reason} ->
         {:reply, {:error, reason}, state}
 
@@ -149,14 +164,19 @@ defmodule Shire.Agent.Coordinator do
     else
       agent_dir = "/workspace/agents/#{name}"
 
-      case @vm.write("#{agent_dir}/recipe.yaml", recipe_yaml) do
+      case @vm.write(state.project_name, "#{agent_dir}/recipe.yaml", recipe_yaml) do
         :ok ->
-          case lookup(name) do
-            {:ok, _pid} -> AgentManager.restart(name)
+          case lookup(state.project_name, name) do
+            {:ok, _pid} -> AgentManager.restart(state.project_name, name)
             {:error, :not_found} -> :ok
           end
 
-          Phoenix.PubSub.broadcast(Shire.PubSub, "agents:lobby", {:agent_updated, name})
+          Phoenix.PubSub.broadcast(
+            Shire.PubSub,
+            "project:#{state.project_name}:agents:lobby",
+            {:agent_updated, name}
+          )
+
           {:reply, :ok, state}
 
         {:error, reason} ->
@@ -173,9 +193,10 @@ defmodule Shire.Agent.Coordinator do
   @impl true
   def handle_call({:delete_agent, agent_name}, _from, state) do
     # Stop the process if running
-    case lookup(agent_name) do
+    case lookup(state.project_name, agent_name) do
       {:ok, pid} ->
-        DynamicSupervisor.terminate_child(Shire.AgentSupervisor, pid)
+        agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, state.project_name}}}
+        DynamicSupervisor.terminate_child(agent_sup, pid)
 
       {:error, :not_found} ->
         :ok
@@ -190,7 +211,7 @@ defmodule Shire.Agent.Coordinator do
     if ref, do: Process.demonitor(ref, [:flush])
 
     # Remove agent directory from VM
-    case @vm.cmd("rm", ["-rf", "/workspace/agents/#{agent_name}"], []) do
+    case @vm.cmd(state.project_name, "rm", ["-rf", "/workspace/agents/#{agent_name}"], []) do
       {:ok, _} ->
         :ok
 
@@ -200,15 +221,21 @@ defmodule Shire.Agent.Coordinator do
 
     statuses = Map.delete(state.statuses, agent_name)
     Logger.info("Deleted agent #{agent_name}")
-    Phoenix.PubSub.broadcast(Shire.PubSub, "agents:lobby", {:agent_deleted, agent_name})
+
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{state.project_name}:agents:lobby",
+      {:agent_deleted, agent_name}
+    )
+
     {:reply, :ok, %{state | monitors: monitors, statuses: statuses}}
   end
 
   @impl true
   def handle_call({:restart_agent, agent_name}, _from, state) do
-    case lookup(agent_name) do
+    case lookup(state.project_name, agent_name) do
       {:ok, _pid} ->
-        case AgentManager.restart(agent_name) do
+        case AgentManager.restart(state.project_name, agent_name) do
           :ok ->
             Logger.info("Restarting agent #{agent_name}")
             {:reply, :ok, state}
@@ -218,8 +245,7 @@ defmodule Shire.Agent.Coordinator do
         end
 
       {:error, :not_found} ->
-        # No process exists — spawn a fresh AgentManager
-        case start_agent_manager(agent_name, state.monitors) do
+        case start_agent_manager(state.project_name, agent_name, state.monitors) do
           {:ok, _pid, monitors} ->
             Logger.info("Started agent #{agent_name} (was not running)")
             {:reply, :ok, %{state | monitors: monitors}}
@@ -243,7 +269,7 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_call(:list_agents, _from, state) do
-    {:ok, names} = scan_agent_dirs()
+    {:ok, names} = scan_agent_dirs(state.project_name)
 
     agents =
       Enum.map(names, fn name ->
@@ -256,7 +282,7 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_call({:get_agent, agent_name}, _from, state) do
-    case read_agent_recipe(agent_name) do
+    case read_agent_recipe(state.project_name, agent_name) do
       {:ok, recipe} ->
         status = Map.get(state.statuses, agent_name, :created)
 
@@ -288,13 +314,13 @@ defmodule Shire.Agent.Coordinator do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agent:#{agent_name}",
+        "project:#{state.project_name}:agent:#{agent_name}",
         {:status, :crashed}
       )
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agents:lobby",
+        "project:#{state.project_name}:agents:lobby",
         {:agent_status, agent_name, :crashed}
       )
 
@@ -328,31 +354,32 @@ defmodule Shire.Agent.Coordinator do
 
   # --- Private ---
 
-  defp deploy_runner do
+  defp deploy_runner(project_name) do
     runner_dir = Application.app_dir(:shire, "priv/sprite")
 
-    # Deploy agent-runner.ts
     content = File.read!(Path.join(runner_dir, "agent-runner.ts"))
 
-    with :ok <- @vm.write("/workspace/.runner/agent-runner.ts", content),
-         :ok <- deploy_harness(runner_dir),
+    with :ok <- @vm.write(project_name, "/workspace/.runner/agent-runner.ts", content),
+         :ok <- deploy_harness(project_name, runner_dir),
          {:ok, _} <-
-           @vm.cmd("bash", ["-c", "cd /workspace/.runner && bun install"], timeout: 120_000) do
+           @vm.cmd(project_name, "bash", ["-c", "cd /workspace/.runner && bun install"],
+             timeout: 120_000
+           ) do
       :ok
     else
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp deploy_harness(runner_dir) do
+  defp deploy_harness(project_name, runner_dir) do
     harness_dir = Path.join(runner_dir, "harness")
 
     if File.dir?(harness_dir) do
-      with {:ok, _} <- @vm.cmd("mkdir", ["-p", "/workspace/.runner/harness"], []) do
+      with {:ok, _} <- @vm.cmd(project_name, "mkdir", ["-p", "/workspace/.runner/harness"], []) do
         Enum.reduce_while(File.ls!(harness_dir), :ok, fn file, :ok ->
           content = File.read!(Path.join(harness_dir, file))
 
-          case @vm.write("/workspace/.runner/harness/#{file}", content) do
+          case @vm.write(project_name, "/workspace/.runner/harness/#{file}", content) do
             :ok -> {:cont, :ok}
             {:error, reason} -> {:halt, {:error, reason}}
           end
@@ -363,10 +390,10 @@ defmodule Shire.Agent.Coordinator do
     end
   end
 
-  defp scan_agent_dirs do
+  defp scan_agent_dirs(project_name) do
     cmd = ~s(for d in /workspace/agents/*/; do test -f "$d/recipe.yaml" && basename "$d"; done)
 
-    case @vm.cmd("bash", ["-c", cmd], []) do
+    case @vm.cmd(project_name, "bash", ["-c", cmd], []) do
       {:ok, output} ->
         names = String.split(output, "\n", trim: true)
         {:ok, names}
@@ -380,10 +407,15 @@ defmodule Shire.Agent.Coordinator do
       {:ok, []}
   end
 
-  defp read_agent_recipe(agent_name) do
+  defp read_agent_recipe(project_name, agent_name) do
     path = "/workspace/agents/#{agent_name}/recipe.yaml"
 
-    case @vm.cmd("bash", ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"], []) do
+    case @vm.cmd(
+           project_name,
+           "bash",
+           ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"],
+           []
+         ) do
       {:error, reason} ->
         {:error, reason}
 
@@ -400,10 +432,9 @@ defmodule Shire.Agent.Coordinator do
   end
 
   defp create_agent_on_vm(name, agent_dir, recipe_yaml, state) do
-    # Create directory structure
     mkdir_results =
       Enum.map(["inbox", "outbox", "scripts", "documents"], fn subdir ->
-        @vm.cmd("mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
+        @vm.cmd(state.project_name, "mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
       end)
 
     case Enum.find(mkdir_results, &match?({:error, _}, &1)) do
@@ -411,11 +442,16 @@ defmodule Shire.Agent.Coordinator do
         {:reply, {:error, reason}, state}
 
       nil ->
-        case @vm.write("#{agent_dir}/recipe.yaml", recipe_yaml) do
+        case @vm.write(state.project_name, "#{agent_dir}/recipe.yaml", recipe_yaml) do
           :ok ->
-            case start_agent_manager(name, state.monitors) do
+            case start_agent_manager(state.project_name, name, state.monitors) do
               {:ok, pid, monitors} ->
-                Phoenix.PubSub.broadcast(Shire.PubSub, "agents:lobby", {:agent_created, name})
+                Phoenix.PubSub.broadcast(
+                  Shire.PubSub,
+                  "project:#{state.project_name}:agents:lobby",
+                  {:agent_created, name}
+                )
+
                 {:reply, {:ok, pid}, %{state | monitors: monitors}}
 
               {:error, reason} ->
@@ -438,8 +474,12 @@ defmodule Shire.Agent.Coordinator do
   defp rename_agent(old_name, new_name, recipe_yaml, state) do
     new_dir = "/workspace/agents/#{new_name}"
 
-    # Check if target name already exists
-    case @vm.cmd("bash", ["-c", "test -d #{new_dir} && echo exists || echo missing"], []) do
+    case @vm.cmd(
+           state.project_name,
+           "bash",
+           ["-c", "test -d #{new_dir} && echo exists || echo missing"],
+           []
+         ) do
       {:ok, output} ->
         if String.trim(output) == "exists" do
           {:reply, {:error, :already_exists}, state}
@@ -457,9 +497,13 @@ defmodule Shire.Agent.Coordinator do
     new_dir = "/workspace/agents/#{new_name}"
 
     # Stop old AgentManager if running
-    case lookup(old_name) do
-      {:ok, pid} -> DynamicSupervisor.terminate_child(Shire.AgentSupervisor, pid)
-      {:error, :not_found} -> :ok
+    case lookup(state.project_name, old_name) do
+      {:ok, pid} ->
+        agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, state.project_name}}}
+        DynamicSupervisor.terminate_child(agent_sup, pid)
+
+      {:error, :not_found} ->
+        :ok
     end
 
     # Clean up old monitor
@@ -471,37 +515,32 @@ defmodule Shire.Agent.Coordinator do
     if ref, do: Process.demonitor(ref, [:flush])
 
     # Rename directory on VM
-    case @vm.cmd("mv", [old_dir, new_dir], []) do
+    case @vm.cmd(state.project_name, "mv", [old_dir, new_dir], []) do
       {:ok, _} ->
-        # Write updated recipe
-        @vm.write("#{new_dir}/recipe.yaml", recipe_yaml)
+        @vm.write(state.project_name, "#{new_dir}/recipe.yaml", recipe_yaml)
 
-        # Migrate messages in DB
-        Shire.Agents.rename_agent_messages(old_name, new_name)
+        Shire.Agents.rename_agent_messages(state.project_name, old_name, new_name)
 
-        # Clean up old status
         statuses = state.statuses |> Map.delete(old_name)
 
-        # Start new AgentManager under new name
-        case start_agent_manager(new_name, monitors) do
+        case start_agent_manager(state.project_name, new_name, monitors) do
           {:ok, _pid, monitors} ->
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "agents:lobby",
+              "project:#{state.project_name}:agents:lobby",
               {:agent_renamed, old_name, new_name}
             )
 
             {:reply, :ok, %{state | monitors: monitors, statuses: statuses}}
 
           {:error, reason} ->
-            # Agent was renamed on disk but couldn't start — still report success
             Logger.warning(
               "Renamed #{old_name} -> #{new_name} but failed to start: #{inspect(reason)}"
             )
 
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "agents:lobby",
+              "project:#{state.project_name}:agents:lobby",
               {:agent_renamed, old_name, new_name}
             )
 
@@ -513,17 +552,15 @@ defmodule Shire.Agent.Coordinator do
     end
   end
 
-  defp start_agent_manager(agent_name, monitors) do
-    opts = [agent_name: agent_name]
+  defp start_agent_manager(project_name, agent_name, monitors) do
+    opts = [project_name: project_name, agent_name: agent_name]
+    agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_name}}}
 
-    case DynamicSupervisor.start_child(
-           Shire.AgentSupervisor,
-           {AgentManager, opts}
-         ) do
+    case DynamicSupervisor.start_child(agent_sup, {AgentManager, opts}) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
         monitors = Map.put(monitors, ref, agent_name)
-        Logger.info("Started agent #{agent_name}")
+        Logger.info("Started agent #{agent_name} (project: #{project_name})")
         {:ok, pid, monitors}
 
       {:error, reason} ->

--- a/lib/shire/agent/terminal_session.ex
+++ b/lib/shire/agent/terminal_session.ex
@@ -1,52 +1,58 @@
 defmodule Shire.Agent.TerminalSession do
   @moduledoc """
-  GenServer managing an interactive TTY session on the shared Sprite VM.
+  GenServer managing an interactive TTY session on a project's Sprite VM.
   Spawns `bash -i` with TTY mode and bridges stdin/stdout to PubSub.
-  Single global session (not per-agent).
+  One terminal session per project.
   """
   use GenServer
   require Logger
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
-  defstruct [:command, :command_ref, pubsub_topic: "terminal:global"]
+  defstruct [:project_name, :command, :command_ref, :pubsub_topic]
 
   # --- Public API ---
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: via())
+    project_name = Keyword.fetch!(opts, :project_name)
+    GenServer.start_link(__MODULE__, opts, name: via(project_name))
   end
 
-  def write(data) do
-    GenServer.cast(via(), {:write, data})
+  def write(project_name, data) do
+    GenServer.cast(via(project_name), {:write, data})
   end
 
-  def resize(rows, cols) do
-    GenServer.cast(via(), {:resize, rows, cols})
+  def resize(project_name, rows, cols) do
+    GenServer.cast(via(project_name), {:resize, rows, cols})
   end
 
-  def stop do
-    GenServer.stop(via())
+  def stop(project_name) do
+    GenServer.stop(via(project_name))
   end
 
-  def find do
-    case Registry.lookup(Shire.AgentRegistry, :global_terminal) do
+  def find(project_name) do
+    case Registry.lookup(Shire.ProjectRegistry, {:terminal, project_name}) do
       [{pid, _}] -> {:ok, pid}
       [] -> :error
     end
   end
 
-  defp via do
-    {:via, Registry, {Shire.AgentRegistry, :global_terminal}}
+  defp via(project_name) do
+    {:via, Registry, {Shire.ProjectRegistry, {:terminal, project_name}}}
   end
 
   # --- Callbacks ---
 
   @impl true
-  def init(_opts) do
-    state = %__MODULE__{}
+  def init(opts) do
+    project_name = Keyword.fetch!(opts, :project_name)
 
-    case @vm.spawn_command("bash", ["-i"],
+    state = %__MODULE__{
+      project_name: project_name,
+      pubsub_topic: "project:#{project_name}:terminal"
+    }
+
+    case @vm.spawn_command(project_name, "bash", ["-i"],
            tty: true,
            stdin: true,
            tty_rows: 24,
@@ -80,14 +86,14 @@ defmodule Shire.Agent.TerminalSession do
 
   @impl true
   def handle_info({:exit, %{ref: ref}, code}, %{command_ref: ref} = state) do
-    Logger.info("Global terminal session exited with code #{code}")
+    Logger.info("Terminal session exited with code #{code} (project: #{state.project_name})")
     broadcast(state, {:terminal_exit, code})
     {:stop, :normal, state}
   end
 
   @impl true
   def handle_info({:error, %{ref: ref}, reason}, %{command_ref: ref} = state) do
-    Logger.error("Global terminal session error: #{inspect(reason)}")
+    Logger.error("Terminal session error (project: #{state.project_name}): #{inspect(reason)}")
     broadcast(state, {:terminal_exit, 1})
     {:stop, :normal, state}
   end

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -12,7 +12,7 @@ defmodule Shire.Agents do
     do: message |> Message.changeset(attrs) |> Repo.update()
 
   @doc """
-  Lists messages for an agent with cursor-based pagination.
+  Lists messages for an agent within a project with cursor-based pagination.
 
   Options:
     - `:before` - message id cursor, fetch messages older than this id
@@ -20,13 +20,13 @@ defmodule Shire.Agents do
 
   Returns `{messages, has_more?}` where messages are ordered oldest-first.
   """
-  def list_messages_for_agent(agent_name, opts \\ []) do
+  def list_messages_for_agent(project_name, agent_name, opts \\ []) do
     limit = Keyword.get(opts, :limit, 50)
     before = Keyword.get(opts, :before)
 
     query =
       from m in Message,
-        where: m.agent_name == ^agent_name,
+        where: m.project_name == ^project_name and m.agent_name == ^agent_name,
         order_by: [desc: m.id],
         limit: ^limit
 
@@ -44,16 +44,16 @@ defmodule Shire.Agents do
   end
 
   @doc """
-  Lists inter-agent messages across all agents with cursor-based pagination.
+  Lists inter-agent messages within a project with cursor-based pagination.
   Returns `{messages, has_more?}` where messages are ordered newest-first.
   """
-  def list_inter_agent_messages(opts \\ []) do
+  def list_inter_agent_messages(project_name, opts \\ []) do
     limit = Keyword.get(opts, :limit, 100)
     before = Keyword.get(opts, :before)
 
     query =
       from m in Message,
-        where: m.role == "inter_agent",
+        where: m.project_name == ^project_name and m.role == "inter_agent",
         order_by: [desc: m.id],
         limit: ^limit
 
@@ -70,13 +70,17 @@ defmodule Shire.Agents do
     {messages, has_more}
   end
 
-  def rename_agent_messages(old_name, new_name) do
-    from(m in Message, where: m.agent_name == ^old_name)
+  def rename_agent_messages(project_name, old_name, new_name) do
+    from(m in Message,
+      where: m.project_name == ^project_name and m.agent_name == ^old_name
+    )
     |> Repo.update_all(set: [agent_name: new_name])
   end
 
-  def delete_messages_for_agent(agent_name) do
-    from(m in Message, where: m.agent_name == ^agent_name)
+  def delete_messages_for_agent(project_name, agent_name) do
+    from(m in Message,
+      where: m.project_name == ^project_name and m.agent_name == ^agent_name
+    )
     |> Repo.delete_all()
   end
 end

--- a/lib/shire/agents/message.ex
+++ b/lib/shire/agents/message.ex
@@ -3,6 +3,7 @@ defmodule Shire.Agents.Message do
   import Ecto.Changeset
 
   schema "messages" do
+    field :project_name, :string
     field :agent_name, :string
     field :role, :string
     field :content, :map, default: %{}
@@ -12,7 +13,7 @@ defmodule Shire.Agents.Message do
 
   def changeset(message, attrs) do
     message
-    |> cast(attrs, [:agent_name, :role, :content])
-    |> validate_required([:agent_name, :role])
+    |> cast(attrs, [:project_name, :agent_name, :role, :content])
+    |> validate_required([:project_name, :agent_name, :role])
   end
 end

--- a/lib/shire/application.ex
+++ b/lib/shire/application.ex
@@ -1,6 +1,4 @@
 defmodule Shire.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   @moduledoc false
 
   use Application
@@ -13,26 +11,15 @@ defmodule Shire.Application do
       {DNSCluster, query: Application.get_env(:shire, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Shire.PubSub},
       {Registry, keys: :unique, name: Shire.AgentRegistry},
-      {DynamicSupervisor, name: Shire.AgentSupervisor, strategy: :one_for_one}
+      {Registry, keys: :unique, name: Shire.ProjectRegistry},
+      {DynamicSupervisor, name: Shire.ProjectSupervisor, strategy: :one_for_one}
     ]
 
     vm_children =
       if Application.get_env(:shire, :skip_vm_boot, false) do
         []
       else
-        [
-          %{
-            id: :vm_supervisor,
-            start:
-              {Supervisor, :start_link,
-               [
-                 [Shire.VirtualMachineImpl],
-                 [strategy: :one_for_one, max_restarts: 10, max_seconds: 300]
-               ]},
-            type: :supervisor
-          },
-          Shire.Agent.Coordinator
-        ]
+        [Shire.ProjectManager]
       end
 
     children =
@@ -40,8 +27,6 @@ defmodule Shire.Application do
         vm_children ++
         [ShireWeb.Endpoint]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Shire.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/shire/project_instance_supervisor.ex
+++ b/lib/shire/project_instance_supervisor.ex
@@ -1,0 +1,26 @@
+defmodule Shire.ProjectInstanceSupervisor do
+  @moduledoc """
+  Per-project supervisor. Starts the VM, Coordinator, and agent DynamicSupervisor
+  for a single project. Uses `one_for_all` strategy: if the VM crashes,
+  the Coordinator and all agents restart too.
+  """
+  use Supervisor
+
+  def start_link(opts) do
+    project_name = Keyword.fetch!(opts, :project_name)
+    Supervisor.start_link(__MODULE__, project_name)
+  end
+
+  @impl true
+  def init(project_name) do
+    children = [
+      {Shire.VirtualMachineImpl, project_name: project_name},
+      {Shire.Agent.Coordinator, project_name: project_name},
+      {DynamicSupervisor,
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_name}}},
+       strategy: :one_for_one}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all, max_restarts: 10, max_seconds: 300)
+  end
+end

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -1,0 +1,193 @@
+defmodule Shire.ProjectManager do
+  @moduledoc """
+  Manages the lifecycle of projects (Sprite VMs).
+  Each project IS a VM. Projects are discovered via the VM module's `list_vms/0`.
+  No DB table — the Sprites API is the source of truth.
+  """
+  use GenServer
+  require Logger
+
+  @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  # --- Public API ---
+
+  @doc "Lists all projects by querying the Sprites API."
+  def list_projects do
+    GenServer.call(__MODULE__, :list_projects, 30_000)
+  end
+
+  @doc "Creates a new project: starts the supervision subtree (VM is created on init)."
+  def create_project(name) when is_binary(name) do
+    GenServer.call(__MODULE__, {:create_project, name}, 120_000)
+  end
+
+  @doc "Destroys a project: stops the supervision subtree and destroys the Sprite VM."
+  def destroy_project(name) when is_binary(name) do
+    GenServer.call(__MODULE__, {:destroy_project, name}, 60_000)
+  end
+
+  @doc "Returns the Coordinator pid for a project."
+  def lookup_coordinator(project_name) do
+    case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project_name}) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @doc "Returns the VirtualMachineImpl pid for a project."
+  def lookup_vm(project_name) do
+    case Registry.lookup(Shire.ProjectRegistry, {:vm, project_name}) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  # --- Callbacks ---
+
+  @impl true
+  def init(_opts) do
+    {:ok, %{projects: %{}, refs: %{}}, {:continue, :discover}}
+  end
+
+  @impl true
+  def handle_continue(:discover, state) do
+    prefix = prefix()
+
+    case @vm.list_vms() do
+      {:ok, vm_names} ->
+        projects =
+          Enum.reduce(vm_names, state.projects, fn vm_name, acc ->
+            if String.starts_with?(vm_name, prefix) do
+              project_name = String.replace_prefix(vm_name, prefix, "")
+
+              case start_project_subtree(project_name) do
+                {:ok, pid} ->
+                  Process.monitor(pid)
+                  Map.put(acc, project_name, pid)
+
+                {:error, reason} ->
+                  Logger.error("Failed to start project #{project_name}: #{inspect(reason)}")
+                  acc
+              end
+            else
+              acc
+            end
+          end)
+
+        Logger.info("Discovered #{map_size(projects)} project(s)")
+        {:noreply, %{state | projects: projects}}
+
+      {:error, reason} ->
+        Logger.error("Failed to list VMs: #{inspect(reason)}")
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:list_projects, _from, state) do
+    projects =
+      Enum.map(state.projects, fn {name, pid} ->
+        status =
+          if Process.alive?(pid) do
+            :running
+          else
+            :error
+          end
+
+        %{name: name, status: status}
+      end)
+
+    {:reply, projects, state}
+  end
+
+  @impl true
+  def handle_call({:create_project, name}, _from, state) do
+    if Map.has_key?(state.projects, name) do
+      {:reply, {:error, :already_exists}, state}
+    else
+      # VirtualMachineImpl.init will create-or-connect to the VM
+      case start_project_subtree(name) do
+        {:ok, pid} ->
+          Process.monitor(pid)
+          projects = Map.put(state.projects, name, pid)
+
+          Phoenix.PubSub.broadcast(
+            Shire.PubSub,
+            "projects:lobby",
+            {:project_created, name}
+          )
+
+          {:reply, {:ok, pid}, %{state | projects: projects}}
+
+        {:error, reason} ->
+          {:reply, {:error, reason}, state}
+      end
+    end
+  end
+
+  @impl true
+  def handle_call({:destroy_project, name}, _from, state) do
+    case Map.pop(state.projects, name) do
+      {nil, _} ->
+        {:reply, {:error, :not_found}, state}
+
+      {pid, projects} ->
+        # Stop the supervision subtree first
+        DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, pid)
+
+        # Destroy the underlying VM
+        case @vm.destroy_vm(name) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("Failed to destroy VM for #{name}: #{inspect(reason)}")
+        end
+
+        Phoenix.PubSub.broadcast(
+          Shire.PubSub,
+          "projects:lobby",
+          {:project_destroyed, name}
+        )
+
+        {:reply, :ok, %{state | projects: projects}}
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    case Enum.find(state.projects, fn {_name, p} -> p == pid end) do
+      {name, _pid} ->
+        Logger.warning("Project #{name} supervisor went down, removing from tracked projects")
+        projects = Map.delete(state.projects, name)
+
+        Phoenix.PubSub.broadcast(
+          Shire.PubSub,
+          "projects:lobby",
+          {:project_destroyed, name}
+        )
+
+        {:noreply, %{state | projects: projects}}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  # --- Private ---
+
+  defp prefix do
+    Application.get_env(:shire, :sprite_vm_prefix, "shire-")
+  end
+
+  defp start_project_subtree(project_name) do
+    DynamicSupervisor.start_child(
+      Shire.ProjectSupervisor,
+      {Shire.ProjectInstanceSupervisor, project_name: project_name}
+    )
+  end
+end

--- a/lib/shire/virtual_machine.ex
+++ b/lib/shire/virtual_machine.ex
@@ -1,6 +1,7 @@
 defmodule Shire.VirtualMachine do
   @moduledoc """
   Behaviour defining the VM interface for all Sprite VM operations.
+  All project-scoped operations take `project_name` as the first parameter.
   Consumers use `@vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)`
   to resolve the implementation at compile time.
   """
@@ -8,17 +9,25 @@ defmodule Shire.VirtualMachine do
   @type cmd_result :: {:ok, binary()} | {:error, term()}
   @type fs_result :: :ok | {:error, term()}
 
-  @callback cmd(binary(), [binary()], keyword()) :: cmd_result()
-  @callback cmd!(binary(), [binary()], keyword()) :: binary()
-  @callback read(binary()) :: cmd_result()
-  @callback write(binary(), binary()) :: fs_result()
-  @callback mkdir_p(binary()) :: fs_result()
-  @callback rm(binary()) :: fs_result()
-  @callback rm_rf(binary()) :: fs_result()
-  @callback ls(binary()) :: {:ok, [map()]} | {:error, term()}
-  @callback stat(binary()) :: {:ok, map()} | {:error, term()}
-  @callback spawn_command(binary(), [binary()], keyword()) ::
+  @callback cmd(String.t(), binary(), [binary()], keyword()) :: cmd_result()
+  @callback cmd!(String.t(), binary(), [binary()], keyword()) :: binary()
+  @callback read(String.t(), binary()) :: cmd_result()
+  @callback write(String.t(), binary(), binary()) :: fs_result()
+  @callback mkdir_p(String.t(), binary()) :: fs_result()
+  @callback rm(String.t(), binary()) :: fs_result()
+  @callback rm_rf(String.t(), binary()) :: fs_result()
+  @callback ls(String.t(), binary()) :: {:ok, [map()]} | {:error, term()}
+  @callback stat(String.t(), binary()) :: {:ok, map()} | {:error, term()}
+  @callback spawn_command(String.t(), binary(), [binary()], keyword()) ::
               {:ok, Sprites.Command.t()} | {:error, term()}
   @callback write_stdin(Sprites.Command.t(), binary()) :: :ok | {:error, term()}
   @callback resize(Sprites.Command.t(), integer(), integer()) :: :ok | {:error, term()}
+
+  # --- VM Management (module-level, not per-project) ---
+
+  @doc "Lists all VM names matching the configured prefix."
+  @callback list_vms() :: {:ok, [String.t()]} | {:error, term()}
+
+  @doc "Destroys the underlying VM for a project."
+  @callback destroy_vm(String.t()) :: :ok | {:error, term()}
 end

--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -1,16 +1,11 @@
 defmodule Shire.VirtualMachineImpl do
   @moduledoc """
-  GenServer owning the shared Sprite VM lifecycle. Provides consistent
+  Per-project GenServer owning a Sprite VM lifecycle. Provides consistent
   error handling, default timeouts, and failure logging for all VM operations.
 
-  Callers use `vm().cmd/3`, `vm().write/2`, etc. via the Shire.VirtualMachine
-  behaviour — this module is the production implementation.
-
-  Init is synchronous — the supervisor blocks until the VM is ready, so
-  downstream processes (Coordinator, AgentManager) are guaranteed a live VM.
-
-  Wrapped in a dedicated supervisor with generous restart tolerance so
-  transient network failures at boot don't permanently disable the VM.
+  Each project gets its own VirtualMachineImpl instance, registered dynamically
+  via Shire.ProjectRegistry. The VM name is derived from the configurable prefix
+  and the project name.
   """
   use GenServer
   require Logger
@@ -24,24 +19,24 @@ defmodule Shire.VirtualMachineImpl do
   @keepalive_duration :timer.minutes(30)
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    project_name = Keyword.fetch!(opts, :project_name)
+    GenServer.start_link(__MODULE__, opts, name: via(project_name))
+  end
+
+  defp via(project_name) do
+    {:via, Registry, {Shire.ProjectRegistry, {:vm, project_name}}}
   end
 
   # --- Public API: Command Execution ---
 
-  @doc """
-  Executes a command on the VM. Returns `{:ok, output}` or `{:error, reason}`.
-  Default timeout is #{@default_cmd_timeout}ms. Override with `timeout:` in opts.
-  """
   @impl Shire.VirtualMachine
-  def cmd(command, args \\ [], opts \\ []) do
-    GenServer.call(__MODULE__, {:cmd, command, args, opts}, call_timeout(opts))
+  def cmd(project_name, command, args \\ [], opts \\ []) do
+    GenServer.call(via(project_name), {:cmd, command, args, opts}, call_timeout(opts))
   end
 
-  @doc "Like `cmd/3` but raises on failure."
   @impl Shire.VirtualMachine
-  def cmd!(command, args \\ [], opts \\ []) do
-    case cmd(command, args, opts) do
+  def cmd!(project_name, command, args \\ [], opts \\ []) do
+    case cmd(project_name, command, args, opts) do
       {:ok, output} ->
         output
 
@@ -58,60 +53,46 @@ defmodule Shire.VirtualMachineImpl do
 
   # --- Public API: Filesystem ---
 
-  @doc "Reads a file from the VM filesystem."
   @impl Shire.VirtualMachine
-  def read(path) do
-    GenServer.call(__MODULE__, {:read, path})
+  def read(project_name, path) do
+    GenServer.call(via(project_name), {:read, path})
   end
 
-  @doc "Writes content to a file on the VM filesystem."
   @impl Shire.VirtualMachine
-  def write(path, content) do
-    GenServer.call(__MODULE__, {:write, path, content})
+  def write(project_name, path, content) do
+    GenServer.call(via(project_name), {:write, path, content})
   end
 
-  @doc "Creates a directory (and parents) on the VM filesystem."
   @impl Shire.VirtualMachine
-  def mkdir_p(path) do
-    GenServer.call(__MODULE__, {:mkdir_p, path})
+  def mkdir_p(project_name, path) do
+    GenServer.call(via(project_name), {:mkdir_p, path})
   end
 
-  @doc "Removes a file from the VM filesystem."
   @impl Shire.VirtualMachine
-  def rm(path) do
-    GenServer.call(__MODULE__, {:rm, path})
+  def rm(project_name, path) do
+    GenServer.call(via(project_name), {:rm, path})
   end
 
-  @doc "Recursively removes a file or directory from the VM filesystem."
   @impl Shire.VirtualMachine
-  def rm_rf(path) do
-    GenServer.call(__MODULE__, {:rm_rf, path})
+  def rm_rf(project_name, path) do
+    GenServer.call(via(project_name), {:rm_rf, path})
   end
 
-  @doc "Lists directory contents on the VM filesystem."
   @impl Shire.VirtualMachine
-  def ls(path) do
-    GenServer.call(__MODULE__, {:ls, path})
+  def ls(project_name, path) do
+    GenServer.call(via(project_name), {:ls, path})
   end
 
-  @doc "Gets file/directory stats from the VM filesystem."
   @impl Shire.VirtualMachine
-  def stat(path) do
-    GenServer.call(__MODULE__, {:stat, path})
+  def stat(project_name, path) do
+    GenServer.call(via(project_name), {:stat, path})
   end
 
   # --- Public API: Interactive Process ---
 
-  @doc """
-  Spawns an async command on the VM (for interactive/streaming use).
-
-  The spawn is executed in the **caller's** process so that stdout/stderr/exit
-  messages are delivered directly to the caller (e.g. AgentManager, TerminalSession)
-  rather than to this GenServer.
-  """
   @impl Shire.VirtualMachine
-  def spawn_command(command, args \\ [], opts \\ []) do
-    sprite = GenServer.call(__MODULE__, :get_sprite)
+  def spawn_command(project_name, command, args \\ [], opts \\ []) do
+    sprite = GenServer.call(via(project_name), :get_sprite)
 
     case sprite do
       nil ->
@@ -122,7 +103,6 @@ defmodule Shire.VirtualMachineImpl do
     end
   end
 
-  @doc "Writes data to a command's stdin. Returns `:ok` or `{:error, reason}` if the process is dead."
   @impl Shire.VirtualMachine
   @spec write_stdin(Sprites.Command.t(), binary()) :: :ok | {:error, term()}
   def write_stdin(command, data) do
@@ -133,7 +113,6 @@ defmodule Shire.VirtualMachineImpl do
       {:error, {:process_dead, reason}}
   end
 
-  @doc "Resizes a command's TTY. Returns `:ok` or `{:error, reason}` if the process is dead."
   @impl Shire.VirtualMachine
   @spec resize(Sprites.Command.t(), integer(), integer()) :: :ok | {:error, term()}
   def resize(command, rows, cols) do
@@ -144,25 +123,82 @@ defmodule Shire.VirtualMachineImpl do
       {:error, {:process_dead, reason}}
   end
 
-  # --- GenServer Callbacks ---
+  # --- VM Management (module-level, no GenServer) ---
 
-  @impl GenServer
-  def init(_opts) do
+  @impl Shire.VirtualMachine
+  def list_vms do
     token = Application.get_env(:shire, :sprites_token)
 
     if token do
-      case init_shared_vm(token) do
-        {:ok, sprite, fs} ->
-          Logger.info("Shared VM #{get_sprite_name()} ready")
-          {:ok, %{sprite: sprite, fs: fs, ping_timer: nil, ping_until: nil}}
+      client = Sprites.new(token)
+      prefix = Application.get_env(:shire, :sprite_vm_prefix, "shire-")
+
+      case Sprites.list(client, prefix: prefix) do
+        {:ok, sprites} ->
+          names =
+            sprites
+            |> Enum.map(fn info -> info["name"] || info[:name] end)
+            |> Enum.filter(&(&1 && String.starts_with?(&1, prefix)))
+
+          {:ok, names}
 
         {:error, reason} ->
-          Logger.error("Failed to initialize shared VM: #{inspect(reason)}")
+          {:error, reason}
+      end
+    else
+      {:ok, []}
+    end
+  end
+
+  @impl Shire.VirtualMachine
+  def destroy_vm(project_name) do
+    token = Application.get_env(:shire, :sprites_token)
+
+    if token do
+      client = Sprites.new(token)
+      name = vm_name(project_name)
+
+      case Sprites.get_sprite(client, name) do
+        {:ok, _} ->
+          sprite = Sprites.sprite(client, name)
+          Sprites.destroy(sprite)
+          :ok
+
+        {:error, {:not_found, _}} ->
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      {:error, :no_token}
+    end
+  end
+
+  # --- GenServer Callbacks ---
+
+  @impl GenServer
+  def init(opts) do
+    project_name = Keyword.fetch!(opts, :project_name)
+    token = Application.get_env(:shire, :sprites_token)
+
+    if token do
+      vm_name = vm_name(project_name)
+
+      case init_vm(token, vm_name) do
+        {:ok, sprite, fs} ->
+          Logger.info("VM #{vm_name} ready (project: #{project_name})")
+
+          {:ok,
+           %{sprite: sprite, fs: fs, project_name: project_name, ping_timer: nil, ping_until: nil}}
+
+        {:error, reason} ->
+          Logger.error("Failed to initialize VM #{vm_name}: #{inspect(reason)}")
           {:stop, {:init_failed, reason}}
       end
     else
       Logger.warning("No SPRITES_TOKEN configured — VM features disabled")
-      {:ok, %{sprite: nil, fs: nil, ping_timer: nil, ping_until: nil}}
+      {:ok, %{sprite: nil, fs: nil, project_name: project_name, ping_timer: nil, ping_until: nil}}
     end
   end
 
@@ -350,22 +386,26 @@ defmodule Shire.VirtualMachineImpl do
   end
 
   @impl GenServer
-  def terminate(reason, %{sprite: nil}),
-    do: Logger.warning("VirtualMachineImpl stopping (no VM): #{inspect(reason)}")
+  def terminate(reason, %{sprite: nil} = state),
+    do:
+      Logger.warning(
+        "VirtualMachineImpl stopping (no VM, project: #{state.project_name}): #{inspect(reason)}"
+      )
 
-  def terminate(reason, _state) do
-    Logger.warning("VirtualMachineImpl stopping: #{inspect(reason)}")
+  def terminate(reason, state) do
+    Logger.warning(
+      "VirtualMachineImpl stopping (project: #{state.project_name}): #{inspect(reason)}"
+    )
   end
 
   # --- Private: VM Initialization ---
 
-  defp get_sprite_name() do
-    Application.get_env(:shire, :sprite_vm_name, "shire-vm")
+  defp vm_name(project_name) do
+    "#{Application.get_env(:shire, :sprite_vm_prefix, "shire-")}#{project_name}"
   end
 
-  defp init_shared_vm(token) do
+  defp init_vm(token, vm_name) do
     client = Sprites.new(token)
-    vm_name = get_sprite_name()
 
     sprite =
       case Sprites.get_sprite(client, vm_name) do
@@ -414,7 +454,6 @@ defmodule Shire.VirtualMachineImpl do
     Sprites.filesystem(patched_sprite)
   end
 
-  # GenServer call timeout: use the command timeout + 5s buffer
   defp call_timeout(opts) do
     (Keyword.get(opts, :timeout, @default_cmd_timeout) || @default_cmd_timeout) + 5_000
   end

--- a/lib/shire/workspace_settings.ex
+++ b/lib/shire/workspace_settings.ex
@@ -1,7 +1,7 @@
 defmodule Shire.WorkspaceSettings do
   @moduledoc """
-  Manages environment variables and global scripts on the Sprite VM.
-  Talks directly to the VM module — no GenServer, no blocking the Coordinator.
+  Manages environment variables and global scripts on a project's Sprite VM.
+  All functions take `project_name` as the first parameter.
   """
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
@@ -9,16 +9,21 @@ defmodule Shire.WorkspaceSettings do
   # --- Environment ---
 
   @doc "Reads `/workspace/.env` from the VM and returns it as a string."
-  def read_env do
-    case @vm.cmd("bash", ["-c", "test -f /workspace/.env && cat /workspace/.env || echo ''"], []) do
+  def read_env(project_name) do
+    case @vm.cmd(
+           project_name,
+           "bash",
+           ["-c", "test -f /workspace/.env && cat /workspace/.env || echo ''"],
+           []
+         ) do
       {:ok, output} -> {:ok, output}
       {:error, _} -> {:ok, ""}
     end
   end
 
   @doc "Writes the given string to `/workspace/.env` on the VM."
-  def write_env(content) do
-    case @vm.write("/workspace/.env", content) do
+  def write_env(project_name, content) do
+    case @vm.write(project_name, "/workspace/.env", content) do
       :ok -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -27,8 +32,9 @@ defmodule Shire.WorkspaceSettings do
   # --- Scripts ---
 
   @doc "Lists script filenames in `/workspace/.scripts/`."
-  def list_scripts do
+  def list_scripts(project_name) do
     case @vm.cmd(
+           project_name,
            "bash",
            ["-c", "test -d /workspace/.scripts && ls /workspace/.scripts || echo ''"],
            []
@@ -47,12 +53,12 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Lists all scripts with their content from `/workspace/.scripts/`."
-  def read_all_scripts do
-    with {:ok, names} <- list_scripts() do
+  def read_all_scripts(project_name) do
+    with {:ok, names} <- list_scripts(project_name) do
       scripts =
         Enum.map(names, fn name ->
           content =
-            case read_script(name) do
+            case read_script(project_name, name) do
               {:ok, c} -> c
               _ -> ""
             end
@@ -65,10 +71,15 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Reads a script file from `/workspace/.scripts/{name}`."
-  def read_script(name) do
+  def read_script(project_name, name) do
     path = "/workspace/.scripts/#{name}"
 
-    case @vm.cmd("bash", ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"], []) do
+    case @vm.cmd(
+           project_name,
+           "bash",
+           ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"],
+           []
+         ) do
       {:ok, output} ->
         if String.trim(output) == "__NOT_FOUND__" do
           {:error, :not_found}
@@ -82,11 +93,11 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Writes a script file to `/workspace/.scripts/{name}`."
-  def write_script(name, content) do
+  def write_script(project_name, name, content) do
     path = "/workspace/.scripts/#{name}"
 
-    with :ok <- @vm.write(path, content),
-         {:ok, _} <- @vm.cmd("chmod", ["+x", path], []) do
+    with :ok <- @vm.write(project_name, path, content),
+         {:ok, _} <- @vm.cmd(project_name, "chmod", ["+x", path], []) do
       :ok
     else
       {:error, reason} -> {:error, reason}
@@ -94,18 +105,18 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Deletes a script file from `/workspace/.scripts/{name}`."
-  def delete_script(name) do
+  def delete_script(project_name, name) do
     path = "/workspace/.scripts/#{name}"
-    @vm.cmd("rm", ["-f", path], [])
+    @vm.cmd(project_name, "rm", ["-f", path], [])
     :ok
   end
 
   @doc "Runs a script from `/workspace/.scripts/{name}` and returns output."
-  def run_script(name) do
+  def run_script(project_name, name) do
     path = "/workspace/.scripts/#{name}"
     script_cmd = "[ -f /workspace/.env ] && set -a && . /workspace/.env && set +a; bash #{path}"
 
-    case @vm.cmd("bash", ["-c", script_cmd], timeout: 120_000) do
+    case @vm.cmd(project_name, "bash", ["-c", script_cmd], timeout: 120_000) do
       {:ok, output} -> {:ok, output}
       {:error, reason} -> {:error, reason}
     end
@@ -114,10 +125,10 @@ defmodule Shire.WorkspaceSettings do
   # --- Bootstrap ---
 
   @doc "Runs the bootstrap script to initialize `/workspace` directories on the VM."
-  def bootstrap_workspace do
+  def bootstrap_workspace(project_name) do
     script = File.read!(Application.app_dir(:shire, "priv/sprite/bootstrap.sh"))
 
-    case @vm.cmd("bash", ["-c", script], timeout: 120_000) do
+    case @vm.cmd(project_name, "bash", ["-c", script], timeout: 120_000) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end

--- a/lib/shire_web/controllers/shared_drive_controller.ex
+++ b/lib/shire_web/controllers/shared_drive_controller.ex
@@ -4,10 +4,10 @@ defmodule ShireWeb.SharedDriveController do
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
   @drive_path "/workspace/shared"
 
-  def download(conn, %{"path" => path}) do
+  def download(conn, %{"project" => project, "path" => path}) do
     vm_path = to_vm_path(path)
 
-    case @vm.read(vm_path) do
+    case @vm.read(project, vm_path) do
       {:ok, content} ->
         filename = Path.basename(path)
         content_type = MIME.from_path(path)

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -3,29 +3,39 @@ defmodule ShireWeb.AgentLive.Index do
 
   alias Shire.Agents
   alias Shire.Agent.Coordinator
+  alias Shire.ProjectManager
   alias ShireWeb.AgentLive.{AgentStreaming, Helpers}
 
   @impl true
-  def mount(_params, _session, socket) do
-    if connected?(socket) do
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agents:lobby")
+  def mount(%{"project" => project}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project) do
+      {:error, :not_found} ->
+        {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
+
+      {:ok, _pid} ->
+        if connected?(socket) do
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:agents:lobby")
+        end
+
+        agents = Coordinator.list_agents(project)
+        projects = ProjectManager.list_projects()
+
+        {:ok,
+         assign(socket,
+           project: project,
+           projects: projects,
+           agents: agents,
+           selected_agent_name: nil,
+           selected_agent: nil,
+           messages: [],
+           has_more: false,
+           loading_more: false,
+           streaming_text: nil,
+           busy_agents: MapSet.new(),
+           agent_statuses: %{},
+           editing_agent: nil
+         )}
     end
-
-    agents = Coordinator.list_agents()
-
-    {:ok,
-     assign(socket,
-       agents: agents,
-       selected_agent_name: nil,
-       selected_agent: nil,
-       messages: [],
-       has_more: false,
-       loading_more: false,
-       streaming_text: nil,
-       busy_agents: MapSet.new(),
-       agent_statuses: %{},
-       editing_agent: nil
-     )}
   end
 
   @impl true
@@ -37,9 +47,11 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_event("delete-agent", %{"name" => name}, socket) do
-    case Coordinator.delete_agent(name) do
+    project = socket.assigns.project
+
+    case Coordinator.delete_agent(project, name) do
       :ok ->
-        agents = Coordinator.list_agents()
+        agents = Coordinator.list_agents(project)
 
         selected =
           if socket.assigns.selected_agent_name == name do
@@ -62,7 +74,7 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   def handle_event("edit-agent", %{"name" => name}, socket) do
-    case Coordinator.get_agent(name) do
+    case Coordinator.get_agent(socket.assigns.project, name) do
       {:ok, agent} ->
         {:noreply, assign(socket, :editing_agent, agent)}
 
@@ -72,9 +84,11 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   def handle_event("create-agent", params, socket) do
-    case Coordinator.create_agent(params) do
+    project = socket.assigns.project
+
+    case Coordinator.create_agent(project, params) do
       {:ok, _pid} ->
-        agents = Coordinator.list_agents()
+        agents = Coordinator.list_agents(project)
 
         {:noreply,
          socket
@@ -94,12 +108,11 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   def handle_event("update-agent", params, socket) do
+    project = socket.assigns.project
     name = params["name"]
 
-    case Coordinator.update_agent(name, params) do
+    case Coordinator.update_agent(project, name, params) do
       :ok ->
-        # The rename broadcast will handle agent list refresh,
-        # but we still need to update local state for the editing_agent close
         {:noreply,
          socket
          |> assign(:editing_agent, nil)
@@ -114,18 +127,19 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_event("select-agent", %{"name" => name}, socket) do
-    case Coordinator.get_agent(name) do
+    project = socket.assigns.project
+
+    case Coordinator.get_agent(project, name) do
       {:ok, agent} ->
         if connected?(socket) do
-          # Unsubscribe from previous agent if any
           if old = socket.assigns.selected_agent_name do
-            Phoenix.PubSub.unsubscribe(Shire.PubSub, "agent:#{old}")
+            Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project}:agent:#{old}")
           end
 
-          Phoenix.PubSub.subscribe(Shire.PubSub, "agent:#{name}")
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:agent:#{name}")
         end
 
-        {messages, has_more} = Agents.list_messages_for_agent(name, limit: 50)
+        {messages, has_more} = Agents.list_messages_for_agent(project, name, limit: 50)
 
         {:noreply,
          assign(socket,
@@ -143,15 +157,15 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_event("send-message", %{"text" => text}, socket) do
+    project = socket.assigns.project
     agent_name = socket.assigns.selected_agent_name
 
-    case Coordinator.send_message(agent_name, text) do
+    case Coordinator.send_message(project, agent_name, text) do
       {:ok, msg} ->
         messages = socket.assigns.messages ++ [Helpers.serialize_message(msg)]
         {:noreply, assign(socket, :messages, messages)}
 
       :ok ->
-        # Message delivered but persistence failed (logged in AgentManager)
         {:noreply, socket}
 
       {:error, reason} ->
@@ -164,10 +178,12 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_event("load-more", %{"before" => before}, socket) do
+    project = socket.assigns.project
     name = socket.assigns.selected_agent_name
 
     if name do
-      {new_messages, has_more} = Agents.list_messages_for_agent(name, before: before, limit: 50)
+      {new_messages, has_more} =
+        Agents.list_messages_for_agent(project, name, before: before, limit: 50)
 
       all_messages =
         Enum.map(new_messages, &Helpers.serialize_message/1) ++ socket.assigns.messages
@@ -203,7 +219,6 @@ defmodule ShireWeb.AgentLive.Index do
         MapSet.delete(socket.assigns.busy_agents, agent_name)
       end
 
-    # Update selected agent's busy state if it's the one that changed
     selected_agent =
       if socket.assigns.selected_agent && socket.assigns.selected_agent_name == agent_name do
         Map.put(socket.assigns.selected_agent, :busy, active)
@@ -220,17 +235,18 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_info({:agent_created, _name}, socket) do
-    agents = Coordinator.list_agents()
+    agents = Coordinator.list_agents(socket.assigns.project)
     {:noreply, assign(socket, :agents, agents)}
   end
 
   @impl true
   def handle_info({:agent_updated, name}, socket) do
-    agents = Coordinator.list_agents()
+    project = socket.assigns.project
+    agents = Coordinator.list_agents(project)
 
     selected_agent =
       if socket.assigns.selected_agent_name == name do
-        case Coordinator.get_agent(name) do
+        case Coordinator.get_agent(project, name) do
           {:ok, agent} -> agent
           _ -> socket.assigns.selected_agent
         end
@@ -243,15 +259,22 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_info({:agent_renamed, old_name, new_name}, socket) do
-    agents = Coordinator.list_agents()
+    project = socket.assigns.project
+    agents = Coordinator.list_agents(project)
 
     if socket.assigns.selected_agent_name == old_name do
-      case Coordinator.get_agent(new_name) do
+      case Coordinator.get_agent(project, new_name) do
         {:ok, agent} ->
-          # Re-subscribe to the new agent's PubSub topic
           if connected?(socket) do
-            Phoenix.PubSub.unsubscribe(Shire.PubSub, "agent:#{old_name}")
-            Phoenix.PubSub.subscribe(Shire.PubSub, "agent:#{new_name}")
+            Phoenix.PubSub.unsubscribe(
+              Shire.PubSub,
+              "project:#{project}:agent:#{old_name}"
+            )
+
+            Phoenix.PubSub.subscribe(
+              Shire.PubSub,
+              "project:#{project}:agent:#{new_name}"
+            )
           end
 
           {:noreply,
@@ -271,7 +294,7 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_info({:agent_deleted, name}, socket) do
-    agents = Coordinator.list_agents()
+    agents = Coordinator.list_agents(socket.assigns.project)
 
     if socket.assigns.selected_agent_name == name do
       {:noreply,
@@ -316,6 +339,8 @@ defmodule ShireWeb.AgentLive.Index do
     ~H"""
     <.react
       name="AgentDashboard"
+      project={@project}
+      projects={@projects}
       agents={@agents_with_busy}
       selectedAgent={@selected_agent}
       editAgent={@editing_agent}

--- a/lib/shire_web/live/agent_live/show.ex
+++ b/lib/shire_web/live/agent_live/show.ex
@@ -2,28 +2,36 @@ defmodule ShireWeb.AgentLive.Show do
   use ShireWeb, :live_view
 
   alias Shire.Agent.Coordinator
+  alias Shire.ProjectManager
 
   @impl true
-  def mount(%{"name" => name}, _session, socket) do
-    agent =
-      try do
-        case Coordinator.get_agent(name) do
-          {:ok, data} -> data
-          {:error, _} -> %{name: name, status: Coordinator.agent_status(name)}
+  def mount(%{"project" => project, "name" => name}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project) do
+      {:error, :not_found} ->
+        {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
+
+      {:ok, _pid} ->
+        agent =
+          try do
+            case Coordinator.get_agent(project, name) do
+              {:ok, data} -> data
+              {:error, _} -> %{name: name, status: Coordinator.agent_status(project, name)}
+            end
+          catch
+            :exit, _ -> %{name: name, status: :created}
+          end
+
+        if connected?(socket) do
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:agent:#{name}")
         end
-      catch
-        :exit, _ -> %{name: name, status: :created}
-      end
 
-    if connected?(socket) do
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agent:#{name}")
+        {:ok,
+         assign(socket,
+           project: project,
+           agent: agent,
+           agent_status: agent.status
+         )}
     end
-
-    {:ok,
-     assign(socket,
-       agent: agent,
-       agent_status: agent.status
-     )}
   end
 
   @impl true
@@ -33,9 +41,10 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("start-agent", _params, socket) do
+    project = socket.assigns.project
     name = socket.assigns.agent.name
 
-    case Coordinator.restart_agent(name) do
+    case Coordinator.restart_agent(project, name) do
       :ok ->
         {:noreply, put_flash(socket, :info, "Agent starting...")}
 
@@ -49,14 +58,15 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("delete-agent", _params, socket) do
+    project = socket.assigns.project
     name = socket.assigns.agent.name
 
-    case Coordinator.delete_agent(name) do
+    case Coordinator.delete_agent(project, name) do
       :ok ->
         {:noreply,
          socket
          |> put_flash(:info, "Agent deleted")
-         |> redirect(to: ~p"/")}
+         |> redirect(to: ~p"/projects/#{project}")}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed to delete: #{inspect(reason)}")}
@@ -65,19 +75,20 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("update-agent", params, socket) do
+    project = socket.assigns.project
     name = socket.assigns.agent.name
     new_name = extract_name_from_recipe(params["recipe_yaml"])
 
-    case Coordinator.update_agent(name, params) do
+    case Coordinator.update_agent(project, name, params) do
       :ok ->
         if new_name && new_name != name do
           {:noreply,
            socket
            |> put_flash(:info, "Agent renamed to #{new_name}")
-           |> push_navigate(to: ~p"/agents/#{new_name}")}
+           |> push_navigate(to: ~p"/projects/#{project}/agents/#{new_name}")}
         else
           agent =
-            case Coordinator.get_agent(name) do
+            case Coordinator.get_agent(project, name) do
               {:ok, data} -> data
               _ -> socket.assigns.agent
             end
@@ -95,9 +106,10 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("restart-agent", _params, socket) do
+    project = socket.assigns.project
     name = socket.assigns.agent.name
 
-    case Coordinator.restart_agent(name) do
+    case Coordinator.restart_agent(project, name) do
       :ok ->
         {:noreply, put_flash(socket, :info, "Agent restarting...")}
 
@@ -141,6 +153,7 @@ defmodule ShireWeb.AgentLive.Show do
     ~H"""
     <.react
       name="AgentShow"
+      project={@project}
       agent={@agent}
       socket={@socket}
     />

--- a/lib/shire_web/live/project_live/index.ex
+++ b/lib/shire_web/live/project_live/index.ex
@@ -1,0 +1,82 @@
+defmodule ShireWeb.ProjectLive.Index do
+  use ShireWeb, :live_view
+
+  alias Shire.ProjectManager
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
+    end
+
+    projects = ProjectManager.list_projects()
+
+    {:ok, assign(socket, projects: projects)}
+  end
+
+  @impl true
+  def handle_params(_params, _url, socket) do
+    {:noreply, assign(socket, :page_title, "Projects")}
+  end
+
+  @impl true
+  def handle_event("create-project", %{"name" => name}, socket) do
+    case ProjectManager.create_project(name) do
+      {:ok, _pid} ->
+        projects = ProjectManager.list_projects()
+
+        {:noreply,
+         socket
+         |> assign(:projects, projects)
+         |> put_flash(:info, "Project created")}
+
+      {:error, :already_exists} ->
+        {:noreply, put_flash(socket, :error, "Project already exists")}
+
+      {:error, :no_token} ->
+        {:noreply, put_flash(socket, :error, "SPRITES_TOKEN not configured")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Failed to create project: #{inspect(reason)}")}
+    end
+  end
+
+  @impl true
+  def handle_event("delete-project", %{"name" => name}, socket) do
+    case ProjectManager.destroy_project(name) do
+      :ok ->
+        projects = ProjectManager.list_projects()
+
+        {:noreply,
+         socket
+         |> assign(:projects, projects)
+         |> put_flash(:info, "Project deleted")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Failed to delete: #{inspect(reason)}")}
+    end
+  end
+
+  @impl true
+  def handle_info({:project_created, _name}, socket) do
+    projects = ProjectManager.list_projects()
+    {:noreply, assign(socket, :projects, projects)}
+  end
+
+  @impl true
+  def handle_info({:project_destroyed, _name}, socket) do
+    projects = ProjectManager.list_projects()
+    {:noreply, assign(socket, :projects, projects)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.react
+      name="ProjectDashboard"
+      projects={@projects}
+      socket={@socket}
+    />
+    """
+  end
+end

--- a/lib/shire_web/live/settings_live/index.ex
+++ b/lib/shire_web/live/settings_live/index.ex
@@ -3,33 +3,40 @@ defmodule ShireWeb.SettingsLive.Index do
 
   alias Shire.Agents
   alias Shire.Agent.TerminalSession
+  alias Shire.ProjectManager
   alias Shire.WorkspaceSettings
 
   @impl true
-  def mount(_params, _session, socket) do
-    {messages, has_more} = Agents.list_inter_agent_messages(limit: 100)
+  def mount(%{"project" => project}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project) do
+      {:error, :not_found} ->
+        {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
 
-    # Load env and scripts from VM (best-effort, empty on failure)
-    env_content =
-      case WorkspaceSettings.read_env() do
-        {:ok, content} -> content
-        _ -> ""
-      end
+      {:ok, _pid} ->
+        {messages, has_more} = Agents.list_inter_agent_messages(project, limit: 100)
 
-    scripts =
-      case WorkspaceSettings.read_all_scripts() do
-        {:ok, list} -> list
-        _ -> []
-      end
+        env_content =
+          case WorkspaceSettings.read_env(project) do
+            {:ok, content} -> content
+            _ -> ""
+          end
 
-    {:ok,
-     assign(socket,
-       messages: messages,
-       has_more_messages: has_more,
-       env_content: env_content,
-       scripts: scripts,
-       terminal_subscribed: false
-     )}
+        scripts =
+          case WorkspaceSettings.read_all_scripts(project) do
+            {:ok, list} -> list
+            _ -> []
+          end
+
+        {:ok,
+         assign(socket,
+           project: project,
+           messages: messages,
+           has_more_messages: has_more,
+           env_content: env_content,
+           scripts: scripts,
+           terminal_subscribed: false
+         )}
+    end
   end
 
   @impl true
@@ -41,7 +48,7 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("save-env", %{"content" => content}, socket) do
-    case WorkspaceSettings.write_env(content) do
+    case WorkspaceSettings.write_env(socket.assigns.project, content) do
       :ok ->
         {:noreply,
          socket
@@ -57,9 +64,11 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("save-script", %{"name" => name, "content" => content}, socket) do
-    case WorkspaceSettings.write_script(name, content) do
+    project = socket.assigns.project
+
+    case WorkspaceSettings.write_script(project, name, content) do
       :ok ->
-        scripts = refresh_scripts()
+        scripts = refresh_scripts(project)
 
         {:noreply,
          socket
@@ -73,17 +82,17 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("delete-script", %{"name" => name}, socket) do
-    :ok = WorkspaceSettings.delete_script(name)
+    :ok = WorkspaceSettings.delete_script(socket.assigns.project, name)
 
     {:noreply,
      socket
-     |> assign(:scripts, refresh_scripts())
+     |> assign(:scripts, refresh_scripts(socket.assigns.project))
      |> put_flash(:info, "Script deleted")}
   end
 
   @impl true
   def handle_event("run-script", %{"name" => name}, socket) do
-    case WorkspaceSettings.run_script(name) do
+    case WorkspaceSettings.run_script(socket.assigns.project, name) do
       {:ok, output} ->
         {:noreply, put_flash(socket, :info, "Script output:\n#{String.slice(output, 0, 500)}")}
 
@@ -98,11 +107,13 @@ defmodule ShireWeb.SettingsLive.Index do
         %{"old_name" => old_name, "new_name" => new_name, "content" => content},
         socket
       ) do
-    with :ok <- WorkspaceSettings.write_script(new_name, content),
-         :ok <- WorkspaceSettings.delete_script(old_name) do
+    project = socket.assigns.project
+
+    with :ok <- WorkspaceSettings.write_script(project, new_name, content),
+         :ok <- WorkspaceSettings.delete_script(project, old_name) do
       {:noreply,
        socket
-       |> assign(:scripts, refresh_scripts())
+       |> assign(:scripts, refresh_scripts(project))
        |> put_flash(:info, "Script renamed")}
     else
       {:error, reason} ->
@@ -114,7 +125,9 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("load-more-messages", %{"before" => before}, socket) do
-    {new_messages, has_more} = Agents.list_inter_agent_messages(before: before, limit: 100)
+    {new_messages, has_more} =
+      Agents.list_inter_agent_messages(socket.assigns.project, before: before, limit: 100)
+
     all_messages = socket.assigns.messages ++ new_messages
 
     {:noreply,
@@ -128,12 +141,14 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("connect-terminal", _params, socket) do
-    case TerminalSession.find() do
+    project = socket.assigns.project
+
+    case TerminalSession.find(project) do
       {:ok, _pid} ->
         {:noreply, subscribe_terminal(socket)}
 
       :error ->
-        case TerminalSession.start_link([]) do
+        case start_terminal(project) do
           {:ok, _pid} ->
             {:noreply, subscribe_terminal(socket)}
 
@@ -146,7 +161,10 @@ defmodule ShireWeb.SettingsLive.Index do
   @impl true
   def handle_event("disconnect-terminal", _params, socket) do
     if socket.assigns.terminal_subscribed do
-      Phoenix.PubSub.unsubscribe(Shire.PubSub, "terminal:global")
+      Phoenix.PubSub.unsubscribe(
+        Shire.PubSub,
+        "project:#{socket.assigns.project}:terminal"
+      )
     end
 
     {:noreply, assign(socket, :terminal_subscribed, false)}
@@ -154,8 +172,10 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("terminal-input", %{"data" => data}, socket) do
-    case TerminalSession.find() do
-      {:ok, _pid} -> TerminalSession.write(data)
+    project = socket.assigns.project
+
+    case TerminalSession.find(project) do
+      {:ok, _pid} -> TerminalSession.write(project, data)
       :error -> :ok
     end
 
@@ -164,8 +184,10 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("terminal-resize", %{"rows" => rows, "cols" => cols}, socket) do
-    case TerminalSession.find() do
-      {:ok, _pid} -> TerminalSession.resize(rows, cols)
+    project = socket.assigns.project
+
+    case TerminalSession.find(project) do
+      {:ok, _pid} -> TerminalSession.resize(project, rows, cols)
       :error -> :ok
     end
 
@@ -183,11 +205,22 @@ defmodule ShireWeb.SettingsLive.Index do
   end
 
   defp subscribe_terminal(socket) do
+    project = socket.assigns.project
+
     unless socket.assigns.terminal_subscribed do
-      Phoenix.PubSub.subscribe(Shire.PubSub, "terminal:global")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:terminal")
     end
 
     assign(socket, :terminal_subscribed, true)
+  end
+
+  defp start_terminal(project) do
+    sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project}}}
+
+    DynamicSupervisor.start_child(
+      sup,
+      {TerminalSession, project_name: project}
+    )
   end
 
   @impl true
@@ -195,6 +228,7 @@ defmodule ShireWeb.SettingsLive.Index do
     ~H"""
     <.react
       name="SettingsPage"
+      project={@project}
       env_content={@env_content}
       scripts={@scripts}
       messages={serialize_inter_agent_messages(@messages)}
@@ -216,8 +250,8 @@ defmodule ShireWeb.SettingsLive.Index do
     end)
   end
 
-  defp refresh_scripts do
-    case WorkspaceSettings.read_all_scripts() do
+  defp refresh_scripts(project) do
+    case WorkspaceSettings.read_all_scripts(project) do
       {:ok, list} -> list
       _ -> []
     end

--- a/lib/shire_web/live/shared_drive_live/index.ex
+++ b/lib/shire_web/live/shared_drive_live/index.ex
@@ -1,15 +1,24 @@
 defmodule ShireWeb.SharedDriveLive.Index do
   use ShireWeb, :live_view
 
+  alias Shire.ProjectManager
+
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
   @drive_path "/workspace/shared"
 
   @impl true
-  def mount(_params, _session, socket) do
-    {:ok,
-     socket
-     |> assign(:current_path, "/")
-     |> assign(:files, list_files("/"))}
+  def mount(%{"project" => project}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project) do
+      {:error, :not_found} ->
+        {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
+
+      {:ok, _pid} ->
+        {:ok,
+         socket
+         |> assign(:project, project)
+         |> assign(:current_path, "/")
+         |> assign(:files, list_files(project, "/"))}
+    end
   end
 
   @impl true
@@ -19,21 +28,24 @@ defmodule ShireWeb.SharedDriveLive.Index do
 
   @impl true
   def handle_event("navigate", %{"path" => path}, socket) do
+    project = socket.assigns.project
+
     {:noreply,
      socket
      |> assign(:current_path, path)
-     |> assign(:files, list_files(path))}
+     |> assign(:files, list_files(project, path))}
   end
 
   def handle_event("create-directory", %{"name" => name}, socket) do
+    project = socket.assigns.project
     path = join_path(socket.assigns.current_path, name)
 
-    case @vm.mkdir_p(to_vm_path(path)) do
+    case @vm.mkdir_p(project, to_vm_path(path)) do
       :ok ->
         {:noreply,
          socket
          |> put_flash(:info, "Directory created")
-         |> assign(:files, list_files(socket.assigns.current_path))}
+         |> assign(:files, list_files(project, socket.assigns.current_path))}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed: #{inspect(reason)}")}
@@ -41,9 +53,11 @@ defmodule ShireWeb.SharedDriveLive.Index do
   end
 
   def handle_event("delete-file", %{"path" => path}, socket) do
-    case @vm.rm(to_vm_path(path)) do
+    project = socket.assigns.project
+
+    case @vm.rm(project, to_vm_path(path)) do
       :ok ->
-        {:noreply, assign(socket, :files, list_files(socket.assigns.current_path))}
+        {:noreply, assign(socket, :files, list_files(project, socket.assigns.current_path))}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed: #{inspect(reason)}")}
@@ -51,9 +65,11 @@ defmodule ShireWeb.SharedDriveLive.Index do
   end
 
   def handle_event("delete-directory", %{"path" => path}, socket) do
-    case @vm.rm_rf(to_vm_path(path)) do
+    project = socket.assigns.project
+
+    case @vm.rm_rf(project, to_vm_path(path)) do
       :ok ->
-        {:noreply, assign(socket, :files, list_files(socket.assigns.current_path))}
+        {:noreply, assign(socket, :files, list_files(project, socket.assigns.current_path))}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed: #{inspect(reason)}")}
@@ -61,18 +77,19 @@ defmodule ShireWeb.SharedDriveLive.Index do
   end
 
   def handle_event("upload-file", %{"name" => name, "content" => content}, socket) do
+    project = socket.assigns.project
     path = join_path(socket.assigns.current_path, name)
 
     case Base.decode64(content) do
       {:ok, decoded} ->
         vm_path = to_vm_path(path)
 
-        with :ok <- @vm.mkdir_p(Path.dirname(vm_path)),
-             :ok <- @vm.write(vm_path, decoded) do
+        with :ok <- @vm.mkdir_p(project, Path.dirname(vm_path)),
+             :ok <- @vm.write(project, vm_path, decoded) do
           {:noreply,
            socket
            |> put_flash(:info, "File uploaded")
-           |> assign(:files, list_files(socket.assigns.current_path))}
+           |> assign(:files, list_files(project, socket.assigns.current_path))}
         else
           {:error, reason} ->
             {:noreply, put_flash(socket, :error, "Upload failed: #{inspect(reason)}")}
@@ -83,10 +100,10 @@ defmodule ShireWeb.SharedDriveLive.Index do
     end
   end
 
-  defp list_files(path) do
+  defp list_files(project, path) do
     vm_path = to_vm_path(path)
 
-    case @vm.ls(vm_path) do
+    case @vm.ls(project, vm_path) do
       {:ok, entries} when is_list(entries) ->
         entries
         |> Enum.sort_by(fn entry -> entry["name"] || to_string(entry) end)
@@ -132,6 +149,7 @@ defmodule ShireWeb.SharedDriveLive.Index do
     ~H"""
     <.react
       name="SharedDrive"
+      project={@project}
       files={@files}
       current_path={@current_path}
       socket={@socket}

--- a/lib/shire_web/router.ex
+++ b/lib/shire_web/router.ex
@@ -18,19 +18,21 @@ defmodule ShireWeb.Router do
     pipe_through :browser
 
     live_session :default, layout: {ShireWeb.Layouts, :app} do
-      live "/", AgentLive.Index, :index
-      live "/agents/:name", AgentLive.Show, :show
+      live "/", ProjectLive.Index, :index
 
-      live "/settings", SettingsLive.Index, :index
+      live "/projects/:project", AgentLive.Index, :index
+      live "/projects/:project/agents/:name", AgentLive.Show, :show
 
-      live "/shared", SharedDriveLive.Index, :index
+      live "/projects/:project/settings", SettingsLive.Index, :index
+
+      live "/projects/:project/shared", SharedDriveLive.Index, :index
     end
   end
 
   scope "/", ShireWeb do
     pipe_through :browser
 
-    get "/shared/download", SharedDriveController, :download
+    get "/projects/:project/shared/download", SharedDriveController, :download
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20260318155804_add_project_name_to_messages.exs
+++ b/priv/repo/migrations/20260318155804_add_project_name_to_messages.exs
@@ -1,0 +1,12 @@
+defmodule Shire.Repo.Migrations.AddProjectNameToMessages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:messages) do
+      add :project_name, :string, null: false, default: "default"
+    end
+
+    create index(:messages, [:project_name, :agent_name])
+    drop_if_exists index(:messages, [:agent_name])
+  end
+end

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -7,13 +7,14 @@ defmodule Shire.Agent.AgentManagerTest do
   alias Shire.Agents
 
   @agent_name "test-agent"
+  @project "test-project"
 
   setup :set_mox_from_context
 
   defp start_manager(opts \\ []) do
     name = Keyword.get(opts, :agent_name, @agent_name)
 
-    start_supervised({AgentManager, agent_name: name, skip_sprite: true})
+    start_supervised({AgentManager, project_name: @project, agent_name: name, skip_sprite: true})
   end
 
   describe "start_link/1" do
@@ -35,7 +36,7 @@ defmodule Shire.Agent.AgentManagerTest do
     end
   end
 
-  describe "send_message/3" do
+  describe "send_message/4" do
     test "returns error when agent is not active" do
       {:ok, pid} = start_manager()
 
@@ -44,7 +45,7 @@ defmodule Shire.Agent.AgentManagerTest do
 
     test "persists user message to DB when from is :user" do
       Mox.set_mox_global()
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       {:ok, pid} = start_manager()
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
@@ -58,7 +59,7 @@ defmodule Shire.Agent.AgentManagerTest do
       assert {:ok, %Shire.Agents.Message{}} =
                GenServer.call(pid, {:send_message, "hello from user", :user})
 
-      {messages, _} = Agents.list_messages_for_agent(@agent_name)
+      {messages, _} = Agents.list_messages_for_agent(@project, @agent_name)
       user_msgs = Enum.filter(messages, &(&1.role == "user"))
       assert length(user_msgs) == 1
       assert hd(user_msgs).content["text"] == "hello from user"
@@ -104,7 +105,7 @@ defmodule Shire.Agent.AgentManagerTest do
 
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agent:#{@agent_name}")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agent:#{@agent_name}")
 
       ref = make_ref()
       command = %{ref: ref}
@@ -349,7 +350,7 @@ defmodule Shire.Agent.AgentManagerTest do
       # Give it a moment to process
       Process.sleep(50)
 
-      {messages, _has_more} = Agents.list_messages_for_agent(@agent_name)
+      {messages, _has_more} = Agents.list_messages_for_agent(@project, @agent_name)
       inter_agent = Enum.find(messages, &(&1.role == "inter_agent"))
       assert inter_agent != nil
       assert inter_agent.content["text"] == "hello from other"
@@ -362,7 +363,7 @@ defmodule Shire.Agent.AgentManagerTest do
     test "transitions to failed when runner exits" do
       {:ok, pid} = start_manager()
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agent:#{@agent_name}")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agent:#{@agent_name}")
 
       ref = make_ref()
 
@@ -384,13 +385,13 @@ defmodule Shire.Agent.AgentManagerTest do
   describe "restart" do
     test "resets state and transitions to bootstrapping" do
       Mox.set_mox_global()
-      stub(Shire.VirtualMachineMock, :cmd, fn _cmd, _args, _opts -> {:ok, ""} end)
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       {:ok, pid} = start_manager()
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agent:#{@agent_name}")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agent:#{@agent_name}")
 
       ref = make_ref()
 
@@ -398,7 +399,7 @@ defmodule Shire.Agent.AgentManagerTest do
         %{state | command: %{ref: ref}, command_ref: ref, status: :active}
       end)
 
-      assert :ok = AgentManager.restart(@agent_name)
+      assert :ok = AgentManager.restart(@project, @agent_name)
 
       assert_receive {:status, :bootstrapping}, 1_000
     end

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -5,16 +5,26 @@ defmodule Shire.Agent.CoordinatorTest do
 
   alias Shire.Agent.{AgentManager, Coordinator}
 
+  @project "test-project"
+
   setup do
     # Global mode so the Coordinator process (separate from test process) can use stubs
     Mox.set_mox_global()
 
     # Stub all VM calls with safe defaults before starting the Coordinator
-    stub(Shire.VirtualMachineMock, :cmd, fn _cmd, _args, _opts -> {:ok, ""} end)
-    stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+
+    # Start the project-scoped DynamicSupervisor for agents
+    start_supervised!(
+      {DynamicSupervisor,
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, @project}}},
+       strategy: :one_for_one},
+      id: :agent_sup
+    )
 
     # Start the Coordinator (handle_continue runs bootstrap/deploy/scan on start)
-    start_supervised!(Shire.Agent.Coordinator)
+    start_supervised!({Shire.Agent.Coordinator, project_name: @project})
 
     # Give handle_continue time to complete
     Process.sleep(50)
@@ -25,7 +35,7 @@ defmodule Shire.Agent.CoordinatorTest do
   defp broadcast_status(agent_name, status) do
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
-      "agents:lobby",
+      "project:#{@project}:agents:lobby",
       {:agent_status, agent_name, status}
     )
 
@@ -37,84 +47,84 @@ defmodule Shire.Agent.CoordinatorTest do
     supervisor_id = Keyword.get(opts, :id, agent_name)
 
     start_supervised(
-      {AgentManager, agent_name: agent_name, skip_sprite: true},
+      {AgentManager, project_name: @project, agent_name: agent_name, skip_sprite: true},
       id: supervisor_id
     )
   end
 
   @agent_name "coord-test-agent"
 
-  describe "lookup/1" do
+  describe "lookup/2" do
     test "returns error when agent is not running" do
-      assert {:error, :not_found} = Coordinator.lookup("nonexistent")
+      assert {:error, :not_found} = Coordinator.lookup(@project, "nonexistent")
     end
 
     test "returns {:ok, pid} for a running agent" do
       {:ok, pid} = start_agent_manager(@agent_name)
-      assert {:ok, ^pid} = Coordinator.lookup(@agent_name)
+      assert {:ok, ^pid} = Coordinator.lookup(@project, @agent_name)
     end
   end
 
-  describe "delete_agent/1" do
+  describe "delete_agent/2" do
     test "succeeds even when agent is not running (deletes dir only)" do
-      assert :ok = Coordinator.delete_agent("nonexistent")
+      assert :ok = Coordinator.delete_agent(@project, "nonexistent")
     end
 
     test "broadcasts {:agent_deleted, name} on lobby" do
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agents:lobby")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agents:lobby")
 
       unique_name = "coord-delete-broadcast-#{System.unique_integer([:positive])}"
-      Coordinator.delete_agent(unique_name)
+      Coordinator.delete_agent(@project, unique_name)
 
       assert_receive {:agent_deleted, ^unique_name}, 500
     end
   end
 
-  describe "restart_agent/1" do
+  describe "restart_agent/2" do
     test "restarts a running agent" do
       {:ok, _pid} = start_agent_manager(@agent_name)
 
       broadcast_status(@agent_name, :failed)
-      assert :failed == Coordinator.agent_status(@agent_name)
+      assert :failed == Coordinator.agent_status(@project, @agent_name)
 
       # Restart should succeed for a running (failed) agent
-      result = Coordinator.restart_agent(@agent_name)
+      result = Coordinator.restart_agent(@project, @agent_name)
       assert result == :ok
     end
   end
 
-  describe "list_running/0" do
+  describe "list_running/1" do
     test "returns a list of strings" do
-      running = Coordinator.list_running()
+      running = Coordinator.list_running(@project)
       assert is_list(running)
       assert Enum.all?(running, &is_binary/1)
     end
 
     test "includes running agents" do
       {:ok, _pid} = start_agent_manager(@agent_name)
-      running = Coordinator.list_running()
+      running = Coordinator.list_running(@project)
       assert @agent_name in running
     end
   end
 
-  describe "agent_status/1" do
+  describe "agent_status/2" do
     test "returns :created for non-running agents" do
-      assert :created == Coordinator.agent_status("nonexistent")
+      assert :created == Coordinator.agent_status(@project, "nonexistent")
     end
 
     test "returns status after PubSub broadcast" do
       {:ok, _pid} = start_agent_manager(@agent_name)
       broadcast_status(@agent_name, :active)
-      assert :active == Coordinator.agent_status(@agent_name)
+      assert :active == Coordinator.agent_status(@project, @agent_name)
     end
   end
 
-  describe "agent_statuses/1" do
+  describe "agent_statuses/2" do
     test "returns status map for given agent names" do
       {:ok, _pid} = start_agent_manager(@agent_name)
       broadcast_status(@agent_name, :bootstrapping)
 
-      result = Coordinator.agent_statuses([@agent_name, "nonexistent"])
+      result = Coordinator.agent_statuses(@project, [@agent_name, "nonexistent"])
       assert result[@agent_name] == :bootstrapping
       assert result["nonexistent"] == :created
     end
@@ -123,13 +133,17 @@ defmodule Shire.Agent.CoordinatorTest do
   describe "status updates via PubSub" do
     test "coordinator updates internal state from lobby broadcasts" do
       broadcast_status(@agent_name, :active)
-      assert :active == Coordinator.agent_status(@agent_name)
+      assert :active == Coordinator.agent_status(@project, @agent_name)
     end
   end
 
   describe "auto-restart on init" do
     test "handle_continue does not crash the coordinator" do
-      assert Process.alive?(GenServer.whereis(Coordinator))
+      assert Process.alive?(
+               GenServer.whereis(
+                 {:via, Registry, {Shire.ProjectRegistry, {:coordinator, @project}}}
+               )
+             )
     end
   end
 
@@ -141,29 +155,34 @@ defmodule Shire.Agent.CoordinatorTest do
       {:ok, _} =
         Registry.register(Shire.AgentRegistry, {:terminal, @agent_name}, "terminal-session")
 
-      running = Coordinator.list_running()
+      running = Coordinator.list_running(@project)
       assert @agent_name in running
       refute {:terminal, @agent_name} in running
     end
   end
 
-  describe "update_agent/2" do
+  describe "update_agent/3" do
     test "writes recipe.yaml to the VM and returns :ok" do
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       unique_name = "coord-update-test-#{System.unique_integer([:positive])}"
 
       result =
-        Coordinator.update_agent(unique_name, %{
+        Coordinator.update_agent(@project, unique_name, %{
           "recipe_yaml" => "version: 1\nname: updated\nharness: claude_code\n"
         })
 
       assert result == :ok
-      assert Process.alive?(GenServer.whereis(Coordinator))
+
+      assert Process.alive?(
+               GenServer.whereis(
+                 {:via, Registry, {Shire.ProjectRegistry, {:coordinator, @project}}}
+               )
+             )
     end
 
     test "restarts agent if it is running" do
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       {:ok, _pid} = start_agent_manager(@agent_name)
 
@@ -171,7 +190,7 @@ defmodule Shire.Agent.CoordinatorTest do
       broadcast_status(@agent_name, :active)
 
       result =
-        Coordinator.update_agent(@agent_name, %{
+        Coordinator.update_agent(@project, @agent_name, %{
           "recipe_yaml" => "version: 1\nname: #{@agent_name}\n"
         })
 
@@ -179,13 +198,13 @@ defmodule Shire.Agent.CoordinatorTest do
     end
 
     test "broadcasts {:agent_updated, name} on lobby" do
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agents:lobby")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agents:lobby")
 
       unique_name = "coord-update-broadcast-#{System.unique_integer([:positive])}"
 
-      Coordinator.update_agent(unique_name, %{
+      Coordinator.update_agent(@project, unique_name, %{
         "recipe_yaml" => "version: 1\nname: #{unique_name}\n"
       })
 
@@ -193,13 +212,13 @@ defmodule Shire.Agent.CoordinatorTest do
     end
   end
 
-  describe "get_agent/1" do
+  describe "get_agent/2" do
     test "returns {:error, :not_found} when agent does not exist on VM" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts ->
         {:ok, "__NOT_FOUND__"}
       end)
 
-      result = Coordinator.get_agent("coord-get-test-nonexistent")
+      result = Coordinator.get_agent(@project, "coord-get-test-nonexistent")
       assert {:error, :not_found} = result
     end
 
@@ -212,11 +231,11 @@ defmodule Shire.Agent.CoordinatorTest do
       system_prompt: You are helpful.
       """
 
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts ->
         {:ok, recipe_yaml}
       end)
 
-      result = Coordinator.get_agent("my-agent")
+      result = Coordinator.get_agent(@project, "my-agent")
 
       assert {:ok, agent} = result
       assert agent.name == "my-agent"
@@ -228,20 +247,20 @@ defmodule Shire.Agent.CoordinatorTest do
     end
   end
 
-  describe "list_agents/0" do
+  describe "list_agents/1" do
     test "returns empty list when no agents on VM" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts -> {:ok, ""} end)
 
-      agents = Coordinator.list_agents()
+      agents = Coordinator.list_agents(@project)
       assert agents == []
     end
 
     test "returns agent map entries for each discovered agent dir" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts ->
         {:ok, "agent-one\nagent-two\n"}
       end)
 
-      agents = Coordinator.list_agents()
+      agents = Coordinator.list_agents(@project)
       assert is_list(agents)
       assert length(agents) == 2
 
@@ -256,12 +275,12 @@ defmodule Shire.Agent.CoordinatorTest do
     end
   end
 
-  describe "update_agent/2 with rename" do
+  describe "update_agent/3 with rename" do
     test "renames workspace folder when recipe name differs from current name" do
       old_name = "coord-rename-old-#{System.unique_integer([:positive])}"
       new_name = "coord-rename-new-#{System.unique_integer([:positive])}"
 
-      stub(Shire.VirtualMachineMock, :cmd, fn cmd, args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, args, _opts ->
         case {cmd, args} do
           {"bash", ["-c", "test -d " <> _]} -> {:ok, "missing\n"}
           {"mv", _} -> {:ok, ""}
@@ -269,12 +288,12 @@ defmodule Shire.Agent.CoordinatorTest do
         end
       end)
 
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "agents:lobby")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agents:lobby")
 
       result =
-        Coordinator.update_agent(old_name, %{
+        Coordinator.update_agent(@project, old_name, %{
           "recipe_yaml" => "version: 1\nname: #{new_name}\nharness: claude_code\n"
         })
 
@@ -286,14 +305,14 @@ defmodule Shire.Agent.CoordinatorTest do
       old_name = "coord-rename-conflict-old-#{System.unique_integer([:positive])}"
       new_name = "coord-rename-conflict-new-#{System.unique_integer([:positive])}"
 
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", ["-c", "test -d " <> _], _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", ["-c", "test -d " <> _], _opts ->
         {:ok, "exists\n"}
       end)
 
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       result =
-        Coordinator.update_agent(old_name, %{
+        Coordinator.update_agent(@project, old_name, %{
           "recipe_yaml" => "version: 1\nname: #{new_name}\n"
         })
 
@@ -307,12 +326,13 @@ defmodule Shire.Agent.CoordinatorTest do
       # Create a message under the old name
       {:ok, _msg} =
         Shire.Agents.create_message(%{
+          project_name: @project,
           agent_name: old_name,
           role: "user",
           content: %{"text" => "hello"}
         })
 
-      stub(Shire.VirtualMachineMock, :cmd, fn cmd, _args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, _args, _opts ->
         case cmd do
           "bash" -> {:ok, "missing\n"}
           "mv" -> {:ok, ""}
@@ -320,30 +340,30 @@ defmodule Shire.Agent.CoordinatorTest do
         end
       end)
 
-      stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       assert :ok =
-               Coordinator.update_agent(old_name, %{
+               Coordinator.update_agent(@project, old_name, %{
                  "recipe_yaml" => "version: 1\nname: #{new_name}\n"
                })
 
       # Old name should have no messages
-      {old_messages, _} = Shire.Agents.list_messages_for_agent(old_name)
+      {old_messages, _} = Shire.Agents.list_messages_for_agent(@project, old_name)
       assert old_messages == []
 
       # New name should have the message
-      {new_messages, _} = Shire.Agents.list_messages_for_agent(new_name)
+      {new_messages, _} = Shire.Agents.list_messages_for_agent(@project, new_name)
       assert length(new_messages) == 1
       assert hd(new_messages).agent_name == new_name
     end
   end
 
-  describe "create_agent/1" do
+  describe "create_agent/2" do
     test "creates agent directory structure on VM and starts AgentManager" do
       unique_name = "coord-create-test-#{System.unique_integer([:positive])}"
       agent_dir = "/workspace/agents/#{unique_name}"
 
-      stub(Shire.VirtualMachineMock, :cmd, fn cmd, args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, args, _opts ->
         case {cmd, args} do
           {"bash", ["-c", "test -d " <> _]} -> {:ok, "missing\n"}
           {"mkdir", _} -> {:ok, ""}
@@ -351,10 +371,10 @@ defmodule Shire.Agent.CoordinatorTest do
         end
       end)
 
-      stub(Shire.VirtualMachineMock, :write, fn ^agent_dir <> _rest, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, ^agent_dir <> _rest, _content -> :ok end)
 
       result =
-        Coordinator.create_agent(%{
+        Coordinator.create_agent(@project, %{
           "name" => unique_name,
           "recipe_yaml" => "version: 1\nname: #{unique_name}\ndescription: A test agent\n"
         })
@@ -363,7 +383,7 @@ defmodule Shire.Agent.CoordinatorTest do
       assert is_pid(pid)
 
       # Clean up
-      Coordinator.delete_agent(unique_name)
+      Coordinator.delete_agent(@project, unique_name)
     end
 
     test "returns {:error, :already_exists} for duplicate names" do
@@ -374,7 +394,7 @@ defmodule Shire.Agent.CoordinatorTest do
       # Second call: agent already exists
       call_count = :counters.new(1, [])
 
-      stub(Shire.VirtualMachineMock, :cmd, fn cmd, args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, args, _opts ->
         case {cmd, args} do
           {"bash", ["-c", "test -d " <> _]} ->
             :counters.add(call_count, 1, 1)
@@ -389,21 +409,24 @@ defmodule Shire.Agent.CoordinatorTest do
         end
       end)
 
-      stub(Shire.VirtualMachineMock, :write, fn ^agent_dir <> _rest, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, ^agent_dir <> _rest, _content -> :ok end)
 
       recipe = "version: 1\nname: #{unique_name}\n"
 
-      {:ok, _pid} = Coordinator.create_agent(%{"name" => unique_name, "recipe_yaml" => recipe})
+      {:ok, _pid} =
+        Coordinator.create_agent(@project, %{"name" => unique_name, "recipe_yaml" => recipe})
 
-      result = Coordinator.create_agent(%{"name" => unique_name, "recipe_yaml" => recipe})
+      result =
+        Coordinator.create_agent(@project, %{"name" => unique_name, "recipe_yaml" => recipe})
+
       assert {:error, :already_exists} = result
 
       # Clean up
-      Coordinator.delete_agent(unique_name)
+      Coordinator.delete_agent(@project, unique_name)
     end
 
     test "returns {:error, :missing_name_or_recipe} for incomplete attrs" do
-      result = Coordinator.create_agent(%{"name" => "no-recipe"})
+      result = Coordinator.create_agent(@project, %{"name" => "no-recipe"})
       assert {:error, :missing_name_or_recipe} = result
     end
   end

--- a/test/shire/agent/terminal_session_test.exs
+++ b/test/shire/agent/terminal_session_test.exs
@@ -3,21 +3,23 @@ defmodule Shire.Agent.TerminalSessionTest do
 
   alias Shire.Agent.TerminalSession
 
-  describe "find/0" do
+  @project "test-project"
+
+  describe "find/1" do
     test "returns :error when no session exists" do
-      assert :error = TerminalSession.find()
+      assert :error = TerminalSession.find(@project)
     end
   end
 
-  describe "write/1" do
+  describe "write/2" do
     test "module compiles and API is callable" do
       assert is_atom(TerminalSession)
     end
   end
 
   describe "registry" do
-    test "uses :global_terminal as registry key" do
-      assert [] = Registry.lookup(Shire.AgentRegistry, :global_terminal)
+    test "uses {:terminal, project_name} as registry key" do
+      assert [] = Registry.lookup(Shire.ProjectRegistry, {:terminal, @project})
     end
   end
 end

--- a/test/shire/agents_test.exs
+++ b/test/shire/agents_test.exs
@@ -3,10 +3,13 @@ defmodule Shire.AgentsTest do
 
   alias Shire.Agents
 
+  @project "test-project"
+
   describe "messages" do
     test "create_message/1 with valid data" do
       assert {:ok, msg} =
                Agents.create_message(%{
+                 project_name: @project,
                  agent_name: "test-agent",
                  role: "user",
                  content: %{"text" => "hi"}
@@ -15,17 +18,20 @@ defmodule Shire.AgentsTest do
       assert msg.role == "user"
       assert msg.content == %{"text" => "hi"}
       assert msg.agent_name == "test-agent"
+      assert msg.project_name == @project
     end
 
-    test "create_message/1 requires agent_name and role" do
+    test "create_message/1 requires project_name, agent_name and role" do
       assert {:error, changeset} = Agents.create_message(%{})
+      assert "can't be blank" in errors_on(changeset).project_name
       assert "can't be blank" in errors_on(changeset).agent_name
       assert "can't be blank" in errors_on(changeset).role
     end
 
-    test "list_messages_for_agent/1 returns messages oldest first" do
+    test "list_messages_for_agent/2 returns messages oldest first" do
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "chat-agent",
           role: "user",
           content: %{"text" => "first"}
@@ -33,20 +39,22 @@ defmodule Shire.AgentsTest do
 
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "chat-agent",
           role: "agent",
           content: %{"text" => "second"}
         })
 
-      {messages, _has_more} = Agents.list_messages_for_agent("chat-agent")
+      {messages, _has_more} = Agents.list_messages_for_agent(@project, "chat-agent")
       assert length(messages) == 2
       assert Enum.at(messages, 0).content["text"] == "first"
       assert Enum.at(messages, 1).content["text"] == "second"
     end
 
-    test "list_inter_agent_messages/0 returns only inter_agent messages" do
+    test "list_inter_agent_messages/1 returns only inter_agent messages" do
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "chat-agent",
           role: "user",
           content: %{"text" => "hi"}
@@ -54,6 +62,7 @@ defmodule Shire.AgentsTest do
 
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "chat-agent",
           role: "inter_agent",
           content: %{
@@ -63,15 +72,16 @@ defmodule Shire.AgentsTest do
           }
         })
 
-      {messages, _has_more} = Agents.list_inter_agent_messages()
+      {messages, _has_more} = Agents.list_inter_agent_messages(@project)
       assert length(messages) == 1
       assert hd(messages).role == "inter_agent"
       assert hd(messages).content["from_agent"] == "Alice"
     end
 
-    test "list_inter_agent_messages/1 supports cursor-based pagination" do
+    test "list_inter_agent_messages/2 supports cursor-based pagination" do
       for i <- 1..3 do
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "chat-agent",
           role: "inter_agent",
           content: %{
@@ -82,19 +92,23 @@ defmodule Shire.AgentsTest do
         })
       end
 
-      {first_page, has_more} = Agents.list_inter_agent_messages(limit: 2)
+      {first_page, has_more} = Agents.list_inter_agent_messages(@project, limit: 2)
       assert length(first_page) == 2
       assert has_more
 
       oldest_id = List.last(first_page).id
-      {second_page, has_more2} = Agents.list_inter_agent_messages(before: oldest_id, limit: 2)
+
+      {second_page, has_more2} =
+        Agents.list_inter_agent_messages(@project, before: oldest_id, limit: 2)
+
       assert length(second_page) == 1
       refute has_more2
     end
 
-    test "rename_agent_messages/2 updates agent_name on all messages" do
+    test "rename_agent_messages/3 updates agent_name on all messages" do
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "old-agent",
           role: "user",
           content: %{"text" => "hello"}
@@ -102,6 +116,7 @@ defmodule Shire.AgentsTest do
 
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "old-agent",
           role: "agent",
           content: %{"text" => "reply"}
@@ -109,27 +124,29 @@ defmodule Shire.AgentsTest do
 
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "unrelated-agent",
           role: "user",
           content: %{"text" => "keep me"}
         })
 
-      {count, _} = Agents.rename_agent_messages("old-agent", "new-agent")
+      {count, _} = Agents.rename_agent_messages(@project, "old-agent", "new-agent")
       assert count == 2
 
-      {old_msgs, _} = Agents.list_messages_for_agent("old-agent")
+      {old_msgs, _} = Agents.list_messages_for_agent(@project, "old-agent")
       assert old_msgs == []
 
-      {new_msgs, _} = Agents.list_messages_for_agent("new-agent")
+      {new_msgs, _} = Agents.list_messages_for_agent(@project, "new-agent")
       assert length(new_msgs) == 2
 
-      {unrelated_msgs, _} = Agents.list_messages_for_agent("unrelated-agent")
+      {unrelated_msgs, _} = Agents.list_messages_for_agent(@project, "unrelated-agent")
       assert length(unrelated_msgs) == 1
     end
 
-    test "delete_messages_for_agent/1 deletes all messages for an agent" do
+    test "delete_messages_for_agent/2 deletes all messages for an agent" do
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "delete-test",
           role: "user",
           content: %{"text" => "hi"}
@@ -137,17 +154,18 @@ defmodule Shire.AgentsTest do
 
       {:ok, _} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "other-agent",
           role: "user",
           content: %{"text" => "keep me"}
         })
 
-      Agents.delete_messages_for_agent("delete-test")
+      Agents.delete_messages_for_agent(@project, "delete-test")
 
-      {msgs, _} = Agents.list_messages_for_agent("delete-test")
+      {msgs, _} = Agents.list_messages_for_agent(@project, "delete-test")
       assert msgs == []
 
-      {other_msgs, _} = Agents.list_messages_for_agent("other-agent")
+      {other_msgs, _} = Agents.list_messages_for_agent(@project, "other-agent")
       assert length(other_msgs) == 1
     end
   end

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -1,0 +1,133 @@
+defmodule Shire.ProjectManagerTest do
+  use Shire.DataCase, async: false
+
+  import Mox
+
+  alias Shire.ProjectManager
+
+  setup do
+    Mox.set_mox_global()
+
+    stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+
+    stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+      {:error, :not_available_in_test}
+    end)
+
+    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
+    stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
+
+    start_supervised!(ProjectManager)
+
+    on_exit(fn ->
+      # Clean up any ProjectInstanceSupervisors started under the app-level DynamicSupervisor
+      for {_, pid, _, _} <- DynamicSupervisor.which_children(Shire.ProjectSupervisor),
+          is_pid(pid) do
+        DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, pid)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "list_projects/0" do
+    test "returns empty list when no projects exist" do
+      assert ProjectManager.list_projects() == []
+    end
+
+    test "returns projects with :running status after creation" do
+      {:ok, _pid} = ProjectManager.create_project("my-project")
+
+      projects = ProjectManager.list_projects()
+      assert length(projects) == 1
+      assert hd(projects).name == "my-project"
+      assert hd(projects).status == :running
+    end
+  end
+
+  describe "create_project/1" do
+    test "creates a project and returns {:ok, pid}" do
+      assert {:ok, pid} = ProjectManager.create_project("test-proj")
+      assert is_pid(pid)
+    end
+
+    test "returns {:error, :already_exists} for duplicate name" do
+      {:ok, _pid} = ProjectManager.create_project("dup-proj")
+      assert {:error, :already_exists} = ProjectManager.create_project("dup-proj")
+    end
+
+    test "broadcasts {:project_created, name} via PubSub" do
+      Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
+
+      {:ok, _pid} = ProjectManager.create_project("broadcast-proj")
+
+      assert_receive {:project_created, "broadcast-proj"}
+    end
+  end
+
+  describe "destroy_project/1" do
+    test "removes a project from the list" do
+      {:ok, _pid} = ProjectManager.create_project("destroy-me")
+      assert :ok = ProjectManager.destroy_project("destroy-me")
+      assert ProjectManager.list_projects() == []
+    end
+
+    test "returns {:error, :not_found} for non-existent project" do
+      assert {:error, :not_found} = ProjectManager.destroy_project("nope")
+    end
+
+    test "broadcasts {:project_destroyed, name} via PubSub" do
+      {:ok, _pid} = ProjectManager.create_project("destroy-broadcast")
+
+      Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
+
+      :ok = ProjectManager.destroy_project("destroy-broadcast")
+
+      assert_receive {:project_destroyed, "destroy-broadcast"}
+    end
+  end
+
+  describe "lookup_coordinator/1" do
+    test "returns {:ok, pid} for existing project" do
+      {:ok, _pid} = ProjectManager.create_project("lookup-proj")
+      Process.sleep(50)
+
+      assert {:ok, pid} = ProjectManager.lookup_coordinator("lookup-proj")
+      assert is_pid(pid)
+    end
+
+    test "returns {:error, :not_found} for non-existent project" do
+      assert {:error, :not_found} = ProjectManager.lookup_coordinator("nope")
+    end
+  end
+
+  describe "lookup_vm/1" do
+    test "returns {:ok, pid} for existing project" do
+      {:ok, _pid} = ProjectManager.create_project("vm-proj")
+      Process.sleep(50)
+
+      assert {:ok, pid} = ProjectManager.lookup_vm("vm-proj")
+      assert is_pid(pid)
+    end
+
+    test "returns {:error, :not_found} for non-existent project" do
+      assert {:error, :not_found} = ProjectManager.lookup_vm("nope")
+    end
+  end
+
+  describe "supervisor monitoring" do
+    test "removes project when supervisor goes down" do
+      {:ok, sup_pid} = ProjectManager.create_project("monitor-proj")
+
+      Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
+
+      # Kill the supervisor
+      Process.exit(sup_pid, :kill)
+
+      assert_receive {:project_destroyed, "monitor-proj"}, 1000
+
+      assert ProjectManager.list_projects() == []
+    end
+  end
+end

--- a/test/shire/virtual_machine_test.exs
+++ b/test/shire/virtual_machine_test.exs
@@ -3,6 +3,8 @@ defmodule Shire.VirtualMachineImplTest do
 
   alias Shire.VirtualMachineImpl, as: VM
 
+  @project "test-project"
+
   describe "build_filesystem/1 patches base_url" do
     test "adds /v1/sprites/{name} prefix to base_url" do
       # Build minimal sprite-like struct to test the patching logic
@@ -54,16 +56,16 @@ defmodule Shire.VirtualMachineImplTest do
       import ExUnit.CaptureLog
 
       assert capture_log([level: :info], fn ->
-               VM.terminate(:shutdown, %{sprite: nil, fs: nil})
+               VM.terminate(:shutdown, %{sprite: nil, fs: nil, project_name: @project})
                Logger.flush()
-             end) =~ "VirtualMachineImpl stopping (no VM)"
+             end) =~ "VirtualMachineImpl stopping (no VM"
     end
 
     test "handles active sprite state without crashing" do
       import ExUnit.CaptureLog
 
       assert capture_log([level: :info], fn ->
-               VM.terminate(:shutdown, %{sprite: :fake, fs: :fake})
+               VM.terminate(:shutdown, %{sprite: :fake, fs: :fake, project_name: @project})
                Logger.flush()
              end) =~ "VirtualMachineImpl stopping"
     end
@@ -97,7 +99,7 @@ defmodule Shire.VirtualMachineImplTest do
     end
 
     test "touch_keepalive is triggered by VM calls (via get_sprite)" do
-      pid = start_supervised!({VM, []}, id: :keepalive_test_vm)
+      pid = start_supervised!({VM, [project_name: @project]}, id: :keepalive_test_vm)
 
       _sprite = GenServer.call(pid, :get_sprite)
 
@@ -107,7 +109,7 @@ defmodule Shire.VirtualMachineImplTest do
     end
 
     test "subsequent VM calls extend ping_until" do
-      pid = start_supervised!({VM, []}, id: :keepalive_extend_vm)
+      pid = start_supervised!({VM, [project_name: @project]}, id: :keepalive_extend_vm)
 
       GenServer.call(pid, :get_sprite)
       state1 = :sys.get_state(pid)

--- a/test/shire/workspace_settings_test.exs
+++ b/test/shire/workspace_settings_test.exs
@@ -5,68 +5,72 @@ defmodule Shire.WorkspaceSettingsTest do
 
   alias Shire.WorkspaceSettings
 
+  @project "test-project"
+
   setup do
     Mox.set_mox_global()
     :ok
   end
 
-  describe "read_env/0" do
+  describe "read_env/1" do
     test "returns {:ok, string} with VM content" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts ->
         {:ok, "MY_VAR=hello\n"}
       end)
 
-      assert {:ok, content} = WorkspaceSettings.read_env()
+      assert {:ok, content} = WorkspaceSettings.read_env(@project)
       assert content == "MY_VAR=hello\n"
     end
 
     test "returns {:ok, empty string} when .env does not exist" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts ->
         {:ok, ""}
       end)
 
-      assert {:ok, ""} = WorkspaceSettings.read_env()
+      assert {:ok, ""} = WorkspaceSettings.read_env(@project)
     end
   end
 
-  describe "write_env/1" do
+  describe "write_env/2" do
     test "writes content to the VM" do
-      expect(Shire.VirtualMachineMock, :write, fn "/workspace/.env", "FOO=bar" -> :ok end)
+      expect(Shire.VirtualMachineMock, :write, fn @project, "/workspace/.env", "FOO=bar" ->
+        :ok
+      end)
 
-      assert :ok = WorkspaceSettings.write_env("FOO=bar")
+      assert :ok = WorkspaceSettings.write_env(@project, "FOO=bar")
     end
 
     test "returns error on failure" do
-      expect(Shire.VirtualMachineMock, :write, fn "/workspace/.env", _content ->
+      expect(Shire.VirtualMachineMock, :write, fn @project, "/workspace/.env", _content ->
         {:error, :write_failed}
       end)
 
-      assert {:error, :write_failed} = WorkspaceSettings.write_env("FOO=bar")
+      assert {:error, :write_failed} = WorkspaceSettings.write_env(@project, "FOO=bar")
     end
   end
 
-  describe "list_scripts/0" do
+  describe "list_scripts/1" do
     test "returns {:ok, []} when no scripts exist" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts -> {:ok, ""} end)
 
-      assert {:ok, []} = WorkspaceSettings.list_scripts()
+      assert {:ok, []} = WorkspaceSettings.list_scripts(@project)
     end
 
     test "returns {:ok, list} with .sh filenames when scripts exist" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts ->
         {:ok, "deploy.sh\nsetup.sh\nreadme.txt\n"}
       end)
 
-      assert {:ok, scripts} = WorkspaceSettings.list_scripts()
+      assert {:ok, scripts} = WorkspaceSettings.list_scripts(@project)
       assert "deploy.sh" in scripts
       assert "setup.sh" in scripts
       refute "readme.txt" in scripts
     end
   end
 
-  describe "read_all_scripts/0" do
+  describe "read_all_scripts/1" do
     test "returns scripts with content" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", ["-c", cmd], _opts ->
+      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", ["-c", cmd], _opts ->
         cond do
           String.contains?(cmd, "ls /workspace/.scripts") ->
             {:ok, "setup.sh\n"}
@@ -80,60 +84,64 @@ defmodule Shire.WorkspaceSettingsTest do
       end)
 
       assert {:ok, [%{name: "setup.sh", content: "#!/bin/bash\necho hi"}]} =
-               WorkspaceSettings.read_all_scripts()
+               WorkspaceSettings.read_all_scripts(@project)
     end
 
     test "returns empty list when no scripts" do
-      stub(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts -> {:ok, ""} end)
 
-      assert {:ok, []} = WorkspaceSettings.read_all_scripts()
+      assert {:ok, []} = WorkspaceSettings.read_all_scripts(@project)
     end
   end
 
-  describe "write_script/2" do
+  describe "write_script/3" do
     test "writes script and makes it executable" do
-      expect(Shire.VirtualMachineMock, :write, fn "/workspace/.scripts/setup.sh", "#!/bin/bash" ->
+      expect(Shire.VirtualMachineMock, :write, fn @project,
+                                                  "/workspace/.scripts/setup.sh",
+                                                  "#!/bin/bash" ->
         :ok
       end)
 
-      expect(Shire.VirtualMachineMock, :cmd, fn "chmod",
+      expect(Shire.VirtualMachineMock, :cmd, fn @project,
+                                                "chmod",
                                                 ["+x", "/workspace/.scripts/setup.sh"],
                                                 _opts ->
         {:ok, ""}
       end)
 
-      assert :ok = WorkspaceSettings.write_script("setup.sh", "#!/bin/bash")
+      assert :ok = WorkspaceSettings.write_script(@project, "setup.sh", "#!/bin/bash")
     end
   end
 
-  describe "delete_script/1" do
+  describe "delete_script/2" do
     test "deletes the script file" do
-      expect(Shire.VirtualMachineMock, :cmd, fn "rm",
+      expect(Shire.VirtualMachineMock, :cmd, fn @project,
+                                                "rm",
                                                 ["-f", "/workspace/.scripts/setup.sh"],
                                                 _opts ->
         {:ok, ""}
       end)
 
-      assert :ok = WorkspaceSettings.delete_script("setup.sh")
+      assert :ok = WorkspaceSettings.delete_script(@project, "setup.sh")
     end
   end
 
-  describe "run_script/1" do
+  describe "run_script/2" do
     test "runs script and returns output" do
-      expect(Shire.VirtualMachineMock, :cmd, fn "bash", ["-c", cmd], _opts ->
+      expect(Shire.VirtualMachineMock, :cmd, fn @project, "bash", ["-c", cmd], _opts ->
         assert String.contains?(cmd, "/workspace/.scripts/setup.sh")
         {:ok, "done\n"}
       end)
 
-      assert {:ok, "done\n"} = WorkspaceSettings.run_script("setup.sh")
+      assert {:ok, "done\n"} = WorkspaceSettings.run_script(@project, "setup.sh")
     end
 
     test "returns error on failure" do
-      expect(Shire.VirtualMachineMock, :cmd, fn "bash", _args, _opts ->
+      expect(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts ->
         {:error, :script_failed}
       end)
 
-      assert {:error, :script_failed} = WorkspaceSettings.run_script("setup.sh")
+      assert {:error, :script_failed} = WorkspaceSettings.run_script(@project, "setup.sh")
     end
   end
 end

--- a/test/shire_web/controllers/page_controller_test.exs
+++ b/test/shire_web/controllers/page_controller_test.exs
@@ -5,21 +5,13 @@ defmodule ShireWeb.PageControllerTest do
 
   setup do
     Mox.set_mox_global()
-
-    stub(Shire.VirtualMachineMock, :cmd, fn _cmd, _args, _opts -> {:ok, ""} end)
-    stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
-
-    stub(Shire.VirtualMachineMock, :spawn_command, fn _cmd, _args, _opts ->
-      {:error, :not_available_in_test}
-    end)
-
-    start_supervised!(Shire.Agent.Coordinator)
-    Process.sleep(50)
+    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
+    start_supervised!(Shire.ProjectManager)
     :ok
   end
 
-  test "GET / renders agent list", %{conn: conn} do
+  test "GET / renders project dashboard", %{conn: conn} do
     conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Agents"
+    assert html_response(conn, 200)
   end
 end

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -4,33 +4,60 @@ defmodule ShireWeb.AgentLiveTest do
   import Phoenix.LiveViewTest
   import Mox
 
+  @project "test-project"
+
   setup do
     Mox.set_mox_global()
 
-    stub(Shire.VirtualMachineMock, :cmd, fn _cmd, _args, _opts -> {:ok, ""} end)
-    stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-    stub(Shire.VirtualMachineMock, :spawn_command, fn _cmd, _args, _opts ->
+    stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}
     end)
 
-    start_supervised!(Shire.Agent.Coordinator)
+    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
+    stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
+
+    start_supervised!(Shire.ProjectManager)
+
+    start_supervised!(
+      {DynamicSupervisor,
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, @project}}},
+       strategy: :one_for_one},
+      id: :agent_sup
+    )
+
+    start_supervised!({Shire.Agent.Coordinator, project_name: @project})
     Process.sleep(50)
+
+    on_exit(fn ->
+      for {_, pid, _, _} <- DynamicSupervisor.which_children(Shire.ProjectSupervisor),
+          is_pid(pid) do
+        DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, pid)
+      end
+    end)
+
     :ok
   end
 
   describe "Index" do
+    test "redirects to / for non-existent project", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/"}}} =
+               live(conn, ~p"/projects/nonexistent")
+    end
+
     test "renders agent list page", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}")
       assert html =~ "AgentDashboard"
     end
 
     test "handles {:agent_status, agent_name, status} from lobby", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agents:lobby",
+        "project:#{@project}:agents:lobby",
         {:agent_status, "test-agent", :active}
       )
 
@@ -39,11 +66,11 @@ defmodule ShireWeb.AgentLiveTest do
     end
 
     test "handles agent_busy broadcast without crashing", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agents:lobby",
+        "project:#{@project}:agents:lobby",
         {:agent_busy, "test-agent", true}
       )
 
@@ -54,7 +81,7 @@ defmodule ShireWeb.AgentLiveTest do
     # --- select-agent ---
 
     test "select-agent with nonexistent agent shows error flash", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       # In test env, Coordinator has no VM, so get_agent returns {:error, :no_vm}
       render_hook(view, "select-agent", %{"name" => "nonexistent-agent"})
@@ -66,7 +93,7 @@ defmodule ShireWeb.AgentLiveTest do
     # --- delete-agent ---
 
     test "delete-agent succeeds and refreshes agents list", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       render_hook(view, "delete-agent", %{"name" => "some-agent"})
 
@@ -75,7 +102,7 @@ defmodule ShireWeb.AgentLiveTest do
     end
 
     test "delete-agent clears selection when deleted agent was selected", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       # First try selecting (will fail due to no VM, but that's ok)
       # Then delete the agent that was "selected" — verifying it clears
@@ -86,7 +113,7 @@ defmodule ShireWeb.AgentLiveTest do
     end
 
     test "delete-agent preserves selection when different agent is deleted", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       render_hook(view, "delete-agent", %{"name" => "other-agent"})
 
@@ -97,7 +124,7 @@ defmodule ShireWeb.AgentLiveTest do
     # --- update-agent ---
 
     test "update-agent does not crash the view", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       render_hook(view, "update-agent", %{
         "name" => "test-agent",
@@ -112,7 +139,7 @@ defmodule ShireWeb.AgentLiveTest do
     # --- create-agent ---
 
     test "create-agent does not crash the view", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       name = "create-test-#{System.unique_integer([:positive])}"
 
@@ -128,7 +155,7 @@ defmodule ShireWeb.AgentLiveTest do
     # --- load-more ---
 
     test "load-more with no selected agent is a no-op", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       render_hook(view, "load-more", %{"before" => "999"})
 
@@ -139,7 +166,7 @@ defmodule ShireWeb.AgentLiveTest do
     # --- edit-agent ---
 
     test "edit-agent with nonexistent agent shows error flash", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       render_hook(view, "edit-agent", %{"name" => "nonexistent"})
 
@@ -150,11 +177,11 @@ defmodule ShireWeb.AgentLiveTest do
     # --- PubSub: agent_status updates statuses map ---
 
     test "agent_status broadcast updates agent_statuses assign", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agents:lobby",
+        "project:#{@project}:agents:lobby",
         {:agent_status, "my-agent", :bootstrapping}
       )
 
@@ -166,11 +193,11 @@ defmodule ShireWeb.AgentLiveTest do
     # --- PubSub: agent_updated refreshes agents list ---
 
     test "agent_updated broadcast refreshes agents list", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agents:lobby",
+        "project:#{@project}:agents:lobby",
         {:agent_updated, "some-agent"}
       )
 
@@ -181,11 +208,11 @@ defmodule ShireWeb.AgentLiveTest do
     # --- PubSub: agent_deleted refreshes agents list ---
 
     test "agent_deleted broadcast refreshes agents list", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agents:lobby",
+        "project:#{@project}:agents:lobby",
         {:agent_deleted, "some-agent"}
       )
 
@@ -194,11 +221,11 @@ defmodule ShireWeb.AgentLiveTest do
     end
 
     test "agent_event for non-selected agent is ignored", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agents:lobby",
+        "project:#{@project}:agents:lobby",
         {:agent_event, "unselected-agent", %{"type" => "text_delta"}}
       )
 
@@ -209,17 +236,17 @@ defmodule ShireWeb.AgentLiveTest do
 
   describe "Show" do
     test "renders agent show page", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/agents/test-agent")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/agents/test-agent")
       assert html =~ "AgentShow"
     end
 
     test "mount sets agent with status", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/agents/my-agent")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/agents/my-agent")
       assert html =~ "AgentShow"
     end
 
     test "update-agent handler does not crash the view", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/agents/test-agent")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/test-agent")
 
       render_hook(view, "update-agent", %{
         "recipe_yaml" =>
@@ -231,19 +258,19 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentShow"
     end
 
-    test "delete-agent handler redirects to index", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/agents/delete-me")
+    test "delete-agent handler redirects to project index", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/delete-me")
 
       render_hook(view, "delete-agent", %{})
-      assert_redirect(view, "/")
+      assert_redirect(view, "/projects/#{@project}")
     end
 
     test "status broadcast updates agent status assign", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/agents/status-agent")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/status-agent")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agent:status-agent",
+        "project:#{@project}:agent:status-agent",
         {:status, :active}
       )
 
@@ -252,11 +279,11 @@ defmodule ShireWeb.AgentLiveTest do
     end
 
     test "status broadcast updates the agent map with new status", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/agents/status-agent")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/status-agent")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agent:status-agent",
+        "project:#{@project}:agent:status-agent",
         {:status, :failed}
       )
 
@@ -265,11 +292,11 @@ defmodule ShireWeb.AgentLiveTest do
     end
 
     test "agent_event broadcast does not crash", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/agents/test-agent")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/test-agent")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "agent:test-agent",
+        "project:#{@project}:agent:test-agent",
         {:agent_event, "test-agent", %{"type" => "text_delta", "payload" => %{"delta" => "hi"}}}
       )
 

--- a/test/shire_web/live/project_live_test.exs
+++ b/test/shire_web/live/project_live_test.exs
@@ -1,0 +1,87 @@
+defmodule ShireWeb.ProjectLiveTest do
+  use ShireWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mox
+
+  setup do
+    Mox.set_mox_global()
+
+    stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+
+    stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+      {:error, :not_available_in_test}
+    end)
+
+    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
+    stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
+
+    start_supervised!(Shire.ProjectManager)
+
+    on_exit(fn ->
+      for {_, pid, _, _} <- DynamicSupervisor.which_children(Shire.ProjectSupervisor),
+          is_pid(pid) do
+        DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, pid)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "Index" do
+    test "renders project dashboard page", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/")
+      assert html =~ "ProjectDashboard"
+    end
+
+    test "create-project event creates a project", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/")
+
+      render_hook(view, "create-project", %{"name" => "new-proj"})
+
+      projects = Shire.ProjectManager.list_projects()
+      assert length(projects) == 1
+      assert hd(projects).name == "new-proj"
+    end
+
+    test "create-project with duplicate name shows error", %{conn: conn} do
+      {:ok, _pid} = Shire.ProjectManager.create_project("existing")
+      {:ok, view, _html} = live(conn, ~p"/")
+
+      render_hook(view, "create-project", %{"name" => "existing"})
+
+      html = render(view)
+      assert html =~ "already exists"
+    end
+
+    test "delete-project event removes a project", %{conn: conn} do
+      {:ok, _pid} = Shire.ProjectManager.create_project("delete-me")
+      {:ok, view, _html} = live(conn, ~p"/")
+
+      render_hook(view, "delete-project", %{"name" => "delete-me"})
+
+      assert Shire.ProjectManager.list_projects() == []
+    end
+
+    test "PubSub project_created message refreshes list", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/")
+
+      {:ok, _pid} = Shire.ProjectManager.create_project("pubsub-proj")
+
+      # The PubSub broadcast from create_project should refresh the LiveView
+      html = render(view)
+      assert html =~ "ProjectDashboard"
+    end
+
+    test "PubSub project_destroyed message refreshes list", %{conn: conn} do
+      {:ok, _pid} = Shire.ProjectManager.create_project("destroy-proj")
+      {:ok, view, _html} = live(conn, ~p"/")
+
+      :ok = Shire.ProjectManager.destroy_project("destroy-proj")
+
+      html = render(view)
+      assert html =~ "ProjectDashboard"
+    end
+  end
+end

--- a/test/shire_web/live/settings_live_test.exs
+++ b/test/shire_web/live/settings_live_test.exs
@@ -6,30 +6,40 @@ defmodule ShireWeb.SettingsLiveTest do
 
   alias Shire.Agents
 
+  @project "test-project"
+
   setup do
     Mox.set_mox_global()
 
-    stub(Shire.VirtualMachineMock, :cmd, fn _cmd, _args, _opts -> {:ok, ""} end)
-    stub(Shire.VirtualMachineMock, :write, fn _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-    stub(Shire.VirtualMachineMock, :spawn_command, fn _cmd, _args, _opts ->
+    stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}
     end)
 
-    start_supervised!(Shire.Agent.Coordinator)
+    start_supervised!(
+      {DynamicSupervisor,
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, @project}}},
+       strategy: :one_for_one},
+      id: :agent_sup
+    )
+
+    start_supervised!({Shire.Agent.Coordinator, project_name: @project})
     Process.sleep(50)
     :ok
   end
 
   describe "Index" do
     test "renders settings page", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/settings")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/settings")
       assert html =~ "SettingsPage"
     end
 
     test "loads inter-agent messages", %{conn: conn} do
       {:ok, _msg} =
         Agents.create_message(%{
+          project_name: @project,
           agent_name: "test-agent",
           role: "inter_agent",
           content: %{
@@ -39,7 +49,7 @@ defmodule ShireWeb.SettingsLiveTest do
           }
         })
 
-      {:ok, _view, html} = live(conn, ~p"/settings")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/settings")
       assert html =~ "Hello from Alice"
       assert html =~ "Alice"
     end

--- a/test/support/vm_stub.ex
+++ b/test/support/vm_stub.ex
@@ -6,34 +6,34 @@ defmodule Shire.VirtualMachineStub do
   @behaviour Shire.VirtualMachine
 
   @impl true
-  def cmd(_command, _args \\ [], _opts \\ []), do: {:ok, ""}
+  def cmd(_project_name, _command, _args \\ [], _opts \\ []), do: {:ok, ""}
 
   @impl true
-  def cmd!(_command, _args \\ [], _opts \\ []), do: ""
+  def cmd!(_project_name, _command, _args \\ [], _opts \\ []), do: ""
 
   @impl true
-  def read(_path), do: {:ok, ""}
+  def read(_project_name, _path), do: {:ok, ""}
 
   @impl true
-  def write(_path, _content), do: :ok
+  def write(_project_name, _path, _content), do: :ok
 
   @impl true
-  def mkdir_p(_path), do: :ok
+  def mkdir_p(_project_name, _path), do: :ok
 
   @impl true
-  def rm(_path), do: :ok
+  def rm(_project_name, _path), do: :ok
 
   @impl true
-  def rm_rf(_path), do: :ok
+  def rm_rf(_project_name, _path), do: :ok
 
   @impl true
-  def ls(_path), do: {:ok, []}
+  def ls(_project_name, _path), do: {:ok, []}
 
   @impl true
-  def stat(_path), do: {:ok, %{type: :file, size: 0}}
+  def stat(_project_name, _path), do: {:ok, %{type: :file, size: 0}}
 
   @impl true
-  def spawn_command(_command, _args \\ [], _opts \\ []),
+  def spawn_command(_project_name, _command, _args \\ [], _opts \\ []),
     do: {:error, :not_available_in_test}
 
   @impl true
@@ -41,4 +41,10 @@ defmodule Shire.VirtualMachineStub do
 
   @impl true
   def resize(_command, _rows, _cols), do: :ok
+
+  @impl true
+  def list_vms, do: {:ok, []}
+
+  @impl true
+  def destroy_vm(_project_name), do: :ok
 end


### PR DESCRIPTION
## Summary

- Introduces project-level isolation where each project maps to its own Sprite VM, Coordinator, agent supervisor, and terminal session
- New `ProjectManager` GenServer discovers/creates/destroys projects via Sprites API, with `Process.monitor` to track supervisor PIDs and auto-cleanup on crash
- New `ProjectInstanceSupervisor` (one_for_all strategy) bundles per-project VM + Coordinator + agent DynamicSupervisor
- All routes scoped under `/projects/:project` with project dashboard at `/`; LiveView mounts validate project existence and redirect on invalid
- All existing modules (Coordinator, AgentManager, TerminalSession, VirtualMachineImpl, WorkspaceSettings, Agents context) refactored to accept a `project` parameter
- New React components: `ProjectDashboard` (project CRUD), `ProjectSwitcher` (cross-project nav)
- Migration adds `project_name` to messages with composite index
- PubSub topics namespaced by project for full event isolation

## Test plan

- [x] `mix compile --warnings-as-errors` — zero warnings
- [x] `mix format --check-formatted` — all formatted
- [x] `mix test` — 135 tests, 0 failures (includes new ProjectManager + ProjectLive tests)
- [x] `bun run tsc --noEmit` — no type errors
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run test` — 101 frontend tests passing
- [ ] Manual: create a project, verify VM boots, create agents, send messages, switch projects
- [ ] Manual: navigate to `/projects/nonexistent` → redirects to `/` with flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)