### PR TITLE
feat: smooth LiveView navigation instead of full page reloads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,3 +183,4 @@ mix precommit
 - Don't use `@apply` in CSS
 - Always use shadcn/ui components (Button, Input, Dialog, etc.) instead of plain HTML elements unless the library doesn't support the needed component
 - shadcn dialog animations: use fade + zoom only, no slide classes (they conflict with translate centering)
+- **Never use `eslint-disable` comments casually** — disabling lint rules is an anti-pattern. Fix the underlying issue (use proper types, runtime checks, etc.) instead. Only use `eslint-disable` when there is genuinely no other option.

--- a/assets/react-components/AgentShow.tsx
+++ b/assets/react-components/AgentShow.tsx
@@ -14,6 +14,7 @@ import {
   AlertDialogCancel,
 } from "./components/ui/alert-dialog";
 import AppLayout from "./components/AppLayout";
+import { navigate } from "./lib/navigate";
 import AgentForm from "./AgentForm";
 import { ChevronLeft, Pencil } from "lucide-react";
 import { type Agent, statusVariant, harnessLabel } from "./types";
@@ -34,12 +35,7 @@ export default function AgentShow({
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="Back"
-              onClick={() => window.location.assign(`/projects/${project}`)}
-            >
+            <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project}`)}>
               <ChevronLeft className="h-5 w-5" />
             </Button>
             <h1 className="text-2xl font-bold">{agent.name}</h1>

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -17,6 +17,7 @@ import {
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
 import ProjectSwitcher from "./ProjectSwitcher";
+import { navigate } from "./lib/navigate";
 import { type Agent, type AgentStatus, type Project } from "./types";
 
 function statusDotColor(status: AgentStatus): string {
@@ -100,7 +101,7 @@ export default function AgentSidebar({
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => window.location.assign(`/projects/${project}/agents/${agent.name}`)}>
+                <DropdownMenuItem onClick={() => navigate(`/projects/${project}/agents/${agent.name}`)}>
                   Settings
                 </DropdownMenuItem>
                 <DropdownMenuItem
@@ -123,7 +124,7 @@ export default function AgentSidebar({
         <button
           type="button"
           className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
-          onClick={() => window.location.assign(`/projects/${project}/settings`)}
+          onClick={() => navigate(`/projects/${project}/settings`)}
         >
           <svg
             width="16"
@@ -143,7 +144,7 @@ export default function AgentSidebar({
         <button
           type="button"
           className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
-          onClick={() => window.location.assign(`/projects/${project}/shared`)}
+          onClick={() => navigate(`/projects/${project}/shared`)}
         >
           <svg
             width="16"

--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -22,6 +22,7 @@ import {
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
 import AppLayout from "./components/AppLayout";
+import { navigate } from "./lib/navigate";
 import type { Project } from "./types";
 
 interface ProjectDashboardProps {
@@ -83,7 +84,7 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
               <Card
                 key={project.name}
                 className="cursor-pointer hover:border-primary/50 transition-colors"
-                onClick={() => window.location.assign(`/projects/${project.name}`)}
+                onClick={() => navigate(`/projects/${project.name}`)}
               >
                 <CardContent className="pt-6">
                   <div className="flex items-center justify-between">

--- a/assets/react-components/ProjectSwitcher.tsx
+++ b/assets/react-components/ProjectSwitcher.tsx
@@ -1,4 +1,5 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./components/ui/select";
+import { navigate } from "./lib/navigate";
 import type { Project } from "./types";
 
 interface ProjectSwitcherProps {
@@ -12,9 +13,9 @@ export default function ProjectSwitcher({ projects, currentProject }: ProjectSwi
       value={currentProject}
       onValueChange={(value) => {
         if (value === "__all__") {
-          window.location.assign("/");
+          navigate("/");
         } else {
-          window.location.assign(`/projects/${value}`);
+          navigate(`/projects/${value}`);
         }
       }}
     >

--- a/assets/react-components/SettingsPage.tsx
+++ b/assets/react-components/SettingsPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "./components/ui/alert-dialog";
 import { ChevronLeft, Play, Trash2, Plus, X } from "lucide-react";
 import AppLayout from "./components/AppLayout";
+import { navigate } from "./lib/navigate";
 import ActivityLog from "./ActivityLog";
 import Terminal from "./Terminal";
 import type { InterAgentMessage } from "./types";
@@ -138,12 +139,7 @@ export default function SettingsPage({
     <AppLayout>
       <div className="space-y-6">
         <div className="flex items-center gap-3">
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Back"
-            onClick={() => window.location.assign(`/projects/${project}`)}
-          >
+          <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project}`)}>
             <ChevronLeft className="h-5 w-5" />
           </Button>
           <h1 className="text-2xl font-bold">Settings</h1>

--- a/assets/react-components/lib/navigate.ts
+++ b/assets/react-components/lib/navigate.ts
@@ -4,10 +4,18 @@
  * Falls back to window.location.assign if liveSocket is not available.
  */
 export function navigate(href: string, opts?: { replace?: boolean }): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const liveSocket = (window as any).liveSocket;
-  if (liveSocket?.js) {
-    liveSocket.js().navigate(href, opts);
+  const liveSocket = "liveSocket" in window ? (window as Record<string, unknown>).liveSocket : undefined;
+  if (
+    liveSocket &&
+    typeof liveSocket === "object" &&
+    "js" in liveSocket &&
+    typeof (liveSocket as Record<string, unknown>).js === "function"
+  ) {
+    const js = (liveSocket as Record<string, (...args: unknown[]) => unknown>).js() as Record<
+      string,
+      (href: string, opts?: { replace?: boolean }) => void
+    >;
+    js.navigate(href, opts);
   } else {
     window.location.assign(href);
   }

--- a/assets/react-components/lib/navigate.ts
+++ b/assets/react-components/lib/navigate.ts
@@ -1,0 +1,14 @@
+/**
+ * Performs smooth LiveView navigation without a full page reload.
+ * Uses the Phoenix LiveView JS commands API (liveSocket.js().navigate).
+ * Falls back to window.location.assign if liveSocket is not available.
+ */
+export function navigate(href: string, opts?: { replace?: boolean }): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const liveSocket = (window as any).liveSocket;
+  if (liveSocket?.js) {
+    liveSocket.js().navigate(href, opts);
+  } else {
+    window.location.assign(href);
+  }
+}

--- a/assets/test/navigate.test.ts
+++ b/assets/test/navigate.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { navigate } from "../react-components/lib/navigate";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const win = window as unknown as Record<string, any>;
+
+describe("navigate", () => {
+  const originalLiveSocket = win.liveSocket;
+  let assignSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { assign: assignSpy },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    win.liveSocket = originalLiveSocket;
+  });
+
+  it("calls liveSocket.js().navigate() when liveSocket is available", () => {
+    const navigateFn = vi.fn();
+    win.liveSocket = {
+      js: () => ({ navigate: navigateFn }),
+    };
+
+    navigate("/projects/test");
+
+    expect(navigateFn).toHaveBeenCalledWith("/projects/test", undefined);
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes replace option through to liveSocket", () => {
+    const navigateFn = vi.fn();
+    win.liveSocket = {
+      js: () => ({ navigate: navigateFn }),
+    };
+
+    navigate("/projects/test", { replace: true });
+
+    expect(navigateFn).toHaveBeenCalledWith("/projects/test", { replace: true });
+  });
+
+  it("falls back to window.location.assign when liveSocket is not available", () => {
+    win.liveSocket = undefined;
+
+    navigate("/projects/test");
+
+    expect(assignSpy).toHaveBeenCalledWith("/projects/test");
+  });
+
+  it("falls back to window.location.assign when liveSocket has no js method", () => {
+    win.liveSocket = {};
+
+    navigate("/projects/test");
+
+    expect(assignSpy).toHaveBeenCalledWith("/projects/test");
+  });
+});

--- a/assets/test/navigate.test.ts
+++ b/assets/test/navigate.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { navigate } from "../react-components/lib/navigate";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const win = window as unknown as Record<string, any>;
+const win = window as unknown as Record<string, unknown>;
 
 describe("navigate", () => {
   const originalLiveSocket = win.liveSocket;


### PR DESCRIPTION
## Summary
- Replace all `window.location.assign()` calls with `liveSocket.js().navigate()` for SPA-like page transitions
- Add `navigate()` utility wrapper with fallback for safety (tests, edge cases)
- All 8 navigation sites across 5 React components now use smooth LiveView transitions that preserve the WebSocket connection

## Test plan
- [x] Navigate utility tests (4 tests covering liveSocket usage, options passthrough, fallback)
- [ ] Manual: click between projects, agents, settings, shared drive — verify no full page reload (no white flash, topbar progress shows)
- [ ] Manual: verify browser back/forward still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)