### PR TITLE
fix: migrate inter-agent messaging to YAML with system feedback

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -7,7 +7,7 @@ import WelcomePanel from "./WelcomePanel";
 import { type Agent, type Project } from "./types";
 
 interface AgentDashboardProps {
-  project: string;
+  project: { id: string; name: string };
   projects: Project[];
   agents: Agent[];
   selectedAgent: Agent | null;
@@ -31,13 +31,13 @@ export default function AgentDashboard({
 }: AgentDashboardProps) {
   const [formOpen, setFormOpen] = React.useState(false);
   const [formTitle, setFormTitle] = React.useState("New Agent");
-  const [editingName, setEditingName] = React.useState<string | null>(null);
+  const [editingAgent, setEditingAgent] = React.useState<Agent | null>(null);
   const [currentAgent, setCurrentAgent] = React.useState<Agent | null>(null);
 
   React.useEffect(() => {
     if (editAgent) {
       setCurrentAgent(editAgent);
-      setEditingName(editAgent.name ?? null);
+      setEditingAgent(editAgent);
       setFormTitle("Edit Agent");
       setFormOpen(true);
     }
@@ -45,17 +45,17 @@ export default function AgentDashboard({
 
   const handleNew = () => {
     setCurrentAgent(null);
-    setEditingName(null);
+    setEditingAgent(null);
     setFormTitle("New Agent");
     setFormOpen(true);
   };
 
-  const handleSelectAgent = (name: string) => {
-    pushEvent("select-agent", { name });
+  const handleSelectAgent = (id: string) => {
+    pushEvent("select-agent", { id });
   };
 
   const handleDeleteAgent = (agent: Agent) => {
-    pushEvent("delete-agent", { name: agent.name });
+    pushEvent("delete-agent", { id: agent.id });
   };
 
   const handleFormClose = () => {
@@ -64,8 +64,8 @@ export default function AgentDashboard({
 
   const handleFormSave = (_event: string, payload: Record<string, unknown>) => {
     setFormOpen(false);
-    if (editingName) {
-      pushEvent("update-agent", { name: editingName, ...payload });
+    if (editingAgent) {
+      pushEvent("update-agent", { id: editingAgent.id, ...payload });
     } else {
       pushEvent("create-agent", payload);
     }
@@ -77,7 +77,7 @@ export default function AgentDashboard({
         project={project}
         projects={projects}
         agents={agents}
-        selectedAgentName={selectedAgent?.name ?? null}
+        selectedAgentId={selectedAgent?.id ?? null}
         onSelectAgent={handleSelectAgent}
         onNewAgent={handleNew}
         onDeleteAgent={handleDeleteAgent}

--- a/assets/react-components/AgentForm.tsx
+++ b/assets/react-components/AgentForm.tsx
@@ -94,9 +94,13 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
 
     const event = agent ? "update-agent" : "create-agent";
     const payload: Record<string, unknown> = {
-      name: agent ? agent.name : finalName,
       recipe_yaml: recipeYaml,
     };
+    if (agent) {
+      payload.id = agent.id;
+    } else {
+      payload.name = finalName;
+    }
 
     pushEvent(event, payload);
     onClose();

--- a/assets/react-components/AgentShow.tsx
+++ b/assets/react-components/AgentShow.tsx
@@ -24,7 +24,7 @@ export default function AgentShow({
   agent,
   pushEvent,
 }: {
-  project: string;
+  project: { id: string; name: string };
   agent: Agent;
   pushEvent: (event: string, payload: Record<string, unknown>) => void;
 }) {
@@ -35,7 +35,7 @@ export default function AgentShow({
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project}`)}>
+            <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project.id}`)}>
               <ChevronLeft className="h-5 w-5" />
             </Button>
             <h1 className="text-2xl font-bold">{agent.name}</h1>

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -36,11 +36,11 @@ function statusDotColor(status: AgentStatus): string {
 }
 
 interface AgentSidebarProps {
-  project: string;
+  project: { id: string; name: string };
   projects: Project[];
   agents: Agent[];
-  selectedAgentName: string | null;
-  onSelectAgent: (name: string) => void;
+  selectedAgentId: string | null;
+  onSelectAgent: (id: string) => void;
   onNewAgent: () => void;
   onDeleteAgent: (agent: Agent) => void;
 }
@@ -49,7 +49,7 @@ export default function AgentSidebar({
   project,
   projects,
   agents,
-  selectedAgentName,
+  selectedAgentId,
   onSelectAgent,
   onNewAgent,
   onDeleteAgent,
@@ -66,7 +66,7 @@ export default function AgentSidebar({
   return (
     <div className="w-64 border-r border-border bg-muted/30 flex flex-col h-full">
       <div className="p-3 border-b border-border">
-        <ProjectSwitcher projects={projects} currentProject={project} />
+        <ProjectSwitcher projects={projects} currentProjectId={project.id} />
       </div>
 
       <div className="p-4 border-b border-border">
@@ -76,11 +76,11 @@ export default function AgentSidebar({
       <div className="flex-1 overflow-y-auto py-1">
         {agents.map((agent) => (
           <div
-            key={agent.name}
+            key={agent.id}
             className={`group flex items-center gap-2 px-3 py-2 mx-1 rounded-md cursor-pointer text-sm ${
-              selectedAgentName === agent.name ? "bg-accent text-accent-foreground" : "hover:bg-muted text-foreground"
+              selectedAgentId === agent.id ? "bg-accent text-accent-foreground" : "hover:bg-muted text-foreground"
             }`}
-            onClick={() => onSelectAgent(agent.name)}
+            onClick={() => onSelectAgent(agent.id)}
           >
             <span
               className={`w-2 h-2 rounded-full flex-shrink-0 ${statusDotColor(agent.status)}${agent.status === "active" && agent.busy ? " animate-pulse" : ""}`}
@@ -101,7 +101,7 @@ export default function AgentSidebar({
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => navigate(`/projects/${project}/agents/${agent.name}`)}>
+                <DropdownMenuItem onClick={() => navigate(`/projects/${project.id}/agents/${agent.id}`)}>
                   Settings
                 </DropdownMenuItem>
                 <DropdownMenuItem
@@ -124,7 +124,7 @@ export default function AgentSidebar({
         <button
           type="button"
           className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
-          onClick={() => navigate(`/projects/${project}/settings`)}
+          onClick={() => navigate(`/projects/${project.id}/settings`)}
         >
           <svg
             width="16"
@@ -144,7 +144,7 @@ export default function AgentSidebar({
         <button
           type="button"
           className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
-          onClick={() => navigate(`/projects/${project}/shared`)}
+          onClick={() => navigate(`/projects/${project.id}/shared`)}
         >
           <svg
             width="16"

--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -88,6 +88,28 @@ function InterAgentMessage({ msg }: { msg: Message }) {
   );
 }
 
+function SystemMessage({ msg }: { msg: Message }) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div className="max-w-[80%] rounded-lg border border-border text-sm w-fit">
+      <Button
+        variant="ghost"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left italic h-auto justify-start"
+      >
+        <span className="text-muted-foreground">{open ? "\u25BC" : "\u25B6"}</span>
+        <span className="text-muted-foreground">System notification</span>
+      </Button>
+      {open && (
+        <div className="border-t border-border px-3 py-2">
+          <Markdown>{msg.text ?? ""}</Markdown>
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface ChatPanelProps {
   agent: Agent;
   messages?: Message[];
@@ -190,6 +212,8 @@ export default function ChatPanel({
             <ToolCallMessage key={msg.id ?? `msg-${i}`} msg={msg} />
           ) : msg.role === "inter_agent" ? (
             <InterAgentMessage key={msg.id ?? `msg-${i}`} msg={msg} />
+          ) : msg.role === "system" ? (
+            <SystemMessage key={msg.id ?? `msg-${i}`} msg={msg} />
           ) : (
             <div key={msg.id ?? `msg-${i}`} className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
               <div

--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -61,7 +61,7 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
 
   const handleDelete = () => {
     if (!deleteProject) return;
-    pushEvent("delete-project", { name: deleteProject.name });
+    pushEvent("delete-project", { id: deleteProject.id });
     setDeleteProject(null);
   };
 
@@ -82,9 +82,9 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {projects.map((project) => (
               <Card
-                key={project.name}
+                key={project.id}
                 className="cursor-pointer hover:border-primary/50 transition-colors"
-                onClick={() => navigate(`/projects/${project.name}`)}
+                onClick={() => navigate(`/projects/${project.id}`)}
               >
                 <CardContent className="pt-6">
                   <div className="flex items-center justify-between">

--- a/assets/react-components/ProjectSwitcher.tsx
+++ b/assets/react-components/ProjectSwitcher.tsx
@@ -4,13 +4,13 @@ import type { Project } from "./types";
 
 interface ProjectSwitcherProps {
   projects: Project[];
-  currentProject: string;
+  currentProjectId: string;
 }
 
-export default function ProjectSwitcher({ projects, currentProject }: ProjectSwitcherProps) {
+export default function ProjectSwitcher({ projects, currentProjectId }: ProjectSwitcherProps) {
   return (
     <Select
-      value={currentProject}
+      value={currentProjectId}
       onValueChange={(value) => {
         if (value === "__all__") {
           navigate("/");
@@ -24,7 +24,7 @@ export default function ProjectSwitcher({ projects, currentProject }: ProjectSwi
       </SelectTrigger>
       <SelectContent>
         {projects.map((project) => (
-          <SelectItem key={project.name} value={project.name}>
+          <SelectItem key={project.id} value={project.id}>
             {project.name}
           </SelectItem>
         ))}

--- a/assets/react-components/SettingsPage.tsx
+++ b/assets/react-components/SettingsPage.tsx
@@ -35,7 +35,7 @@ interface ScriptDraft {
 }
 
 interface SettingsPageProps {
-  project: string;
+  project: { id: string; name: string };
   env_content: string;
   scripts: Script[];
   messages: InterAgentMessage[];
@@ -139,7 +139,7 @@ export default function SettingsPage({
     <AppLayout>
       <div className="space-y-6">
         <div className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project}`)}>
+          <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project.id}`)}>
             <ChevronLeft className="h-5 w-5" />
           </Button>
           <h1 className="text-2xl font-bold">Settings</h1>

--- a/assets/react-components/SharedDrive.tsx
+++ b/assets/react-components/SharedDrive.tsx
@@ -30,7 +30,7 @@ export interface SharedDriveFile {
 }
 
 interface SharedDriveProps {
-  project: string;
+  project: { id: string; name: string };
   files: SharedDriveFile[];
   current_path: string;
   pushEvent: (event: string, payload: Record<string, unknown>) => void;
@@ -177,7 +177,7 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
                         {file.type === "file" && (
                           <Button variant="ghost" size="sm" asChild>
                             <a
-                              href={`/projects/${project}/shared/download?path=${encodeURIComponent(file.path)}`}
+                              href={`/projects/${project.id}/shared/download?path=${encodeURIComponent(file.path)}`}
                               download
                             >
                               Download

--- a/assets/react-components/types.ts
+++ b/assets/react-components/types.ts
@@ -1,4 +1,5 @@
 export interface Project {
+  id: string;
   name: string;
   status: "running" | "starting" | "error";
 }
@@ -20,6 +21,7 @@ export interface Skill {
 }
 
 export interface Agent {
+  id: string;
   name: string;
   description?: string;
   status: AgentStatus;

--- a/assets/test/AgentDashboard.test.tsx
+++ b/assets/test/AgentDashboard.test.tsx
@@ -6,12 +6,14 @@ import { type Agent, type Project } from "../react-components/types";
 
 const agents: Agent[] = [
   {
+    id: "a1",
     name: "Agent One",
     status: "active",
     model: "claude-sonnet-4-6",
     harness: "claude_code",
   },
   {
+    id: "a2",
     name: "Agent Two",
     status: "created",
     harness: "claude_code",
@@ -19,12 +21,12 @@ const agents: Agent[] = [
 ];
 
 const projects: Project[] = [
-  { name: "test-project", status: "running" },
-  { name: "other-project", status: "running" },
+  { id: "p1", name: "test-project", status: "running" },
+  { id: "p2", name: "other-project", status: "running" },
 ];
 
 const defaultProps = {
-  project: "test-project",
+  project: { id: "p1", name: "test-project" },
   projects,
   editAgent: null,
   pushEvent: vi.fn(),
@@ -63,7 +65,7 @@ describe("AgentDashboard", () => {
     render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} pushEvent={pushEvent} />);
 
     await userEvent.click(screen.getByText("Agent One"));
-    expect(pushEvent).toHaveBeenCalledWith("select-agent", { name: "Agent One" });
+    expect(pushEvent).toHaveBeenCalledWith("select-agent", { id: "a1" });
   });
 
   it("opens new agent dialog from sidebar", async () => {

--- a/assets/test/AgentForm.test.tsx
+++ b/assets/test/AgentForm.test.tsx
@@ -74,6 +74,7 @@ describe("AgentForm", () => {
 
   it("loads skills from existing agent", () => {
     const agent: Agent = {
+      id: "a-test",
       name: "test",
       status: "created",
       harness: "claude_code",
@@ -95,6 +96,7 @@ describe("AgentForm", () => {
 
   it("submits update-agent event with recipe_yaml for existing agent", async () => {
     const agent: Agent = {
+      id: "a-existing",
       name: "existing-agent",
       status: "active",
       harness: "claude_code",
@@ -108,7 +110,7 @@ describe("AgentForm", () => {
     expect(pushEvent).toHaveBeenCalledWith(
       "update-agent",
       expect.objectContaining({
-        name: "existing-agent",
+        id: "a-existing",
         recipe_yaml: expect.any(String),
       }),
     );

--- a/assets/test/AgentShow.test.tsx
+++ b/assets/test/AgentShow.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../react-components/Terminal", () => ({
 import AgentShow from "../react-components/AgentShow";
 
 const agent: Agent = {
+  id: "a1",
   name: "Test Agent",
   status: "active",
   model: "claude-sonnet-4-6",
@@ -22,7 +23,7 @@ const agent: Agent = {
 
 describe("AgentShow", () => {
   it("renders agent details", () => {
-    render(<AgentShow project="test-project" agent={agent} pushEvent={vi.fn()} />);
+    render(<AgentShow project={{ id: "p1", name: "test-project" }} agent={agent} pushEvent={vi.fn()} />);
     expect(screen.getByRole("heading", { name: "Test Agent" })).toBeInTheDocument();
     expect(screen.getByText("claude-sonnet-4-6")).toBeInTheDocument();
     expect(screen.getByText("You are a helpful assistant.")).toBeInTheDocument();
@@ -32,7 +33,7 @@ describe("AgentShow", () => {
   it("shows fallback for missing model and system prompt", () => {
     render(
       <AgentShow
-        project="test-project"
+        project={{ id: "p1", name: "test-project" }}
         agent={{ ...agent, model: undefined, system_prompt: undefined }}
         pushEvent={vi.fn()}
       />,
@@ -41,27 +42,51 @@ describe("AgentShow", () => {
   });
 
   it("shows Start and Delete buttons for created agent", () => {
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "created" }} pushEvent={vi.fn()} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "created" }}
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
   it("shows Restart and Delete buttons for active agent", () => {
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "active" }} pushEvent={vi.fn()} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "active" }}
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Restart Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
   it("calls pushEvent with start-agent", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "created" }} pushEvent={pushEvent} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "created" }}
+        pushEvent={pushEvent}
+      />,
+    );
     await userEvent.click(screen.getByText("Start Agent"));
     expect(pushEvent).toHaveBeenCalledWith("start-agent", {});
   });
 
   it("calls pushEvent with restart-agent after confirming", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "active" }} pushEvent={pushEvent} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "active" }}
+        pushEvent={pushEvent}
+      />,
+    );
     await userEvent.click(screen.getByText("Restart Agent"));
     await userEvent.click(screen.getByText("Restart"));
     expect(pushEvent).toHaveBeenCalledWith("restart-agent", {});
@@ -69,51 +94,87 @@ describe("AgentShow", () => {
 
   it("calls pushEvent with delete-agent after confirming", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "active" }} pushEvent={pushEvent} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "active" }}
+        pushEvent={pushEvent}
+      />,
+    );
     await userEvent.click(screen.getByText("Delete Agent"));
     await userEvent.click(screen.getByText("Delete"));
     expect(pushEvent).toHaveBeenCalledWith("delete-agent", {});
   });
 
   it("shows Start and Delete buttons for crashed agent", () => {
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "crashed" }} pushEvent={vi.fn()} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "crashed" }}
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
   it("shows Restart and Delete buttons for bootstrapping agent", () => {
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "bootstrapping" }} pushEvent={vi.fn()} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "bootstrapping" }}
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Restart Agent")).toBeInTheDocument();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
     expect(screen.queryByText("Start Agent")).not.toBeInTheDocument();
   });
 
   it("shows Delete button for failed agent", () => {
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "failed" }} pushEvent={vi.fn()} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "failed" }}
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
   });
 
   it("calls pushEvent with delete-agent for created agent after confirming", async () => {
     const pushEvent = vi.fn();
-    render(<AgentShow project="test-project" agent={{ ...agent, status: "created" }} pushEvent={pushEvent} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "created" }}
+        pushEvent={pushEvent}
+      />,
+    );
     await userEvent.click(screen.getByText("Delete Agent"));
     await userEvent.click(screen.getByText("Delete"));
     expect(pushEvent).toHaveBeenCalledWith("delete-agent", {});
   });
 
   it("displays harness badge", () => {
-    render(<AgentShow project="test-project" agent={agent} pushEvent={vi.fn()} />);
+    render(<AgentShow project={{ id: "p1", name: "test-project" }} agent={agent} pushEvent={vi.fn()} />);
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
   });
 
   it("displays Pi harness", () => {
-    render(<AgentShow project="test-project" agent={{ ...agent, harness: "pi" }} pushEvent={vi.fn()} />);
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, harness: "pi" }}
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Pi")).toBeInTheDocument();
   });
 
   it("shows Edit button and opens edit form dialog", async () => {
-    render(<AgentShow project="test-project" agent={agent} pushEvent={vi.fn()} />);
+    render(<AgentShow project={{ id: "p1", name: "test-project" }} agent={agent} pushEvent={vi.fn()} />);
     const editBtn = screen.getByRole("button", { name: /edit/i });
     expect(editBtn).toBeInTheDocument();
     await userEvent.click(editBtn);

--- a/assets/test/AgentSidebar.test.tsx
+++ b/assets/test/AgentSidebar.test.tsx
@@ -6,17 +6,20 @@ import { type Agent, type Project } from "../react-components/types";
 
 const agents: Agent[] = [
   {
+    id: "a1",
     name: "Active Agent",
     status: "active",
     model: "claude-sonnet-4-6",
     harness: "claude_code",
   },
   {
+    id: "a2",
     name: "Created Agent",
     status: "created",
     harness: "claude_code",
   },
   {
+    id: "a3",
     name: "Failed Agent",
     status: "failed",
     harness: "claude_code",
@@ -24,14 +27,14 @@ const agents: Agent[] = [
 ];
 
 const projects: Project[] = [
-  { name: "test-project", status: "running" },
-  { name: "other-project", status: "running" },
+  { id: "p1", name: "test-project", status: "running" },
+  { id: "p2", name: "other-project", status: "running" },
 ];
 
 const defaultProps = {
-  project: "test-project",
+  project: { id: "p1", name: "test-project" },
   projects,
-  selectedAgentName: null as string | null,
+  selectedAgentId: null as string | null,
   onSelectAgent: vi.fn(),
   onNewAgent: vi.fn(),
   onDeleteAgent: vi.fn(),
@@ -55,7 +58,7 @@ describe("AgentSidebar", () => {
     render(<AgentSidebar {...defaultProps} agents={agents} onSelectAgent={onSelectAgent} />);
 
     await userEvent.click(screen.getByText("Active Agent"));
-    expect(onSelectAgent).toHaveBeenCalledWith("Active Agent");
+    expect(onSelectAgent).toHaveBeenCalledWith("a1");
   });
 
   it("calls onNewAgent when clicking New Agent button", async () => {

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -156,6 +156,45 @@ describe("ChatPanel", () => {
     expect(screen.queryByText("Here is the analysis result")).not.toBeInTheDocument();
   });
 
+  it("renders system message collapsed by default", () => {
+    const sysMsg: Message = {
+      id: 20,
+      role: "system",
+      text: "Your outbox message was invalid",
+      ts: "2026-03-17T00:00:04Z",
+    };
+    render(<ChatPanel agent={activeAgent} messages={[sysMsg]} pushEvent={vi.fn()} />);
+    expect(screen.getByText("System notification")).toBeInTheDocument();
+    expect(screen.queryByText("Your outbox message was invalid")).not.toBeInTheDocument();
+  });
+
+  it("expands system message on click", async () => {
+    const sysMsg: Message = {
+      id: 20,
+      role: "system",
+      text: "Your outbox message was invalid",
+      ts: "2026-03-17T00:00:04Z",
+    };
+    render(<ChatPanel agent={activeAgent} messages={[sysMsg]} pushEvent={vi.fn()} />);
+    await userEvent.click(screen.getByText("System notification"));
+    expect(screen.getByText("Your outbox message was invalid")).toBeInTheDocument();
+  });
+
+  it("collapses system message on second click", async () => {
+    const sysMsg: Message = {
+      id: 20,
+      role: "system",
+      text: "Your outbox message was invalid",
+      ts: "2026-03-17T00:00:04Z",
+    };
+    render(<ChatPanel agent={activeAgent} messages={[sysMsg]} pushEvent={vi.fn()} />);
+    const toggle = screen.getByText("System notification");
+    await userEvent.click(toggle);
+    expect(screen.getByText("Your outbox message was invalid")).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(screen.queryByText("Your outbox message was invalid")).not.toBeInTheDocument();
+  });
+
   it("shows thinking indicator when agent is busy", () => {
     const busyAgent = { ...activeAgent, busy: true };
     render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -5,6 +5,7 @@ import ChatPanel, { type Message } from "../react-components/ChatPanel";
 import { type Agent } from "../react-components/types";
 
 const activeAgent: Agent = {
+  id: "a1",
   name: "Test Agent",
   status: "active",
   model: "claude-sonnet-4-6",

--- a/assets/test/ProjectDashboard.test.tsx
+++ b/assets/test/ProjectDashboard.test.tsx
@@ -5,8 +5,8 @@ import ProjectDashboard from "../react-components/ProjectDashboard";
 import type { Project } from "../react-components/types";
 
 const projects: Project[] = [
-  { name: "test-project", status: "running" },
-  { name: "other-project", status: "running" },
+  { id: "p1", name: "test-project", status: "running" },
+  { id: "p2", name: "other-project", status: "running" },
 ];
 
 describe("ProjectDashboard", () => {
@@ -28,8 +28,8 @@ describe("ProjectDashboard", () => {
 
   it("shows status badges on project cards", () => {
     const mixedProjects: Project[] = [
-      { name: "running-project", status: "running" },
-      { name: "error-project", status: "error" },
+      { id: "p3", name: "running-project", status: "running" },
+      { id: "p4", name: "error-project", status: "error" },
     ];
     render(<ProjectDashboard projects={mixedProjects} pushEvent={vi.fn()} />);
     expect(screen.getByText("running")).toBeInTheDocument();
@@ -85,6 +85,6 @@ describe("ProjectDashboard", () => {
     const confirmDelete = screen.getAllByText("Delete").find((el) => el.closest("[role='alertdialog']"));
     await userEvent.click(confirmDelete!);
 
-    expect(pushEvent).toHaveBeenCalledWith("delete-project", { name: "test-project" });
+    expect(pushEvent).toHaveBeenCalledWith("delete-project", { id: "p1" });
   });
 });

--- a/assets/test/ProjectSwitcher.test.tsx
+++ b/assets/test/ProjectSwitcher.test.tsx
@@ -4,18 +4,18 @@ import ProjectSwitcher from "../react-components/ProjectSwitcher";
 import type { Project } from "../react-components/types";
 
 const projects: Project[] = [
-  { name: "test-project", status: "running" },
-  { name: "other-project", status: "running" },
+  { id: "p1", name: "test-project", status: "running" },
+  { id: "p2", name: "other-project", status: "running" },
 ];
 
 describe("ProjectSwitcher", () => {
   it("renders with current project selected", () => {
-    render(<ProjectSwitcher projects={projects} currentProject="test-project" />);
+    render(<ProjectSwitcher projects={projects} currentProjectId="p1" />);
     expect(screen.getByText("test-project")).toBeInTheDocument();
   });
 
   it("renders as a select trigger", () => {
-    render(<ProjectSwitcher projects={projects} currentProject="test-project" />);
+    render(<ProjectSwitcher projects={projects} currentProjectId="p1" />);
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
@@ -26,7 +26,7 @@ describe("ProjectSwitcher", () => {
       writable: true,
     });
 
-    render(<ProjectSwitcher projects={projects} currentProject="test-project" />);
+    render(<ProjectSwitcher projects={projects} currentProjectId="p1" />);
     // The select component renders the current value; full interaction testing
     // of Radix Select in jsdom is limited, so we verify the component renders
     expect(screen.getByRole("combobox")).toBeInTheDocument();

--- a/assets/test/SettingsPage.test.tsx
+++ b/assets/test/SettingsPage.test.tsx
@@ -8,7 +8,7 @@ vi.mock("../react-components/Terminal", () => ({
 }));
 
 const defaultProps = {
-  project: "test-project",
+  project: { id: "p1", name: "test-project" },
   env_content: "",
   scripts: [] as { name: string; content: string }[],
   messages: [] as { id: number; from_agent: string; to_agent: string; text: string; ts: string }[],

--- a/assets/test/SharedDrive.test.tsx
+++ b/assets/test/SharedDrive.test.tsx
@@ -5,7 +5,7 @@ import SharedDrive from "../react-components/SharedDrive";
 import type { SharedDriveFile } from "../react-components/SharedDrive";
 
 const defaultProps = {
-  project: "test-project",
+  project: { id: "p1", name: "test-project" },
   files: [] as SharedDriveFile[],
   current_path: "/",
   pushEvent: vi.fn(),

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -11,7 +11,7 @@ defmodule Shire.Agent.AgentManager do
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
-  defp comms_prompt(agent_name) do
+  defp comms_prompt(agent_name, agent_id) do
     """
     # Inter-Agent Communication
 
@@ -25,13 +25,12 @@ defmodule Shire.Agent.AgentManager do
     - The user sees YOUR output, not the other agents' — always produce the complete response
 
     ## Discovering Peers
-    List `/workspace/agents/` to see other agents. Each subdirectory is an agent.
-    Read their `recipe.yaml` to see what they do.
+    Read `/workspace/peers.yaml` to see available agents and their descriptions.
 
     ## Sending Messages
     To message another agent, write a JSON file to your **outbox**:
 
-    **Path:** `/workspace/agents/#{agent_name}/outbox/<any-name>.json`
+    **Path:** `/workspace/agents/#{agent_id}/outbox/<any-name>.json`
 
     **Format:**
     ```json
@@ -43,7 +42,7 @@ defmodule Shire.Agent.AgentManager do
 
     Example using Bash:
     ```bash
-    echo '{"to":"target-agent","text":"Hello, can you help me with X?"}' > /workspace/agents/#{agent_name}/outbox/msg.json
+    echo '{"to":"target-agent","text":"Hello, can you help me with X?"}' > /workspace/agents/#{agent_id}/outbox/msg.json
     ```
 
     The system delivers the message to the target agent automatically.
@@ -66,15 +65,16 @@ defmodule Shire.Agent.AgentManager do
     data, or artifacts that multiple agents need access to.
 
     ## Guidelines
-    - List `/workspace/agents/` before messaging to confirm the target agent exists
+    - Read `/workspace/peers.yaml` before messaging to confirm the target agent exists
     - Be specific about what you need from the other agent
     - Don't send messages unnecessarily — only when collaboration genuinely helps
     """
   end
 
   defstruct [
+    :agent_id,
     :agent_name,
-    :project_name,
+    :project_id,
     :command,
     :command_ref,
     :pubsub_topic,
@@ -87,13 +87,13 @@ defmodule Shire.Agent.AgentManager do
   # --- Public API ---
 
   def start_link(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
-    agent_name = Keyword.fetch!(opts, :agent_name)
-    GenServer.start_link(__MODULE__, opts, name: via(project_name, agent_name))
+    project_id = Keyword.fetch!(opts, :project_id)
+    agent_id = Keyword.fetch!(opts, :agent_id)
+    GenServer.start_link(__MODULE__, opts, name: via(project_id, agent_id))
   end
 
-  def send_message(project_name, agent_name, text, from \\ :user) do
-    GenServer.call(via(project_name, agent_name), {:send_message, text, from}, 60_000)
+  def send_message(project_id, agent_id, text, from \\ :user) do
+    GenServer.call(via(project_id, agent_id), {:send_message, text, from}, 60_000)
   end
 
   @spec get_state(atom() | pid() | {atom(), any()} | {:via, atom(), any()}) :: any()
@@ -101,26 +101,28 @@ defmodule Shire.Agent.AgentManager do
     GenServer.call(server, :get_state, 60_000)
   end
 
-  def restart(project_name, agent_name) do
-    GenServer.call(via(project_name, agent_name), :restart, 60_000)
+  def restart(project_id, agent_id) do
+    GenServer.call(via(project_id, agent_id), :restart, 60_000)
   end
 
-  defp via(project_name, agent_name) do
-    {:via, Registry, {Shire.AgentRegistry, {project_name, agent_name}, agent_name}}
+  defp via(project_id, agent_id) do
+    {:via, Registry, {Shire.AgentRegistry, {project_id, agent_id}, agent_id}}
   end
 
   # --- Callbacks ---
 
   @impl true
   def init(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
+    project_id = Keyword.fetch!(opts, :project_id)
+    agent_id = Keyword.fetch!(opts, :agent_id)
     agent_name = Keyword.fetch!(opts, :agent_name)
     skip_sprite = Keyword.get(opts, :skip_sprite, false)
 
     state = %__MODULE__{
-      project_name: project_name,
+      project_id: project_id,
+      agent_id: agent_id,
       agent_name: agent_name,
-      pubsub_topic: "project:#{project_name}:agent:#{agent_name}",
+      pubsub_topic: "project:#{project_id}:agent:#{agent_id}",
       status: :idle
     }
 
@@ -136,8 +138,8 @@ defmodule Shire.Agent.AgentManager do
     state = transition_status(state, :bootstrapping)
 
     Task.start_link(fn ->
-      result = setup_agent_workspace(state.project_name, state.agent_name)
-      GenServer.cast(via(state.project_name, state.agent_name), {:bootstrap_complete, result})
+      result = setup_agent_workspace(state.project_id, state.agent_id, state.agent_name)
+      GenServer.cast(via(state.project_id, state.agent_id), {:bootstrap_complete, result})
     end)
 
     {:noreply, state}
@@ -145,12 +147,12 @@ defmodule Shire.Agent.AgentManager do
 
   @impl true
   def handle_continue(:spawn_runner, state) do
-    agent_dir = "/workspace/agents/#{state.agent_name}"
-    kill_existing_runner(state.project_name, state.agent_name)
-    env = load_env_vars(state.project_name)
+    agent_dir = "/workspace/agents/#{state.agent_id}"
+    kill_existing_runner(state.project_id, state.agent_id)
+    env = load_env_vars(state.project_id)
 
     case @vm.spawn_command(
-           state.project_name,
+           state.project_id,
            "bun",
            ["run", "/workspace/.runner/agent-runner.ts", "--agent-dir", agent_dir],
            env: env,
@@ -178,26 +180,22 @@ defmodule Shire.Agent.AgentManager do
       "payload" => %{"text" => text}
     }
 
-    inbox_dir = "/workspace/agents/#{state.agent_name}/inbox"
+    inbox_dir = "/workspace/agents/#{state.agent_id}/inbox"
     filename = "#{envelope["ts"]}-#{random_suffix()}.json"
+    inbox_path = "#{inbox_dir}/#{filename}"
 
-    case write_inbox_file(state.project_name, "#{inbox_dir}/#{filename}", envelope) do
-      :ok ->
-        case Agents.create_message(%{
-               project_name: state.project_name,
-               agent_name: state.agent_name,
-               role: "user",
-               content: %{"text" => text}
-             }) do
-          {:ok, msg} ->
-            {:reply, {:ok, msg}, state}
-
-          {:error, reason} ->
-            Logger.warning("Failed to persist user message: #{inspect(reason)}")
-            {:reply, :ok, state}
-        end
+    case Agents.send_message_with_inbox(
+           state.project_id,
+           state.agent_id,
+           text,
+           inbox_path,
+           envelope
+         ) do
+      {:ok, msg} ->
+        {:reply, {:ok, msg}, state}
 
       {:error, reason} ->
+        Logger.warning("Failed to send message: #{inspect(reason)}")
         {:reply, {:error, reason}, state}
     end
   end
@@ -214,15 +212,22 @@ defmodule Shire.Agent.AgentManager do
 
   @impl true
   def handle_call(:restart, _from, state) do
-    kill_existing_runner(state.project_name, state.agent_name)
+    kill_existing_runner(state.project_id, state.agent_id)
+
+    # Re-fetch agent name from DB in case it was renamed
+    agent_name =
+      case Agents.get_agent(state.agent_id) do
+        {:ok, agent} -> agent.name
+        _ -> state.agent_name
+      end
 
     state =
-      %{state | command: nil, command_ref: nil}
+      %{state | command: nil, command_ref: nil, agent_name: agent_name}
       |> transition_status(:bootstrapping)
 
     Task.start_link(fn ->
-      result = setup_agent_workspace(state.project_name, state.agent_name)
-      GenServer.cast(via(state.project_name, state.agent_name), {:bootstrap_complete, result})
+      result = setup_agent_workspace(state.project_id, state.agent_id, state.agent_name)
+      GenServer.cast(via(state.project_id, state.agent_id), {:bootstrap_complete, result})
     end)
 
     {:reply, :ok, state}
@@ -242,8 +247,8 @@ defmodule Shire.Agent.AgentManager do
              "payload" => %{"from_agent" => from_agent, "text" => text}
            }} ->
             Agents.create_message(%{
-              project_name: acc.project_name,
-              agent_name: acc.agent_name,
+              project_id: acc.project_id,
+              agent_id: acc.agent_id,
               role: "inter_agent",
               content: %{
                 "text" => text,
@@ -255,20 +260,28 @@ defmodule Shire.Agent.AgentManager do
             acc
 
           {:ok, %{"type" => "spawn_agent", "payload" => %{"name" => new_name}}} ->
-            Shire.Agent.Coordinator.restart_agent(acc.project_name, new_name)
+            # Look up agent by name to get ID
+            case Agents.get_agent_by_name(acc.project_id, new_name) do
+              %{id: agent_id} ->
+                Shire.Agent.Coordinator.restart_agent(acc.project_id, agent_id)
+
+              nil ->
+                Logger.warning("spawn_agent: agent #{new_name} not found")
+            end
+
             acc
 
           {:ok, %{"type" => "processing", "payload" => %{"active" => active}}} ->
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "project:#{acc.project_name}:agents:lobby",
-              {:agent_busy, acc.agent_name, active}
+              "project:#{acc.project_id}:agents:lobby",
+              {:agent_busy, acc.agent_id, active}
             )
 
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "project:#{acc.project_name}:agent:#{acc.agent_name}",
-              {:agent_busy, acc.agent_name, active}
+              "project:#{acc.project_id}:agent:#{acc.agent_id}",
+              {:agent_busy, acc.agent_id, active}
             )
 
             acc
@@ -318,8 +331,8 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @impl true
-  def terminate(_reason, %{project_name: project_name, agent_name: agent_name} = _state) do
-    kill_existing_runner(project_name, agent_name)
+  def terminate(_reason, %{project_id: project_id, agent_id: agent_id} = _state) do
+    kill_existing_runner(project_id, agent_id)
     :ok
   end
 
@@ -341,29 +354,29 @@ defmodule Shire.Agent.AgentManager do
 
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
-      "project:#{state.project_name}:agent:#{state.agent_name}",
+      "project:#{state.project_id}:agent:#{state.agent_id}",
       {:status, status}
     )
 
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
-      "project:#{state.project_name}:agents:lobby",
-      {:agent_status, state.agent_name, status}
+      "project:#{state.project_id}:agents:lobby",
+      {:agent_status, state.agent_id, status}
     )
 
     state
   end
 
-  defp setup_agent_workspace(project_name, agent_name) do
-    agent_dir = "/workspace/agents/#{agent_name}"
+  defp setup_agent_workspace(project_id, agent_id, agent_name) do
+    agent_dir = "/workspace/agents/#{agent_id}"
 
     # Create agent directory structure
     for subdir <- ["inbox", "outbox", "scripts", "documents", ".claude/skills"] do
-      @vm.cmd(project_name, "mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
+      @vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
     end
 
     # Read recipe to determine harness type
-    recipe = read_recipe(project_name, agent_name)
+    recipe = read_recipe(project_id, agent_id)
     harness = recipe["harness"] || "claude_code"
 
     # Write comms instructions to the file the harness reads
@@ -373,10 +386,10 @@ defmodule Shire.Agent.AgentManager do
         _ -> "AGENTS.md"
       end
 
-    @vm.write(project_name, "#{agent_dir}/#{comms_file}", comms_prompt(agent_name))
+    @vm.write(project_id, "#{agent_dir}/#{comms_file}", comms_prompt(agent_name, agent_id))
 
     # Deploy skills from recipe
-    deploy_skills(project_name, recipe, agent_dir)
+    deploy_skills(project_id, recipe, agent_dir)
 
     :ok
   rescue
@@ -388,10 +401,10 @@ defmodule Shire.Agent.AgentManager do
       {:error, e}
   end
 
-  defp read_recipe(project_name, agent_name) do
-    path = "/workspace/agents/#{agent_name}/recipe.yaml"
+  defp read_recipe(project_id, agent_id) do
+    path = "/workspace/agents/#{agent_id}/recipe.yaml"
 
-    case @vm.cmd(project_name, "cat", [path], []) do
+    case @vm.cmd(project_id, "cat", [path], []) do
       {:ok, content} ->
         case YamlElixir.read_from_string(content) do
           {:ok, %{} = recipe} -> recipe
@@ -403,7 +416,7 @@ defmodule Shire.Agent.AgentManager do
     end
   end
 
-  defp deploy_skills(project_name, %{"skills" => [_ | _] = skills} = recipe, agent_dir) do
+  defp deploy_skills(project_id, %{"skills" => [_ | _] = skills} = recipe, agent_dir) do
     harness = recipe["harness"] || "claude_code"
 
     skill_base =
@@ -413,24 +426,24 @@ defmodule Shire.Agent.AgentManager do
       end
 
     # Clean stale skills from previous recipe versions
-    @vm.cmd(project_name, "rm", ["-rf", skill_base], [])
+    @vm.cmd(project_id, "rm", ["-rf", skill_base], [])
 
     for skill <- skills do
       skill_dir = "#{skill_base}/#{skill["name"]}"
-      @vm.cmd(project_name, "mkdir", ["-p", skill_dir], [])
+      @vm.cmd(project_id, "mkdir", ["-p", skill_dir], [])
 
       skill_md = build_skill_md(skill)
-      @vm.write(project_name, "#{skill_dir}/SKILL.md", skill_md)
+      @vm.write(project_id, "#{skill_dir}/SKILL.md", skill_md)
 
       for ref <- skill["references"] || [] do
-        @vm.write(project_name, "#{skill_dir}/#{ref["name"]}", ref["content"])
+        @vm.write(project_id, "#{skill_dir}/#{ref["name"]}", ref["content"])
       end
     end
 
     :ok
   end
 
-  defp deploy_skills(_project_name, _recipe, _agent_dir), do: :ok
+  defp deploy_skills(_project_id, _recipe, _agent_dir), do: :ok
 
   defp build_skill_md(skill) do
     """
@@ -443,19 +456,15 @@ defmodule Shire.Agent.AgentManager do
     """
   end
 
-  defp write_inbox_file(project_name, path, envelope) do
-    @vm.write(project_name, path, Jason.encode!(envelope))
-  end
-
   defp random_suffix do
     :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
   end
 
-  defp kill_existing_runner(project_name, agent_name) do
+  defp kill_existing_runner(project_id, agent_id) do
     @vm.cmd(
-      project_name,
+      project_id,
       "pkill",
-      ["-f", "agent-runner.ts --agent-dir /workspace/agents/#{agent_name}"],
+      ["-f", "agent-runner.ts --agent-dir /workspace/agents/#{agent_id}"],
       []
     )
 
@@ -486,8 +495,8 @@ defmodule Shire.Agent.AgentManager do
     Phoenix.PubSub.broadcast(Shire.PubSub, state.pubsub_topic, message)
   end
 
-  defp load_env_vars(project_name) do
-    case @vm.cmd(project_name, "cat", ["/workspace/.env"], []) do
+  defp load_env_vars(project_id) do
+    case @vm.cmd(project_id, "cat", ["/workspace/.env"], []) do
       {:ok, content} ->
         content
         |> String.split("\n", trim: true)
@@ -510,7 +519,7 @@ defmodule Shire.Agent.AgentManager do
   defp persist_and_broadcast(state, %{"type" => "text_delta"} = event) do
     delta = get_in(event, ["payload", "delta"]) || ""
     state = %{state | streaming_text: (state.streaming_text || "") <> delta}
-    broadcast(state, {:agent_event, state.agent_name, event})
+    broadcast(state, {:agent_event, state.agent_id, event})
     state
   end
 
@@ -525,8 +534,8 @@ defmodule Shire.Agent.AgentManager do
     input = Map.get(payload, "input", %{})
 
     case Agents.create_message(%{
-           project_name: state.project_name,
-           agent_name: state.agent_name,
+           project_id: state.project_id,
+           agent_id: state.agent_id,
            role: "tool_use",
            content: %{
              "tool" => tool,
@@ -539,12 +548,12 @@ defmodule Shire.Agent.AgentManager do
       {:ok, msg} ->
         tool_use_ids = Map.put(state.tool_use_ids, tool_use_id, msg.id)
         enriched = put_in(event, ["message"], serialize_message(msg))
-        broadcast(state, {:agent_event, state.agent_name, enriched})
+        broadcast(state, {:agent_event, state.agent_id, enriched})
         %{state | tool_use_ids: tool_use_ids}
 
       {:error, reason} ->
         Logger.warning("Failed to persist tool_use message: #{inspect(reason)}")
-        broadcast(state, {:agent_event, state.agent_name, event})
+        broadcast(state, {:agent_event, state.agent_id, event})
         state
     end
   end
@@ -562,8 +571,8 @@ defmodule Shire.Agent.AgentManager do
         tool = Map.get(payload, "tool", "unknown")
 
         case Agents.create_message(%{
-               project_name: state.project_name,
-               agent_name: state.agent_name,
+               project_id: state.project_id,
+               agent_id: state.agent_id,
                role: "tool_use",
                content: %{
                  "tool" => tool,
@@ -576,18 +585,18 @@ defmodule Shire.Agent.AgentManager do
           {:ok, msg} ->
             tool_use_ids = Map.put(state.tool_use_ids, tool_use_id, msg.id)
             enriched = put_in(event, ["message"], serialize_message(msg))
-            broadcast(state, {:agent_event, state.agent_name, enriched})
+            broadcast(state, {:agent_event, state.agent_id, enriched})
             %{state | tool_use_ids: tool_use_ids}
 
           {:error, _} ->
-            broadcast(state, {:agent_event, state.agent_name, event})
+            broadcast(state, {:agent_event, state.agent_id, event})
             state
         end
 
       db_id ->
         db_msg = Agents.get_message!(db_id)
         Agents.update_message(db_msg, %{content: Map.merge(db_msg.content, %{"input" => input})})
-        broadcast(state, {:agent_event, state.agent_name, event})
+        broadcast(state, {:agent_event, state.agent_id, event})
         state
     end
   end
@@ -609,7 +618,7 @@ defmodule Shire.Agent.AgentManager do
         })
     end
 
-    broadcast(state, {:agent_event, state.agent_name, event})
+    broadcast(state, {:agent_event, state.agent_id, event})
     %{state | tool_use_ids: Map.delete(state.tool_use_ids, tool_use_id)}
   end
 
@@ -617,17 +626,17 @@ defmodule Shire.Agent.AgentManager do
     state = flush_and_broadcast_streaming(state)
 
     case Agents.create_message(%{
-           project_name: state.project_name,
-           agent_name: state.agent_name,
+           project_id: state.project_id,
+           agent_id: state.agent_id,
            role: "agent",
            content: %{"text" => text}
          }) do
       {:ok, msg} ->
         enriched = put_in(event, ["message"], serialize_message(msg))
-        broadcast(state, {:agent_event, state.agent_name, enriched})
+        broadcast(state, {:agent_event, state.agent_id, enriched})
 
       {:error, _} ->
-        broadcast(state, {:agent_event, state.agent_name, event})
+        broadcast(state, {:agent_event, state.agent_id, event})
     end
 
     state
@@ -635,12 +644,12 @@ defmodule Shire.Agent.AgentManager do
 
   defp persist_and_broadcast(state, %{"type" => "turn_complete"} = event) do
     state = flush_and_broadcast_streaming(state)
-    broadcast(state, {:agent_event, state.agent_name, event})
+    broadcast(state, {:agent_event, state.agent_id, event})
     state
   end
 
   defp persist_and_broadcast(state, event) do
-    broadcast(state, {:agent_event, state.agent_name, event})
+    broadcast(state, {:agent_event, state.agent_id, event})
     state
   end
 
@@ -651,8 +660,8 @@ defmodule Shire.Agent.AgentManager do
 
   defp flush_and_broadcast_streaming(state) do
     case Agents.create_message(%{
-           project_name: state.project_name,
-           agent_name: state.agent_name,
+           project_id: state.project_id,
+           agent_id: state.agent_id,
            role: "agent",
            content: %{"text" => state.streaming_text}
          }) do
@@ -663,7 +672,7 @@ defmodule Shire.Agent.AgentManager do
           "message" => serialize_message(msg)
         }
 
-        broadcast(state, {:agent_event, state.agent_name, flush_event})
+        broadcast(state, {:agent_event, state.agent_id, flush_event})
 
       {:error, _} ->
         :ok

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -28,24 +28,28 @@ defmodule Shire.Agent.AgentManager do
     Read `/workspace/peers.yaml` to see available agents and their descriptions.
 
     ## Sending Messages
-    To message another agent, write a JSON file to your **outbox**:
+    To message another agent, write a YAML file to your **outbox**:
 
-    **Path:** `/workspace/agents/#{agent_id}/outbox/<any-name>.json`
+    **Path:** `/workspace/agents/#{agent_id}/outbox/<any-name>.yaml`
 
     **Format:**
-    ```json
-    {
-      "to": "<target-agent-name>",
-      "text": "<your message>"
-    }
+    ```yaml
+    to: <target-agent-name>
+    text: "<your message>"
     ```
 
     Example using Bash:
     ```bash
-    echo '{"to":"target-agent","text":"Hello, can you help me with X?"}' > /workspace/agents/#{agent_id}/outbox/msg.json
+    cat > /workspace/agents/#{agent_id}/outbox/msg.yaml <<'EOF'
+    to: target-agent
+    text: "Hello, can you help me with X?"
+    EOF
     ```
 
+    **Note:** Always quote the `text` value if it contains special characters like `:`, `#`, `{`, `}`, or newlines.
+
     The system delivers the message to the target agent automatically.
+    If your message is invalid (unparseable YAML or missing required fields), you will receive a system notification with the error details.
 
     ## Receiving Messages
     Messages arrive in your conversation automatically:
@@ -181,7 +185,7 @@ defmodule Shire.Agent.AgentManager do
     }
 
     inbox_dir = "/workspace/agents/#{state.agent_id}/inbox"
-    filename = "#{envelope["ts"]}-#{random_suffix()}.json"
+    filename = "#{envelope["ts"]}-#{random_suffix()}.yaml"
     inbox_path = "#{inbox_dir}/#{filename}"
 
     case Agents.send_message_with_inbox(
@@ -256,6 +260,32 @@ defmodule Shire.Agent.AgentManager do
                 "to_agent" => acc.agent_name
               }
             })
+
+            acc
+
+          {:ok,
+           %{
+             "type" => "system_message_received",
+             "payload" => %{"text" => text}
+           }} ->
+            case Agents.create_message(%{
+                   project_id: acc.project_id,
+                   agent_id: acc.agent_id,
+                   role: "system",
+                   content: %{"text" => text}
+                 }) do
+              {:ok, msg} ->
+                event = %{
+                  "type" => "system_message",
+                  "payload" => %{"text" => text},
+                  "message" => serialize_message(msg)
+                }
+
+                broadcast(acc, {:agent_event, acc.agent_id, event})
+
+              {:error, _} ->
+                :ok
+            end
 
             acc
 

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -7,91 +7,91 @@ defmodule Shire.Agent.Coordinator do
   use GenServer
   require Logger
 
+  alias Shire.Agents
   alias Shire.Agent.AgentManager
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
   def start_link(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
-    GenServer.start_link(__MODULE__, opts, name: via(project_name))
+    project_id = Keyword.fetch!(opts, :project_id)
+    GenServer.start_link(__MODULE__, opts, name: via(project_id))
   end
 
-  defp via(project_name) do
-    {:via, Registry, {Shire.ProjectRegistry, {:coordinator, project_name}}}
+  defp via(project_id) do
+    {:via, Registry, {Shire.ProjectRegistry, {:coordinator, project_id}}}
   end
 
   # --- Public API ---
 
   @doc "Returns the current status for an agent (defaults to :created if not tracked)."
-  def agent_status(project_name, agent_name) do
-    GenServer.call(via(project_name), {:agent_status, agent_name})
+  def agent_status(project_id, agent_id) do
+    GenServer.call(via(project_id), {:agent_status, agent_id})
   end
 
-  @doc "Returns a map of `%{agent_name => status}` for the given agent names."
-  def agent_statuses(project_name, agent_names) do
-    GenServer.call(via(project_name), {:agent_statuses, agent_names})
+  @doc "Returns a map of `%{agent_id => status}` for the given agent IDs."
+  def agent_statuses(project_id, agent_ids) do
+    GenServer.call(via(project_id), {:agent_statuses, agent_ids})
   end
 
-  @doc "Creates a new agent: writes recipe.yaml on VM and starts runner."
-  def create_agent(project_name, attrs) do
-    GenServer.call(via(project_name), {:create_agent, attrs}, 60_000)
+  @doc "Creates a new agent: inserts DB record, sets up VM workspace, and starts runner."
+  def create_agent(project_id, attrs) do
+    GenServer.call(via(project_id), {:create_agent, attrs}, 60_000)
   end
 
   @doc "Updates an agent's recipe.yaml on the VM."
-  def update_agent(project_name, agent_name, attrs) do
-    GenServer.call(via(project_name), {:update_agent, agent_name, attrs}, 30_000)
+  def update_agent(project_id, agent_id, attrs) do
+    GenServer.call(via(project_id), {:update_agent, agent_id, attrs}, 30_000)
   end
 
-  def delete_agent(project_name, agent_name) do
-    GenServer.call(via(project_name), {:delete_agent, agent_name}, 30_000)
+  def delete_agent(project_id, agent_id) do
+    GenServer.call(via(project_id), {:delete_agent, agent_id}, 30_000)
   end
 
-  def restart_agent(project_name, agent_name) do
-    GenServer.call(via(project_name), {:restart_agent, agent_name}, 60_000)
+  def restart_agent(project_id, agent_id) do
+    GenServer.call(via(project_id), {:restart_agent, agent_id}, 60_000)
   end
 
-  def send_message(project_name, agent_name, text) do
-    AgentManager.send_message(project_name, agent_name, text, :user)
+  def send_message(project_id, agent_id, text) do
+    AgentManager.send_message(project_id, agent_id, text, :user)
   end
 
-  @doc "Look up a running agent's pid by name within a project."
-  def lookup(project_name, agent_name) do
-    case Registry.lookup(Shire.AgentRegistry, {project_name, agent_name}) do
+  @doc "Look up a running agent's pid by ID within a project."
+  def lookup(project_id, agent_id) do
+    case Registry.lookup(Shire.AgentRegistry, {project_id, agent_id}) do
       [{pid, _}] -> {:ok, pid}
       [] -> {:error, :not_found}
     end
   end
 
-  @doc "Returns all running agent names for a project."
-  def list_running(project_name) do
+  @doc "Returns all running agent IDs for a project."
+  def list_running(project_id) do
     Registry.select(Shire.AgentRegistry, [
-      {{{project_name, :"$1"}, :"$2", :_}, [], [:"$1"]}
+      {{{project_id, :"$1"}, :"$2", :_}, [], [:"$1"]}
     ])
   end
 
   @doc """
-  Lists agents by scanning `/workspace/agents/` on the VM.
-  Returns `[%{name: name, ...}]` for each agent directory with a recipe.yaml.
+  Lists agents from the DB for this project, merged with runtime statuses.
   """
-  def list_agents(project_name) do
-    GenServer.call(via(project_name), :list_agents, 30_000)
+  def list_agents(project_id) do
+    GenServer.call(via(project_id), :list_agents, 30_000)
   end
 
-  @doc "Reads an agent's recipe.yaml from the VM."
-  def get_agent(project_name, agent_name) do
-    GenServer.call(via(project_name), {:get_agent, agent_name}, 15_000)
+  @doc "Gets an agent's details: DB record + recipe.yaml from VM."
+  def get_agent(project_id, agent_id) do
+    GenServer.call(via(project_id), {:get_agent, agent_id}, 15_000)
   end
 
   # --- Callbacks ---
 
   @impl true
   def init(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
+    project_id = Keyword.fetch!(opts, :project_id)
 
-    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_name}:agents:lobby")
+    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
 
     state = %{
-      project_name: project_name,
+      project_id: project_id,
       monitors: %{},
       statuses: %{}
     }
@@ -101,52 +101,70 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_continue(:deploy_and_scan, state) do
-    case Shire.WorkspaceSettings.bootstrap_workspace(state.project_name) do
+    case Shire.WorkspaceSettings.bootstrap_workspace(state.project_id) do
       :ok -> :ok
       {:error, reason} -> Logger.error("Bootstrap failed: #{inspect(reason)}")
     end
 
-    case deploy_runner(state.project_name) do
+    case deploy_runner(state.project_id) do
       :ok -> :ok
       {:error, reason} -> Logger.error("Runner deployment failed: #{inspect(reason)}")
     end
 
-    {:ok, agent_names} = scan_agent_dirs(state.project_name)
+    # Write peers.yaml before starting any agents
+    write_peers_yaml(state.project_id)
+
+    # Get agents from DB and start managers for those with folders on VM
+    db_agents = Agents.list_agents(state.project_id)
 
     monitors =
-      Enum.reduce(agent_names, state.monitors, fn name, acc ->
-        case start_agent_manager(state.project_name, name, acc) do
+      Enum.reduce(db_agents, state.monitors, fn agent, acc ->
+        case start_agent_manager(state.project_id, agent.id, agent.name, acc) do
           {:ok, _pid, updated_monitors} -> updated_monitors
           {:error, _} -> acc
         end
       end)
 
-    Logger.info(
-      "Project #{state.project_name}: scanned and started #{length(agent_names)} agents"
-    )
+    Logger.info("Project #{state.project_id}: started #{map_size(monitors)} agents")
 
     {:noreply, %{state | monitors: monitors}}
   end
 
   @impl true
   def handle_call({:create_agent, %{"name" => name, "recipe_yaml" => recipe_yaml}}, _from, state) do
-    agent_dir = "/workspace/agents/#{name}"
+    case Agents.create_agent_with_vm(state.project_id, name, recipe_yaml) do
+      {:ok, agent} ->
+        # Post-commit: write peers.yaml and start agent manager
+        write_peers_yaml(state.project_id)
 
-    case @vm.cmd(
-           state.project_name,
-           "bash",
-           ["-c", "test -d #{agent_dir} && echo exists || echo missing"],
-           []
-         ) do
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+        case start_agent_manager(state.project_id, agent.id, agent.name, state.monitors) do
+          {:ok, pid, monitors} ->
+            Phoenix.PubSub.broadcast(
+              Shire.PubSub,
+              "project:#{state.project_id}:agents:lobby",
+              {:agent_created, agent.id}
+            )
 
-      {:ok, output} ->
-        if String.trim(output) == "exists" do
+            {:reply, {:ok, pid}, %{state | monitors: monitors}}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        unique_error? =
+          Enum.any?(changeset.errors, fn {_field, {_msg, opts}} ->
+            opts[:constraint] == :unique
+          end)
+
+        if unique_error? do
           {:reply, {:error, :already_exists}, state}
         else
-          create_agent_on_vm(name, agent_dir, recipe_yaml, state)
+          {:reply, {:error, changeset}, state}
         end
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
     end
   end
 
@@ -156,46 +174,70 @@ defmodule Shire.Agent.Coordinator do
   end
 
   @impl true
-  def handle_call({:update_agent, name, %{"recipe_yaml" => recipe_yaml}}, _from, state) do
-    new_name = extract_name_from_yaml(recipe_yaml)
+  def handle_call({:update_agent, agent_id, %{"recipe_yaml" => recipe_yaml}}, _from, state) do
+    case Agents.get_agent(agent_id) do
+      {:ok, agent} ->
+        new_name = extract_name_from_yaml(recipe_yaml)
 
-    if new_name && new_name != name do
-      rename_agent(name, new_name, recipe_yaml, state)
-    else
-      agent_dir = "/workspace/agents/#{name}"
+        # Update DB name if it changed
+        name_changed = new_name && new_name != agent.name
 
-      case @vm.write(state.project_name, "#{agent_dir}/recipe.yaml", recipe_yaml) do
-        :ok ->
-          case lookup(state.project_name, name) do
-            {:ok, _pid} -> AgentManager.restart(state.project_name, name)
+        with :ok <- maybe_rename(agent, new_name, name_changed),
+             :ok <-
+               @vm.write(
+                 state.project_id,
+                 "/workspace/agents/#{agent_id}/recipe.yaml",
+                 recipe_yaml
+               ) do
+          case lookup(state.project_id, agent_id) do
+            {:ok, _pid} -> AgentManager.restart(state.project_id, agent_id)
             {:error, :not_found} -> :ok
           end
 
+          # Rewrite peers.yaml in case name or description changed
+          write_peers_yaml(state.project_id)
+
+          event =
+            if name_changed,
+              do: {:agent_renamed, agent_id, agent.name, new_name},
+              else: {:agent_updated, agent_id}
+
           Phoenix.PubSub.broadcast(
             Shire.PubSub,
-            "project:#{state.project_name}:agents:lobby",
-            {:agent_updated, name}
+            "project:#{state.project_id}:agents:lobby",
+            event
           )
 
-          {:reply, :ok, state}
+          # Also broadcast on agent-specific topic so show page gets the event
+          if name_changed do
+            Phoenix.PubSub.broadcast(
+              Shire.PubSub,
+              "project:#{state.project_id}:agent:#{agent_id}",
+              event
+            )
+          end
 
-        {:error, reason} ->
-          {:reply, {:error, reason}, state}
-      end
+          {:reply, :ok, state}
+        else
+          {:error, reason} -> {:reply, {:error, reason}, state}
+        end
+
+      {:error, :not_found} ->
+        {:reply, {:error, :not_found}, state}
     end
   end
 
   @impl true
-  def handle_call({:update_agent, _name, _attrs}, _from, state) do
+  def handle_call({:update_agent, _agent_id, _attrs}, _from, state) do
     {:reply, {:error, :missing_recipe_yaml}, state}
   end
 
   @impl true
-  def handle_call({:delete_agent, agent_name}, _from, state) do
+  def handle_call({:delete_agent, agent_id}, _from, state) do
     # Stop the process if running
-    case lookup(state.project_name, agent_name) do
+    case lookup(state.project_id, agent_id) do
       {:ok, pid} ->
-        agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, state.project_name}}}
+        agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, state.project_id}}}
         DynamicSupervisor.terminate_child(agent_sup, pid)
 
       {:error, :not_found} ->
@@ -204,40 +246,47 @@ defmodule Shire.Agent.Coordinator do
 
     # Clean up monitor
     {ref, monitors} =
-      Enum.find_value(state.monitors, {nil, state.monitors}, fn {ref, name} ->
-        if name == agent_name, do: {ref, Map.delete(state.monitors, ref)}
+      Enum.find_value(state.monitors, {nil, state.monitors}, fn {ref, id} ->
+        if id == agent_id, do: {ref, Map.delete(state.monitors, ref)}
       end)
 
     if ref, do: Process.demonitor(ref, [:flush])
 
-    # Remove agent directory from VM
-    case @vm.cmd(state.project_name, "rm", ["-rf", "/workspace/agents/#{agent_name}"], []) do
-      {:ok, _} ->
-        :ok
+    # Delete agent (Multi: rm folder + delete DB record)
+    case Agents.get_agent(agent_id) do
+      {:ok, agent} ->
+        case Agents.delete_agent_with_vm(state.project_id, agent) do
+          :ok ->
+            # Post-commit: rewrite peers.yaml
+            write_peers_yaml(state.project_id)
 
-      {:error, reason} ->
-        Logger.warning("Failed to remove agent dir for #{agent_name}: #{inspect(reason)}")
+            statuses = Map.delete(state.statuses, agent_id)
+            Logger.info("Deleted agent #{agent_id}")
+
+            Phoenix.PubSub.broadcast(
+              Shire.PubSub,
+              "project:#{state.project_id}:agents:lobby",
+              {:agent_deleted, agent_id}
+            )
+
+            {:reply, :ok, %{state | monitors: monitors, statuses: statuses}}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, %{state | monitors: monitors}}
+        end
+
+      {:error, :not_found} ->
+        {:reply, {:error, :not_found}, %{state | monitors: monitors}}
     end
-
-    statuses = Map.delete(state.statuses, agent_name)
-    Logger.info("Deleted agent #{agent_name}")
-
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "project:#{state.project_name}:agents:lobby",
-      {:agent_deleted, agent_name}
-    )
-
-    {:reply, :ok, %{state | monitors: monitors, statuses: statuses}}
   end
 
   @impl true
-  def handle_call({:restart_agent, agent_name}, _from, state) do
-    case lookup(state.project_name, agent_name) do
+  def handle_call({:restart_agent, agent_id}, _from, state) do
+    case lookup(state.project_id, agent_id) do
       {:ok, _pid} ->
-        case AgentManager.restart(state.project_name, agent_name) do
+        case AgentManager.restart(state.project_id, agent_id) do
           :ok ->
-            Logger.info("Restarting agent #{agent_name}")
+            Logger.info("Restarting agent #{agent_id}")
             {:reply, :ok, state}
 
           {:error, reason} ->
@@ -245,49 +294,57 @@ defmodule Shire.Agent.Coordinator do
         end
 
       {:error, :not_found} ->
-        case start_agent_manager(state.project_name, agent_name, state.monitors) do
-          {:ok, _pid, monitors} ->
-            Logger.info("Started agent #{agent_name} (was not running)")
-            {:reply, :ok, %{state | monitors: monitors}}
+        # Get agent name from DB
+        case Agents.get_agent(agent_id) do
+          {:ok, agent} ->
+            case start_agent_manager(state.project_id, agent.id, agent.name, state.monitors) do
+              {:ok, _pid, monitors} ->
+                Logger.info("Started agent #{agent_id} (was not running)")
+                {:reply, :ok, %{state | monitors: monitors}}
 
-          {:error, reason} ->
-            {:reply, {:error, reason}, state}
+              {:error, reason} ->
+                {:reply, {:error, reason}, state}
+            end
+
+          {:error, :not_found} ->
+            {:reply, {:error, :not_found}, state}
         end
     end
   end
 
   @impl true
-  def handle_call({:agent_status, agent_name}, _from, state) do
-    {:reply, Map.get(state.statuses, agent_name, :created), state}
+  def handle_call({:agent_status, agent_id}, _from, state) do
+    {:reply, Map.get(state.statuses, agent_id, :created), state}
   end
 
   @impl true
-  def handle_call({:agent_statuses, agent_names}, _from, state) do
-    result = Map.new(agent_names, fn name -> {name, Map.get(state.statuses, name, :created)} end)
+  def handle_call({:agent_statuses, agent_ids}, _from, state) do
+    result = Map.new(agent_ids, fn id -> {id, Map.get(state.statuses, id, :created)} end)
     {:reply, result, state}
   end
 
   @impl true
   def handle_call(:list_agents, _from, state) do
-    {:ok, names} = scan_agent_dirs(state.project_name)
-
     agents =
-      Enum.map(names, fn name ->
-        status = Map.get(state.statuses, name, :created)
-        %{name: name, status: status}
+      Agents.list_agents(state.project_id)
+      |> Enum.map(fn agent ->
+        status = Map.get(state.statuses, agent.id, :created)
+        %{id: agent.id, name: agent.name, status: status}
       end)
 
     {:reply, agents, state}
   end
 
   @impl true
-  def handle_call({:get_agent, agent_name}, _from, state) do
-    case read_agent_recipe(state.project_name, agent_name) do
-      {:ok, recipe} ->
-        status = Map.get(state.statuses, agent_name, :created)
+  def handle_call({:get_agent, agent_id}, _from, state) do
+    case Agents.get_agent(agent_id) do
+      {:ok, agent} ->
+        recipe = read_agent_recipe(state.project_id, agent_id)
+        status = Map.get(state.statuses, agent_id, :created)
 
-        agent = %{
-          name: recipe["name"] || agent_name,
+        agent_data = %{
+          id: agent.id,
+          name: agent.name,
           description: recipe["description"],
           harness: recipe["harness"] || "claude_code",
           model: recipe["model"],
@@ -296,32 +353,32 @@ defmodule Shire.Agent.Coordinator do
           status: status
         }
 
-        {:reply, {:ok, agent}, state}
+        {:reply, {:ok, agent_data}, state}
 
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+      {:error, :not_found} ->
+        {:reply, {:error, :not_found}, state}
     end
   end
 
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
-    {agent_name, monitors} = Map.pop(state.monitors, ref)
+    {agent_id, monitors} = Map.pop(state.monitors, ref)
 
-    if agent_name do
-      Logger.warning("Agent #{agent_name} process died: #{inspect(reason)}")
+    if agent_id do
+      Logger.warning("Agent #{agent_id} process died: #{inspect(reason)}")
 
-      statuses = Map.put(state.statuses, agent_name, :crashed)
+      statuses = Map.put(state.statuses, agent_id, :crashed)
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{state.project_name}:agent:#{agent_name}",
+        "project:#{state.project_id}:agent:#{agent_id}",
         {:status, :crashed}
       )
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{state.project_name}:agents:lobby",
-        {:agent_status, agent_name, :crashed}
+        "project:#{state.project_id}:agents:lobby",
+        {:agent_status, agent_id, :crashed}
       )
 
       {:noreply, %{state | monitors: monitors, statuses: statuses}}
@@ -331,18 +388,18 @@ defmodule Shire.Agent.Coordinator do
   end
 
   @impl true
-  def handle_info({:agent_status, agent_name, status}, state) do
-    statuses = Map.put(state.statuses, agent_name, status)
+  def handle_info({:agent_status, agent_id, status}, state) do
+    statuses = Map.put(state.statuses, agent_id, status)
     {:noreply, %{state | statuses: statuses}}
   end
 
   @impl true
-  def handle_info({:agent_busy, _agent_name, _active}, state) do
+  def handle_info({:agent_busy, _agent_id, _active}, state) do
     {:noreply, state}
   end
 
   @impl true
-  def handle_info({:agent_created, _name}, state) do
+  def handle_info({:agent_created, _id}, state) do
     {:noreply, state}
   end
 
@@ -354,15 +411,15 @@ defmodule Shire.Agent.Coordinator do
 
   # --- Private ---
 
-  defp deploy_runner(project_name) do
+  defp deploy_runner(project_id) do
     runner_dir = Application.app_dir(:shire, "priv/sprite")
 
     content = File.read!(Path.join(runner_dir, "agent-runner.ts"))
 
-    with :ok <- @vm.write(project_name, "/workspace/.runner/agent-runner.ts", content),
-         :ok <- deploy_harness(project_name, runner_dir),
+    with :ok <- @vm.write(project_id, "/workspace/.runner/agent-runner.ts", content),
+         :ok <- deploy_harness(project_id, runner_dir),
          {:ok, _} <-
-           @vm.cmd(project_name, "bash", ["-c", "cd /workspace/.runner && bun install"],
+           @vm.cmd(project_id, "bash", ["-c", "cd /workspace/.runner && bun install"],
              timeout: 120_000
            ) do
       :ok
@@ -371,15 +428,15 @@ defmodule Shire.Agent.Coordinator do
     end
   end
 
-  defp deploy_harness(project_name, runner_dir) do
+  defp deploy_harness(project_id, runner_dir) do
     harness_dir = Path.join(runner_dir, "harness")
 
     if File.dir?(harness_dir) do
-      with {:ok, _} <- @vm.cmd(project_name, "mkdir", ["-p", "/workspace/.runner/harness"], []) do
+      with {:ok, _} <- @vm.cmd(project_id, "mkdir", ["-p", "/workspace/.runner/harness"], []) do
         Enum.reduce_while(File.ls!(harness_dir), :ok, fn file, :ok ->
           content = File.read!(Path.join(harness_dir, file))
 
-          case @vm.write(project_name, "/workspace/.runner/harness/#{file}", content) do
+          case @vm.write(project_id, "/workspace/.runner/harness/#{file}", content) do
             :ok -> {:cont, :ok}
             {:error, reason} -> {:halt, {:error, reason}}
           end
@@ -390,77 +447,35 @@ defmodule Shire.Agent.Coordinator do
     end
   end
 
-  defp scan_agent_dirs(project_name) do
-    cmd = ~s(for d in /workspace/agents/*/; do test -f "$d/recipe.yaml" && basename "$d"; done)
-
-    case @vm.cmd(project_name, "bash", ["-c", cmd], []) do
-      {:ok, output} ->
-        names = String.split(output, "\n", trim: true)
-        {:ok, names}
-
-      {:error, _} ->
-        {:ok, []}
-    end
-  rescue
-    e ->
-      Logger.error("scan_agent_dirs crashed: #{inspect(e)}")
-      {:ok, []}
-  end
-
-  defp read_agent_recipe(project_name, agent_name) do
-    path = "/workspace/agents/#{agent_name}/recipe.yaml"
+  defp read_agent_recipe(project_id, agent_id) do
+    path = "/workspace/agents/#{agent_id}/recipe.yaml"
 
     case @vm.cmd(
-           project_name,
+           project_id,
            "bash",
            ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"],
            []
          ) do
-      {:error, reason} ->
-        {:error, reason}
-
       {:ok, output} ->
         if String.trim(output) == "__NOT_FOUND__" do
-          {:error, :not_found}
+          %{}
         else
           case YamlElixir.read_from_string(output) do
-            {:ok, recipe} -> {:ok, recipe}
-            {:error, reason} -> {:error, reason}
+            {:ok, recipe} ->
+              recipe
+
+            {:error, reason} ->
+              Logger.warning(
+                "Failed to parse recipe YAML for agent #{agent_id}: #{inspect(reason)}"
+              )
+
+              %{}
           end
         end
-    end
-  end
 
-  defp create_agent_on_vm(name, agent_dir, recipe_yaml, state) do
-    mkdir_results =
-      Enum.map(["inbox", "outbox", "scripts", "documents"], fn subdir ->
-        @vm.cmd(state.project_name, "mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
-      end)
-
-    case Enum.find(mkdir_results, &match?({:error, _}, &1)) do
       {:error, reason} ->
-        {:reply, {:error, reason}, state}
-
-      nil ->
-        case @vm.write(state.project_name, "#{agent_dir}/recipe.yaml", recipe_yaml) do
-          :ok ->
-            case start_agent_manager(state.project_name, name, state.monitors) do
-              {:ok, pid, monitors} ->
-                Phoenix.PubSub.broadcast(
-                  Shire.PubSub,
-                  "project:#{state.project_name}:agents:lobby",
-                  {:agent_created, name}
-                )
-
-                {:reply, {:ok, pid}, %{state | monitors: monitors}}
-
-              {:error, reason} ->
-                {:reply, {:error, reason}, state}
-            end
-
-          {:error, reason} ->
-            {:reply, {:error, reason}, state}
-        end
+        Logger.warning("Failed to read recipe for agent #{agent_id}: #{inspect(reason)}")
+        %{}
     end
   end
 
@@ -471,100 +486,64 @@ defmodule Shire.Agent.Coordinator do
     end
   end
 
-  defp rename_agent(old_name, new_name, recipe_yaml, state) do
-    new_dir = "/workspace/agents/#{new_name}"
+  defp maybe_rename(_agent, _new_name, false), do: :ok
 
-    case @vm.cmd(
-           state.project_name,
-           "bash",
-           ["-c", "test -d #{new_dir} && echo exists || echo missing"],
-           []
-         ) do
-      {:ok, output} ->
-        if String.trim(output) == "exists" do
-          {:reply, {:error, :already_exists}, state}
-        else
-          do_rename_agent(old_name, new_name, recipe_yaml, state)
-        end
-
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+  defp maybe_rename(agent, new_name, true) do
+    case Agents.rename_agent(agent, new_name) do
+      {:ok, _updated} -> :ok
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  defp do_rename_agent(old_name, new_name, recipe_yaml, state) do
-    old_dir = "/workspace/agents/#{old_name}"
-    new_dir = "/workspace/agents/#{new_name}"
-
-    # Stop old AgentManager if running
-    case lookup(state.project_name, old_name) do
-      {:ok, pid} ->
-        agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, state.project_name}}}
-        DynamicSupervisor.terminate_child(agent_sup, pid)
-
-      {:error, :not_found} ->
-        :ok
-    end
-
-    # Clean up old monitor
-    {ref, monitors} =
-      Enum.find_value(state.monitors, {nil, state.monitors}, fn {ref, name} ->
-        if name == old_name, do: {ref, Map.delete(state.monitors, ref)}
-      end)
-
-    if ref, do: Process.demonitor(ref, [:flush])
-
-    # Rename directory on VM
-    case @vm.cmd(state.project_name, "mv", [old_dir, new_dir], []) do
-      {:ok, _} ->
-        @vm.write(state.project_name, "#{new_dir}/recipe.yaml", recipe_yaml)
-
-        Shire.Agents.rename_agent_messages(state.project_name, old_name, new_name)
-
-        statuses = state.statuses |> Map.delete(old_name)
-
-        case start_agent_manager(state.project_name, new_name, monitors) do
-          {:ok, _pid, monitors} ->
-            Phoenix.PubSub.broadcast(
-              Shire.PubSub,
-              "project:#{state.project_name}:agents:lobby",
-              {:agent_renamed, old_name, new_name}
-            )
-
-            {:reply, :ok, %{state | monitors: monitors, statuses: statuses}}
-
-          {:error, reason} ->
-            Logger.warning(
-              "Renamed #{old_name} -> #{new_name} but failed to start: #{inspect(reason)}"
-            )
-
-            Phoenix.PubSub.broadcast(
-              Shire.PubSub,
-              "project:#{state.project_name}:agents:lobby",
-              {:agent_renamed, old_name, new_name}
-            )
-
-            {:reply, :ok, %{state | monitors: monitors, statuses: statuses}}
-        end
-
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-    end
-  end
-
-  defp start_agent_manager(project_name, agent_name, monitors) do
-    opts = [project_name: project_name, agent_name: agent_name]
-    agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_name}}}
+  defp start_agent_manager(project_id, agent_id, agent_name, monitors) do
+    opts = [project_id: project_id, agent_id: agent_id, agent_name: agent_name]
+    agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}}
 
     case DynamicSupervisor.start_child(agent_sup, {AgentManager, opts}) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
-        monitors = Map.put(monitors, ref, agent_name)
-        Logger.info("Started agent #{agent_name} (project: #{project_name})")
+        monitors = Map.put(monitors, ref, agent_id)
+        Logger.info("Started agent #{agent_name} (#{agent_id}) in project #{project_id}")
         {:ok, pid, monitors}
 
       {:error, reason} ->
-        Logger.error("Failed to start agent #{agent_name}: #{inspect(reason)}")
+        Logger.error("Failed to start agent #{agent_name} (#{agent_id}): #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc false
+  def write_peers_yaml(project_id) do
+    agents = Agents.list_agents(project_id)
+
+    peers =
+      Enum.map(agents, fn agent ->
+        recipe = read_agent_recipe(project_id, agent.id)
+
+        %{
+          "id" => agent.id,
+          "name" => agent.name,
+          "description" => recipe["description"] || ""
+        }
+      end)
+
+    yaml_content =
+      case peers do
+        [] ->
+          "# No agents configured\n"
+
+        _ ->
+          Enum.map_join(peers, "\n", fn peer ->
+            "- id: #{peer["id"]}\n  name: #{Jason.encode!(peer["name"])}\n  description: #{Jason.encode!(peer["description"])}"
+          end) <> "\n"
+      end
+
+    case @vm.write(project_id, "/workspace/peers.yaml", yaml_content) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to write peers.yaml: #{inspect(reason)}")
         {:error, reason}
     end
   end

--- a/lib/shire/agent/terminal_session.ex
+++ b/lib/shire/agent/terminal_session.ex
@@ -9,50 +9,50 @@ defmodule Shire.Agent.TerminalSession do
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
-  defstruct [:project_name, :command, :command_ref, :pubsub_topic]
+  defstruct [:project_id, :command, :command_ref, :pubsub_topic]
 
   # --- Public API ---
 
   def start_link(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
-    GenServer.start_link(__MODULE__, opts, name: via(project_name))
+    project_id = Keyword.fetch!(opts, :project_id)
+    GenServer.start_link(__MODULE__, opts, name: via(project_id))
   end
 
-  def write(project_name, data) do
-    GenServer.cast(via(project_name), {:write, data})
+  def write(project_id, data) do
+    GenServer.cast(via(project_id), {:write, data})
   end
 
-  def resize(project_name, rows, cols) do
-    GenServer.cast(via(project_name), {:resize, rows, cols})
+  def resize(project_id, rows, cols) do
+    GenServer.cast(via(project_id), {:resize, rows, cols})
   end
 
-  def stop(project_name) do
-    GenServer.stop(via(project_name))
+  def stop(project_id) do
+    GenServer.stop(via(project_id))
   end
 
-  def find(project_name) do
-    case Registry.lookup(Shire.ProjectRegistry, {:terminal, project_name}) do
+  def find(project_id) do
+    case Registry.lookup(Shire.ProjectRegistry, {:terminal, project_id}) do
       [{pid, _}] -> {:ok, pid}
       [] -> :error
     end
   end
 
-  defp via(project_name) do
-    {:via, Registry, {Shire.ProjectRegistry, {:terminal, project_name}}}
+  defp via(project_id) do
+    {:via, Registry, {Shire.ProjectRegistry, {:terminal, project_id}}}
   end
 
   # --- Callbacks ---
 
   @impl true
   def init(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
+    project_id = Keyword.fetch!(opts, :project_id)
 
     state = %__MODULE__{
-      project_name: project_name,
-      pubsub_topic: "project:#{project_name}:terminal"
+      project_id: project_id,
+      pubsub_topic: "project:#{project_id}:terminal"
     }
 
-    case @vm.spawn_command(project_name, "bash", ["-i"],
+    case @vm.spawn_command(project_id, "bash", ["-i"],
            tty: true,
            stdin: true,
            tty_rows: 24,
@@ -86,14 +86,14 @@ defmodule Shire.Agent.TerminalSession do
 
   @impl true
   def handle_info({:exit, %{ref: ref}, code}, %{command_ref: ref} = state) do
-    Logger.info("Terminal session exited with code #{code} (project: #{state.project_name})")
+    Logger.info("Terminal session exited with code #{code} (project: #{state.project_id})")
     broadcast(state, {:terminal_exit, code})
     {:stop, :normal, state}
   end
 
   @impl true
   def handle_info({:error, %{ref: ref}, reason}, %{command_ref: ref} = state) do
-    Logger.error("Terminal session error (project: #{state.project_name}): #{inspect(reason)}")
+    Logger.error("Terminal session error (project: #{state.project_id}): #{inspect(reason)}")
     broadcast(state, {:terminal_exit, 1})
     {:stop, :normal, state}
   end

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -1,15 +1,129 @@
 defmodule Shire.Agents do
   import Ecto.Query
+  require Logger
+  alias Ecto.Multi
   alias Shire.Repo
-  alias Shire.Agents.Message
+  alias Shire.Agents.{Agent, Message}
 
-  # Message CRUD
+  @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
+
+  # --- Agent CRUD ---
+
+  @doc """
+  Creates an agent record and sets up its workspace on the VM.
+  Uses Ecto.Multi to ensure DB and VM operations are atomic.
+  """
+  def create_agent_with_vm(project_id, name, recipe_yaml, vm \\ @vm) do
+    Multi.new()
+    |> Multi.insert(:agent, Agent.changeset(%Agent{}, %{name: name, project_id: project_id}))
+    |> Multi.run(:vm_setup, fn _repo, %{agent: agent} ->
+      agent_dir = "/workspace/agents/#{agent.id}"
+
+      with {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/inbox"], []),
+           {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/outbox"], []),
+           {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/scripts"], []),
+           {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/documents"], []),
+           :ok <- vm.write(project_id, "#{agent_dir}/recipe.yaml", recipe_yaml) do
+        {:ok, agent.id}
+      else
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{agent: agent}} -> {:ok, agent}
+      {:error, :agent, changeset, _} -> {:error, changeset}
+      {:error, :vm_setup, reason, _} -> {:error, reason}
+    end
+  end
+
+  @doc "Renames an agent in the database."
+  def rename_agent(%Agent{} = agent, new_name) do
+    agent
+    |> Agent.changeset(%{name: new_name})
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes an agent and removes its workspace from the VM.
+  Uses Ecto.Multi to ensure DB and VM operations are atomic.
+  """
+  def delete_agent_with_vm(project_id, %Agent{} = agent, vm \\ @vm) do
+    Multi.new()
+    |> Multi.delete(:agent, agent)
+    |> Multi.run(:rm_folder, fn _repo, _ ->
+      case vm.cmd(project_id, "rm", ["-rf", "/workspace/agents/#{agent.id}"], []) do
+        {:ok, _} ->
+          {:ok, :removed}
+
+        {:error, reason} ->
+          Logger.warning(
+            "Failed to remove agent directory /workspace/agents/#{agent.id}: #{inspect(reason)}"
+          )
+
+          {:ok, :cleanup_failed}
+      end
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, _} -> :ok
+      {:error, :agent, changeset, _} -> {:error, changeset}
+    end
+  end
+
+  def get_agent!(id), do: Repo.get!(Agent, id)
+
+  def get_agent(id) do
+    case Repo.get(Agent, id) do
+      nil -> {:error, :not_found}
+      agent -> {:ok, agent}
+    end
+  end
+
+  def get_agent_by_name(project_id, name) do
+    Repo.get_by(Agent, project_id: project_id, name: name)
+  end
+
+  def list_agents(project_id) do
+    from(a in Agent, where: a.project_id == ^project_id, order_by: [asc: a.name])
+    |> Repo.all()
+  end
+
+  # --- Message CRUD ---
 
   def create_message(attrs), do: %Message{} |> Message.changeset(attrs) |> Repo.insert()
   def get_message!(id), do: Repo.get!(Message, id)
 
   def update_message(%Message{} = message, attrs),
     do: message |> Message.changeset(attrs) |> Repo.update()
+
+  @doc """
+  Sends a message: inserts DB record and writes inbox file on VM atomically.
+  """
+  def send_message_with_inbox(project_id, agent_id, text, inbox_path, envelope, vm \\ @vm) do
+    Multi.new()
+    |> Multi.insert(
+      :message,
+      Message.changeset(%Message{}, %{
+        project_id: project_id,
+        agent_id: agent_id,
+        role: "user",
+        content: %{"text" => text}
+      })
+    )
+    |> Multi.run(:write_inbox, fn _repo, _changes ->
+      case vm.write(project_id, inbox_path, Jason.encode!(envelope)) do
+        :ok -> {:ok, :written}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{message: msg}} -> {:ok, msg}
+      {:error, :message, changeset, _} -> {:error, changeset}
+      {:error, :write_inbox, reason, _} -> {:error, reason}
+    end
+  end
 
   @doc """
   Lists messages for an agent within a project with cursor-based pagination.
@@ -20,13 +134,13 @@ defmodule Shire.Agents do
 
   Returns `{messages, has_more?}` where messages are ordered oldest-first.
   """
-  def list_messages_for_agent(project_name, agent_name, opts \\ []) do
+  def list_messages_for_agent(project_id, agent_id, opts \\ []) do
     limit = Keyword.get(opts, :limit, 50)
     before = Keyword.get(opts, :before)
 
     query =
       from m in Message,
-        where: m.project_name == ^project_name and m.agent_name == ^agent_name,
+        where: m.project_id == ^project_id and m.agent_id == ^agent_id,
         order_by: [desc: m.id],
         limit: ^limit
 
@@ -47,13 +161,13 @@ defmodule Shire.Agents do
   Lists inter-agent messages within a project with cursor-based pagination.
   Returns `{messages, has_more?}` where messages are ordered newest-first.
   """
-  def list_inter_agent_messages(project_name, opts \\ []) do
+  def list_inter_agent_messages(project_id, opts \\ []) do
     limit = Keyword.get(opts, :limit, 100)
     before = Keyword.get(opts, :before)
 
     query =
       from m in Message,
-        where: m.project_name == ^project_name and m.role == "inter_agent",
+        where: m.project_id == ^project_id and m.role == "inter_agent",
         order_by: [desc: m.id],
         limit: ^limit
 
@@ -68,19 +182,5 @@ defmodule Shire.Agents do
     has_more = length(messages) == limit
 
     {messages, has_more}
-  end
-
-  def rename_agent_messages(project_name, old_name, new_name) do
-    from(m in Message,
-      where: m.project_name == ^project_name and m.agent_name == ^old_name
-    )
-    |> Repo.update_all(set: [agent_name: new_name])
-  end
-
-  def delete_messages_for_agent(project_name, agent_name) do
-    from(m in Message,
-      where: m.project_name == ^project_name and m.agent_name == ^agent_name
-    )
-    |> Repo.delete_all()
   end
 end

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -112,7 +112,7 @@ defmodule Shire.Agents do
       })
     )
     |> Multi.run(:write_inbox, fn _repo, _changes ->
-      case vm.write(project_id, inbox_path, Jason.encode!(envelope)) do
+      case vm.write(project_id, inbox_path, Ymlr.document!(envelope)) do
         :ok -> {:ok, :written}
         {:error, reason} -> {:error, reason}
       end

--- a/lib/shire/agents/agent.ex
+++ b/lib/shire/agents/agent.ex
@@ -1,0 +1,24 @@
+defmodule Shire.Agents.Agent do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "agents" do
+    field :name, :string
+
+    belongs_to :project, Shire.Projects.Project
+    has_many :messages, Shire.Agents.Message
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(agent, attrs) do
+    agent
+    |> cast(attrs, [:name, :project_id])
+    |> validate_required([:name, :project_id])
+    |> unique_constraint([:project_id, :name], name: :agents_project_id_name_index)
+    |> foreign_key_constraint(:project_id)
+  end
+end

--- a/lib/shire/agents/message.ex
+++ b/lib/shire/agents/message.ex
@@ -2,9 +2,11 @@ defmodule Shire.Agents.Message do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @foreign_key_type :binary_id
+
   schema "messages" do
-    field :project_name, :string
-    field :agent_name, :string
+    belongs_to :project, Shire.Projects.Project
+    belongs_to :agent, Shire.Agents.Agent
     field :role, :string
     field :content, :map, default: %{}
 
@@ -13,7 +15,9 @@ defmodule Shire.Agents.Message do
 
   def changeset(message, attrs) do
     message
-    |> cast(attrs, [:project_name, :agent_name, :role, :content])
-    |> validate_required([:project_name, :agent_name, :role])
+    |> cast(attrs, [:project_id, :agent_id, :role, :content])
+    |> validate_required([:project_id, :agent_id, :role])
+    |> foreign_key_constraint(:project_id)
+    |> foreign_key_constraint(:agent_id)
   end
 end

--- a/lib/shire/project_instance_supervisor.ex
+++ b/lib/shire/project_instance_supervisor.ex
@@ -7,17 +7,17 @@ defmodule Shire.ProjectInstanceSupervisor do
   use Supervisor
 
   def start_link(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
-    Supervisor.start_link(__MODULE__, project_name)
+    project_id = Keyword.fetch!(opts, :project_id)
+    Supervisor.start_link(__MODULE__, project_id)
   end
 
   @impl true
-  def init(project_name) do
+  def init(project_id) do
     children = [
-      {Shire.VirtualMachineImpl, project_name: project_name},
-      {Shire.Agent.Coordinator, project_name: project_name},
+      {Shire.VirtualMachineImpl, project_id: project_id},
+      {Shire.Agent.Coordinator, project_id: project_id},
       {DynamicSupervisor,
-       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_name}}},
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
        strategy: :one_for_one}
     ]
 

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -1,11 +1,14 @@
 defmodule Shire.ProjectManager do
   @moduledoc """
   Manages the lifecycle of projects (Sprite VMs).
-  Each project IS a VM. Projects are discovered via the VM module's `list_vms/0`.
-  No DB table — the Sprites API is the source of truth.
+  Each project IS a VM. Projects are backed by DB records with UUID primary keys.
+  The VM name is derived from the project's UUID.
   """
   use GenServer
   require Logger
+
+  alias Shire.Projects
+  alias Shire.Projects.Project
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
@@ -15,32 +18,37 @@ defmodule Shire.ProjectManager do
 
   # --- Public API ---
 
-  @doc "Lists all projects by querying the Sprites API."
+  @doc "Lists all projects from the DB, merged with runtime status."
   def list_projects do
     GenServer.call(__MODULE__, :list_projects, 30_000)
   end
 
-  @doc "Creates a new project: starts the supervision subtree (VM is created on init)."
+  @doc "Creates a new project: inserts DB record and starts the supervision subtree."
   def create_project(name) when is_binary(name) do
     GenServer.call(__MODULE__, {:create_project, name}, 120_000)
   end
 
-  @doc "Destroys a project: stops the supervision subtree and destroys the Sprite VM."
-  def destroy_project(name) when is_binary(name) do
-    GenServer.call(__MODULE__, {:destroy_project, name}, 60_000)
+  @doc "Destroys a project: stops the supervision subtree, destroys the VM, and deletes the DB record."
+  def destroy_project(project_id) when is_binary(project_id) do
+    GenServer.call(__MODULE__, {:destroy_project, project_id}, 60_000)
+  end
+
+  @doc "Renames a project (DB-only, no VM change needed since VM name uses UUID)."
+  def rename_project(project_id, new_name) when is_binary(project_id) and is_binary(new_name) do
+    GenServer.call(__MODULE__, {:rename_project, project_id, new_name}, 15_000)
   end
 
   @doc "Returns the Coordinator pid for a project."
-  def lookup_coordinator(project_name) do
-    case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project_name}) do
+  def lookup_coordinator(project_id) do
+    case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project_id}) do
       [{pid, _}] -> {:ok, pid}
       [] -> {:error, :not_found}
     end
   end
 
   @doc "Returns the VirtualMachineImpl pid for a project."
-  def lookup_vm(project_name) do
-    case Registry.lookup(Shire.ProjectRegistry, {:vm, project_name}) do
+  def lookup_vm(project_id) do
+    case Registry.lookup(Shire.ProjectRegistry, {:vm, project_id}) do
       [{pid, _}] -> {:ok, pid}
       [] -> {:error, :not_found}
     end
@@ -55,50 +63,40 @@ defmodule Shire.ProjectManager do
 
   @impl true
   def handle_continue(:discover, state) do
-    prefix = prefix()
+    db_projects = Projects.list_projects()
 
-    case @vm.list_vms() do
-      {:ok, vm_names} ->
-        projects =
-          Enum.reduce(vm_names, state.projects, fn vm_name, acc ->
-            if String.starts_with?(vm_name, prefix) do
-              project_name = String.replace_prefix(vm_name, prefix, "")
+    projects =
+      Enum.reduce(db_projects, state.projects, fn project, acc ->
+        case start_project_subtree(project.id) do
+          {:ok, pid} ->
+            Process.monitor(pid)
+            Map.put(acc, project.id, pid)
 
-              case start_project_subtree(project_name) do
-                {:ok, pid} ->
-                  Process.monitor(pid)
-                  Map.put(acc, project_name, pid)
+          {:error, reason} ->
+            Logger.error("Failed to start project #{project.name} (#{project.id}): #{inspect(reason)}")
+            acc
+        end
+      end)
 
-                {:error, reason} ->
-                  Logger.error("Failed to start project #{project_name}: #{inspect(reason)}")
-                  acc
-              end
-            else
-              acc
-            end
-          end)
-
-        Logger.info("Discovered #{map_size(projects)} project(s)")
-        {:noreply, %{state | projects: projects}}
-
-      {:error, reason} ->
-        Logger.error("Failed to list VMs: #{inspect(reason)}")
-        {:noreply, state}
-    end
+    Logger.info("Discovered #{map_size(projects)} project(s)")
+    {:noreply, %{state | projects: projects}}
   end
 
   @impl true
   def handle_call(:list_projects, _from, state) do
     projects =
-      Enum.map(state.projects, fn {name, pid} ->
+      Projects.list_projects()
+      |> Enum.map(fn project ->
+        pid = Map.get(state.projects, project.id)
+
         status =
-          if Process.alive?(pid) do
-            :running
-          else
-            :error
+          cond do
+            pid && Process.alive?(pid) -> :running
+            pid -> :error
+            true -> :stopped
           end
 
-        %{name: name, status: status}
+        %{id: project.id, name: project.name, status: status}
       end)
 
     {:reply, projects, state}
@@ -106,32 +104,40 @@ defmodule Shire.ProjectManager do
 
   @impl true
   def handle_call({:create_project, name}, _from, state) do
-    if Map.has_key?(state.projects, name) do
+    # Check DB first
+    if Projects.get_project_by_name(name) do
       {:reply, {:error, :already_exists}, state}
     else
-      # VirtualMachineImpl.init will create-or-connect to the VM
-      case start_project_subtree(name) do
-        {:ok, pid} ->
-          Process.monitor(pid)
-          projects = Map.put(state.projects, name, pid)
+      case Projects.create_project(name) do
+        {:ok, project} ->
+          case start_project_subtree(project.id) do
+            {:ok, pid} ->
+              Process.monitor(pid)
+              projects = Map.put(state.projects, project.id, pid)
 
-          Phoenix.PubSub.broadcast(
-            Shire.PubSub,
-            "projects:lobby",
-            {:project_created, name}
-          )
+              Phoenix.PubSub.broadcast(
+                Shire.PubSub,
+                "projects:lobby",
+                {:project_created, project}
+              )
 
-          {:reply, {:ok, pid}, %{state | projects: projects}}
+              {:reply, {:ok, project}, %{state | projects: projects}}
 
-        {:error, reason} ->
-          {:reply, {:error, reason}, state}
+            {:error, reason} ->
+              # Subtree failed — clean up DB record
+              Projects.delete_project(project)
+              {:reply, {:error, reason}, state}
+          end
+
+        {:error, changeset} ->
+          {:reply, {:error, changeset}, state}
       end
     end
   end
 
   @impl true
-  def handle_call({:destroy_project, name}, _from, state) do
-    case Map.pop(state.projects, name) do
+  def handle_call({:destroy_project, project_id}, _from, state) do
+    case Map.pop(state.projects, project_id) do
       {nil, _} ->
         {:reply, {:error, :not_found}, state}
 
@@ -140,18 +146,24 @@ defmodule Shire.ProjectManager do
         DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, pid)
 
         # Destroy the underlying VM
-        case @vm.destroy_vm(name) do
+        case @vm.destroy_vm(project_id) do
           :ok ->
             :ok
 
           {:error, reason} ->
-            Logger.warning("Failed to destroy VM for #{name}: #{inspect(reason)}")
+            Logger.warning("Failed to destroy VM for #{project_id}: #{inspect(reason)}")
+        end
+
+        # Delete DB record (cascades to agents and messages)
+        case Projects.get_project_by_id(project_id) do
+          %Project{} = project -> Projects.delete_project(project)
+          nil -> :ok
         end
 
         Phoenix.PubSub.broadcast(
           Shire.PubSub,
           "projects:lobby",
-          {:project_destroyed, name}
+          {:project_destroyed, project_id}
         )
 
         {:reply, :ok, %{state | projects: projects}}
@@ -159,16 +171,42 @@ defmodule Shire.ProjectManager do
   end
 
   @impl true
+  def handle_call({:rename_project, project_id, new_name}, _from, state) do
+    case Projects.get_project_by_id(project_id) do
+      %Project{} = project ->
+        case Projects.rename_project(project, new_name) do
+          {:ok, updated} ->
+            Phoenix.PubSub.broadcast(
+              Shire.PubSub,
+              "projects:lobby",
+              {:project_renamed, updated}
+            )
+
+            {:reply, {:ok, updated}, state}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
+
+      nil ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    case Enum.find(state.projects, fn {_name, p} -> p == pid end) do
-      {name, _pid} ->
-        Logger.warning("Project #{name} supervisor went down, removing from tracked projects")
-        projects = Map.delete(state.projects, name)
+    case Enum.find(state.projects, fn {_id, p} -> p == pid end) do
+      {project_id, _pid} ->
+        Logger.warning(
+          "Project #{project_id} supervisor went down, removing from tracked projects"
+        )
+
+        projects = Map.delete(state.projects, project_id)
 
         Phoenix.PubSub.broadcast(
           Shire.PubSub,
           "projects:lobby",
-          {:project_destroyed, name}
+          {:project_destroyed, project_id}
         )
 
         {:noreply, %{state | projects: projects}}
@@ -180,14 +218,11 @@ defmodule Shire.ProjectManager do
 
   # --- Private ---
 
-  defp prefix do
-    Application.get_env(:shire, :sprite_vm_prefix, "shire-")
-  end
 
-  defp start_project_subtree(project_name) do
+  defp start_project_subtree(project_id) do
     DynamicSupervisor.start_child(
       Shire.ProjectSupervisor,
-      {Shire.ProjectInstanceSupervisor, project_name: project_name}
+      {Shire.ProjectInstanceSupervisor, project_id: project_id}
     )
   end
 end

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -73,7 +73,10 @@ defmodule Shire.ProjectManager do
             Map.put(acc, project.id, pid)
 
           {:error, reason} ->
-            Logger.error("Failed to start project #{project.name} (#{project.id}): #{inspect(reason)}")
+            Logger.error(
+              "Failed to start project #{project.name} (#{project.id}): #{inspect(reason)}"
+            )
+
             acc
         end
       end)
@@ -217,7 +220,6 @@ defmodule Shire.ProjectManager do
   end
 
   # --- Private ---
-
 
   defp start_project_subtree(project_id) do
     DynamicSupervisor.start_child(

--- a/lib/shire/projects.ex
+++ b/lib/shire/projects.ex
@@ -1,0 +1,40 @@
+defmodule Shire.Projects do
+  import Ecto.Query
+  alias Ecto.Multi
+  alias Shire.Repo
+  alias Shire.Projects.Project
+
+  def create_project(name) do
+    %Project{}
+    |> Project.changeset(%{name: name})
+    |> Repo.insert()
+  end
+
+  def get_project!(id), do: Repo.get!(Project, id)
+
+  def get_project_by_id(id) do
+    Repo.get(Project, id)
+  end
+
+  def get_project_by_name(name) do
+    Repo.get_by(Project, name: name)
+  end
+
+  def list_projects do
+    Repo.all(from(p in Project, order_by: [asc: p.name]))
+  end
+
+  def rename_project(%Project{} = project, new_name) do
+    Multi.new()
+    |> Multi.update(:project, Project.changeset(project, %{name: new_name}))
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{project: project}} -> {:ok, project}
+      {:error, :project, changeset, _} -> {:error, changeset}
+    end
+  end
+
+  def delete_project(%Project{} = project) do
+    Repo.delete(project)
+  end
+end

--- a/lib/shire/projects/project.ex
+++ b/lib/shire/projects/project.ex
@@ -1,0 +1,22 @@
+defmodule Shire.Projects.Project do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "projects" do
+    field :name, :string
+
+    has_many :agents, Shire.Agents.Agent
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(project, attrs) do
+    project
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> unique_constraint(:name)
+  end
+end

--- a/lib/shire/virtual_machine.ex
+++ b/lib/shire/virtual_machine.ex
@@ -1,7 +1,7 @@
 defmodule Shire.VirtualMachine do
   @moduledoc """
   Behaviour defining the VM interface for all Sprite VM operations.
-  All project-scoped operations take `project_name` as the first parameter.
+  All project-scoped operations take `project_id` as the first parameter.
   Consumers use `@vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)`
   to resolve the implementation at compile time.
   """
@@ -24,9 +24,6 @@ defmodule Shire.VirtualMachine do
   @callback resize(Sprites.Command.t(), integer(), integer()) :: :ok | {:error, term()}
 
   # --- VM Management (module-level, not per-project) ---
-
-  @doc "Lists all VM names matching the configured prefix."
-  @callback list_vms() :: {:ok, [String.t()]} | {:error, term()}
 
   @doc "Destroys the underlying VM for a project."
   @callback destroy_vm(String.t()) :: :ok | {:error, term()}

--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -19,24 +19,24 @@ defmodule Shire.VirtualMachineImpl do
   @keepalive_duration :timer.minutes(30)
 
   def start_link(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
-    GenServer.start_link(__MODULE__, opts, name: via(project_name))
+    project_id = Keyword.fetch!(opts, :project_id)
+    GenServer.start_link(__MODULE__, opts, name: via(project_id))
   end
 
-  defp via(project_name) do
-    {:via, Registry, {Shire.ProjectRegistry, {:vm, project_name}}}
+  defp via(project_id) do
+    {:via, Registry, {Shire.ProjectRegistry, {:vm, project_id}}}
   end
 
   # --- Public API: Command Execution ---
 
   @impl Shire.VirtualMachine
-  def cmd(project_name, command, args \\ [], opts \\ []) do
-    GenServer.call(via(project_name), {:cmd, command, args, opts}, call_timeout(opts))
+  def cmd(project_id, command, args \\ [], opts \\ []) do
+    GenServer.call(via(project_id), {:cmd, command, args, opts}, call_timeout(opts))
   end
 
   @impl Shire.VirtualMachine
-  def cmd!(project_name, command, args \\ [], opts \\ []) do
-    case cmd(project_name, command, args, opts) do
+  def cmd!(project_id, command, args \\ [], opts \\ []) do
+    case cmd(project_id, command, args, opts) do
       {:ok, output} ->
         output
 
@@ -54,45 +54,45 @@ defmodule Shire.VirtualMachineImpl do
   # --- Public API: Filesystem ---
 
   @impl Shire.VirtualMachine
-  def read(project_name, path) do
-    GenServer.call(via(project_name), {:read, path})
+  def read(project_id, path) do
+    GenServer.call(via(project_id), {:read, path})
   end
 
   @impl Shire.VirtualMachine
-  def write(project_name, path, content) do
-    GenServer.call(via(project_name), {:write, path, content})
+  def write(project_id, path, content) do
+    GenServer.call(via(project_id), {:write, path, content})
   end
 
   @impl Shire.VirtualMachine
-  def mkdir_p(project_name, path) do
-    GenServer.call(via(project_name), {:mkdir_p, path})
+  def mkdir_p(project_id, path) do
+    GenServer.call(via(project_id), {:mkdir_p, path})
   end
 
   @impl Shire.VirtualMachine
-  def rm(project_name, path) do
-    GenServer.call(via(project_name), {:rm, path})
+  def rm(project_id, path) do
+    GenServer.call(via(project_id), {:rm, path})
   end
 
   @impl Shire.VirtualMachine
-  def rm_rf(project_name, path) do
-    GenServer.call(via(project_name), {:rm_rf, path})
+  def rm_rf(project_id, path) do
+    GenServer.call(via(project_id), {:rm_rf, path})
   end
 
   @impl Shire.VirtualMachine
-  def ls(project_name, path) do
-    GenServer.call(via(project_name), {:ls, path})
+  def ls(project_id, path) do
+    GenServer.call(via(project_id), {:ls, path})
   end
 
   @impl Shire.VirtualMachine
-  def stat(project_name, path) do
-    GenServer.call(via(project_name), {:stat, path})
+  def stat(project_id, path) do
+    GenServer.call(via(project_id), {:stat, path})
   end
 
   # --- Public API: Interactive Process ---
 
   @impl Shire.VirtualMachine
-  def spawn_command(project_name, command, args \\ [], opts \\ []) do
-    sprite = GenServer.call(via(project_name), :get_sprite)
+  def spawn_command(project_id, command, args \\ [], opts \\ []) do
+    sprite = GenServer.call(via(project_id), :get_sprite)
 
     case sprite do
       nil ->
@@ -126,37 +126,12 @@ defmodule Shire.VirtualMachineImpl do
   # --- VM Management (module-level, no GenServer) ---
 
   @impl Shire.VirtualMachine
-  def list_vms do
+  def destroy_vm(project_id) do
     token = Application.get_env(:shire, :sprites_token)
 
     if token do
       client = Sprites.new(token)
-      prefix = Application.get_env(:shire, :sprite_vm_prefix, "shire-")
-
-      case Sprites.list(client, prefix: prefix) do
-        {:ok, sprites} ->
-          names =
-            sprites
-            |> Enum.map(fn info -> info["name"] || info[:name] end)
-            |> Enum.filter(&(&1 && String.starts_with?(&1, prefix)))
-
-          {:ok, names}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
-    else
-      {:ok, []}
-    end
-  end
-
-  @impl Shire.VirtualMachine
-  def destroy_vm(project_name) do
-    token = Application.get_env(:shire, :sprites_token)
-
-    if token do
-      client = Sprites.new(token)
-      name = vm_name(project_name)
+      name = vm_name(project_id)
 
       case Sprites.get_sprite(client, name) do
         {:ok, _} ->
@@ -179,18 +154,18 @@ defmodule Shire.VirtualMachineImpl do
 
   @impl GenServer
   def init(opts) do
-    project_name = Keyword.fetch!(opts, :project_name)
+    project_id = Keyword.fetch!(opts, :project_id)
     token = Application.get_env(:shire, :sprites_token)
 
     if token do
-      vm_name = vm_name(project_name)
+      vm_name = vm_name(project_id)
 
       case init_vm(token, vm_name) do
         {:ok, sprite, fs} ->
-          Logger.info("VM #{vm_name} ready (project: #{project_name})")
+          Logger.info("VM #{vm_name} ready (project: #{project_id})")
 
           {:ok,
-           %{sprite: sprite, fs: fs, project_name: project_name, ping_timer: nil, ping_until: nil}}
+           %{sprite: sprite, fs: fs, project_id: project_id, ping_timer: nil, ping_until: nil}}
 
         {:error, reason} ->
           Logger.error("Failed to initialize VM #{vm_name}: #{inspect(reason)}")
@@ -198,7 +173,7 @@ defmodule Shire.VirtualMachineImpl do
       end
     else
       Logger.warning("No SPRITES_TOKEN configured — VM features disabled")
-      {:ok, %{sprite: nil, fs: nil, project_name: project_name, ping_timer: nil, ping_until: nil}}
+      {:ok, %{sprite: nil, fs: nil, project_id: project_id, ping_timer: nil, ping_until: nil}}
     end
   end
 
@@ -389,19 +364,19 @@ defmodule Shire.VirtualMachineImpl do
   def terminate(reason, %{sprite: nil} = state),
     do:
       Logger.warning(
-        "VirtualMachineImpl stopping (no VM, project: #{state.project_name}): #{inspect(reason)}"
+        "VirtualMachineImpl stopping (no VM, project: #{state.project_id}): #{inspect(reason)}"
       )
 
   def terminate(reason, state) do
     Logger.warning(
-      "VirtualMachineImpl stopping (project: #{state.project_name}): #{inspect(reason)}"
+      "VirtualMachineImpl stopping (project: #{state.project_id}): #{inspect(reason)}"
     )
   end
 
   # --- Private: VM Initialization ---
 
-  defp vm_name(project_name) do
-    "#{Application.get_env(:shire, :sprite_vm_prefix, "shire-")}#{project_name}"
+  defp vm_name(project_id) do
+    "#{Application.get_env(:shire, :sprite_vm_prefix, "shire-")}#{project_id}"
   end
 
   defp init_vm(token, vm_name) do

--- a/lib/shire/workspace_settings.ex
+++ b/lib/shire/workspace_settings.ex
@@ -1,7 +1,7 @@
 defmodule Shire.WorkspaceSettings do
   @moduledoc """
   Manages environment variables and global scripts on a project's Sprite VM.
-  All functions take `project_name` as the first parameter.
+  All functions take `project_id` as the first parameter.
   """
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
@@ -9,9 +9,9 @@ defmodule Shire.WorkspaceSettings do
   # --- Environment ---
 
   @doc "Reads `/workspace/.env` from the VM and returns it as a string."
-  def read_env(project_name) do
+  def read_env(project_id) do
     case @vm.cmd(
-           project_name,
+           project_id,
            "bash",
            ["-c", "test -f /workspace/.env && cat /workspace/.env || echo ''"],
            []
@@ -22,8 +22,8 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Writes the given string to `/workspace/.env` on the VM."
-  def write_env(project_name, content) do
-    case @vm.write(project_name, "/workspace/.env", content) do
+  def write_env(project_id, content) do
+    case @vm.write(project_id, "/workspace/.env", content) do
       :ok -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -32,9 +32,9 @@ defmodule Shire.WorkspaceSettings do
   # --- Scripts ---
 
   @doc "Lists script filenames in `/workspace/.scripts/`."
-  def list_scripts(project_name) do
+  def list_scripts(project_id) do
     case @vm.cmd(
-           project_name,
+           project_id,
            "bash",
            ["-c", "test -d /workspace/.scripts && ls /workspace/.scripts || echo ''"],
            []
@@ -53,12 +53,12 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Lists all scripts with their content from `/workspace/.scripts/`."
-  def read_all_scripts(project_name) do
-    with {:ok, names} <- list_scripts(project_name) do
+  def read_all_scripts(project_id) do
+    with {:ok, names} <- list_scripts(project_id) do
       scripts =
         Enum.map(names, fn name ->
           content =
-            case read_script(project_name, name) do
+            case read_script(project_id, name) do
               {:ok, c} -> c
               _ -> ""
             end
@@ -71,11 +71,11 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Reads a script file from `/workspace/.scripts/{name}`."
-  def read_script(project_name, name) do
+  def read_script(project_id, name) do
     path = "/workspace/.scripts/#{name}"
 
     case @vm.cmd(
-           project_name,
+           project_id,
            "bash",
            ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"],
            []
@@ -93,11 +93,11 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Writes a script file to `/workspace/.scripts/{name}`."
-  def write_script(project_name, name, content) do
+  def write_script(project_id, name, content) do
     path = "/workspace/.scripts/#{name}"
 
-    with :ok <- @vm.write(project_name, path, content),
-         {:ok, _} <- @vm.cmd(project_name, "chmod", ["+x", path], []) do
+    with :ok <- @vm.write(project_id, path, content),
+         {:ok, _} <- @vm.cmd(project_id, "chmod", ["+x", path], []) do
       :ok
     else
       {:error, reason} -> {:error, reason}
@@ -105,18 +105,18 @@ defmodule Shire.WorkspaceSettings do
   end
 
   @doc "Deletes a script file from `/workspace/.scripts/{name}`."
-  def delete_script(project_name, name) do
+  def delete_script(project_id, name) do
     path = "/workspace/.scripts/#{name}"
-    @vm.cmd(project_name, "rm", ["-f", path], [])
+    @vm.cmd(project_id, "rm", ["-f", path], [])
     :ok
   end
 
   @doc "Runs a script from `/workspace/.scripts/{name}` and returns output."
-  def run_script(project_name, name) do
+  def run_script(project_id, name) do
     path = "/workspace/.scripts/#{name}"
     script_cmd = "[ -f /workspace/.env ] && set -a && . /workspace/.env && set +a; bash #{path}"
 
-    case @vm.cmd(project_name, "bash", ["-c", script_cmd], timeout: 120_000) do
+    case @vm.cmd(project_id, "bash", ["-c", script_cmd], timeout: 120_000) do
       {:ok, output} -> {:ok, output}
       {:error, reason} -> {:error, reason}
     end
@@ -125,10 +125,10 @@ defmodule Shire.WorkspaceSettings do
   # --- Bootstrap ---
 
   @doc "Runs the bootstrap script to initialize `/workspace` directories on the VM."
-  def bootstrap_workspace(project_name) do
+  def bootstrap_workspace(project_id) do
     script = File.read!(Application.app_dir(:shire, "priv/sprite/bootstrap.sh"))
 
-    case @vm.cmd(project_name, "bash", ["-c", script], timeout: 120_000) do
+    case @vm.cmd(project_id, "bash", ["-c", script], timeout: 120_000) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end

--- a/lib/shire_web/controllers/shared_drive_controller.ex
+++ b/lib/shire_web/controllers/shared_drive_controller.ex
@@ -4,10 +4,10 @@ defmodule ShireWeb.SharedDriveController do
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
   @drive_path "/workspace/shared"
 
-  def download(conn, %{"project" => project, "path" => path}) do
+  def download(conn, %{"project_id" => project_id, "path" => path}) do
     vm_path = to_vm_path(path)
 
-    case @vm.read(project, vm_path) do
+    case @vm.read(project_id, vm_path) do
       {:ok, content} ->
         filename = Path.basename(path)
         content_type = MIME.from_path(path)

--- a/lib/shire_web/live/agent_live/agent_streaming.ex
+++ b/lib/shire_web/live/agent_live/agent_streaming.ex
@@ -102,6 +102,9 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
         # Fallback: no message included
         {messages, nil}
 
+      %{"type" => "system_message", "message" => msg} ->
+        {messages ++ [msg], streaming_text}
+
       %{"type" => "turn_complete"} ->
         {messages, nil}
 

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -2,30 +2,32 @@ defmodule ShireWeb.AgentLive.Index do
   use ShireWeb, :live_view
 
   alias Shire.Agents
+  alias Shire.Projects
   alias Shire.Agent.Coordinator
   alias Shire.ProjectManager
   alias ShireWeb.AgentLive.{AgentStreaming, Helpers}
 
   @impl true
-  def mount(%{"project" => project}, _session, socket) do
-    case ProjectManager.lookup_coordinator(project) do
+  def mount(%{"project_id" => project_id}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project_id) do
       {:error, :not_found} ->
         {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
 
       {:ok, _pid} ->
         if connected?(socket) do
-          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:agents:lobby")
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
         end
 
-        agents = Coordinator.list_agents(project)
+        project = Projects.get_project!(project_id)
+        agents = Coordinator.list_agents(project_id)
         projects = ProjectManager.list_projects()
 
         {:ok,
          assign(socket,
-           project: project,
+           project: %{id: project.id, name: project.name},
            projects: projects,
            agents: agents,
-           selected_agent_name: nil,
+           selected_agent_id: nil,
            selected_agent: nil,
            messages: [],
            has_more: false,
@@ -46,24 +48,24 @@ defmodule ShireWeb.AgentLive.Index do
   # Agent CRUD events
 
   @impl true
-  def handle_event("delete-agent", %{"name" => name}, socket) do
-    project = socket.assigns.project
+  def handle_event("delete-agent", %{"id" => agent_id}, socket) do
+    project_id = socket.assigns.project.id
 
-    case Coordinator.delete_agent(project, name) do
+    case Coordinator.delete_agent(project_id, agent_id) do
       :ok ->
-        agents = Coordinator.list_agents(project)
+        agents = Coordinator.list_agents(project_id)
 
         selected =
-          if socket.assigns.selected_agent_name == name do
+          if socket.assigns.selected_agent_id == agent_id do
             nil
           else
-            socket.assigns.selected_agent_name
+            socket.assigns.selected_agent_id
           end
 
         {:noreply,
          assign(socket,
            agents: agents,
-           selected_agent_name: selected,
+           selected_agent_id: selected,
            selected_agent: if(selected, do: socket.assigns.selected_agent, else: nil),
            messages: if(selected, do: socket.assigns.messages, else: [])
          )}
@@ -73,8 +75,8 @@ defmodule ShireWeb.AgentLive.Index do
     end
   end
 
-  def handle_event("edit-agent", %{"name" => name}, socket) do
-    case Coordinator.get_agent(socket.assigns.project, name) do
+  def handle_event("edit-agent", %{"id" => agent_id}, socket) do
+    case Coordinator.get_agent(socket.assigns.project.id, agent_id) do
       {:ok, agent} ->
         {:noreply, assign(socket, :editing_agent, agent)}
 
@@ -84,11 +86,11 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   def handle_event("create-agent", params, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    case Coordinator.create_agent(project, params) do
+    case Coordinator.create_agent(project_id, params) do
       {:ok, _pid} ->
-        agents = Coordinator.list_agents(project)
+        agents = Coordinator.list_agents(project_id)
 
         {:noreply,
          socket
@@ -108,10 +110,10 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   def handle_event("update-agent", params, socket) do
-    project = socket.assigns.project
-    name = params["name"]
+    project_id = socket.assigns.project.id
+    agent_id = params["id"]
 
-    case Coordinator.update_agent(project, name, params) do
+    case Coordinator.update_agent(project_id, agent_id, params) do
       :ok ->
         {:noreply,
          socket
@@ -126,24 +128,24 @@ defmodule ShireWeb.AgentLive.Index do
   # Agent selection and chat events
 
   @impl true
-  def handle_event("select-agent", %{"name" => name}, socket) do
-    project = socket.assigns.project
+  def handle_event("select-agent", %{"id" => agent_id}, socket) do
+    project_id = socket.assigns.project.id
 
-    case Coordinator.get_agent(project, name) do
+    case Coordinator.get_agent(project_id, agent_id) do
       {:ok, agent} ->
         if connected?(socket) do
-          if old = socket.assigns.selected_agent_name do
-            Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project}:agent:#{old}")
+          if old = socket.assigns.selected_agent_id do
+            Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:agent:#{old}")
           end
 
-          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:agent:#{name}")
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
         end
 
-        {messages, has_more} = Agents.list_messages_for_agent(project, name, limit: 50)
+        {messages, has_more} = Agents.list_messages_for_agent(project_id, agent_id, limit: 50)
 
         {:noreply,
          assign(socket,
-           selected_agent_name: name,
+           selected_agent_id: agent_id,
            selected_agent: agent,
            messages: Enum.map(messages, &Helpers.serialize_message/1),
            has_more: has_more,
@@ -157,10 +159,10 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_event("send-message", %{"text" => text}, socket) do
-    project = socket.assigns.project
-    agent_name = socket.assigns.selected_agent_name
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.selected_agent_id
 
-    case Coordinator.send_message(project, agent_name, text) do
+    case Coordinator.send_message(project_id, agent_id, text) do
       {:ok, msg} ->
         messages = socket.assigns.messages ++ [Helpers.serialize_message(msg)]
         {:noreply, assign(socket, :messages, messages)}
@@ -178,12 +180,12 @@ defmodule ShireWeb.AgentLive.Index do
 
   @impl true
   def handle_event("load-more", %{"before" => before}, socket) do
-    project = socket.assigns.project
-    name = socket.assigns.selected_agent_name
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.selected_agent_id
 
-    if name do
+    if agent_id do
       {new_messages, has_more} =
-        Agents.list_messages_for_agent(project, name, before: before, limit: 50)
+        Agents.list_messages_for_agent(project_id, agent_id, before: before, limit: 50)
 
       all_messages =
         Enum.map(new_messages, &Helpers.serialize_message/1) ++ socket.assigns.messages
@@ -199,11 +201,31 @@ defmodule ShireWeb.AgentLive.Index do
     end
   end
 
-  # PubSub handlers
+  # PubSub handlers (agent-specific topic)
 
   @impl true
-  def handle_info({:agent_event, agent_name, event}, socket) do
-    if socket.assigns.selected_agent_name == agent_name do
+  def handle_info({:status, status}, socket) do
+    agent_id = socket.assigns.selected_agent_id
+
+    if agent_id do
+      statuses = Map.put(socket.assigns.agent_statuses, agent_id, status)
+
+      selected_agent =
+        if socket.assigns.selected_agent do
+          Map.put(socket.assigns.selected_agent, :status, status)
+        else
+          socket.assigns.selected_agent
+        end
+
+      {:noreply, assign(socket, agent_statuses: statuses, selected_agent: selected_agent)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_info({:agent_event, agent_id, event}, socket) do
+    if socket.assigns.selected_agent_id == agent_id do
       {:noreply, AgentStreaming.process_agent_event(socket, event)}
     else
       {:noreply, socket}
@@ -211,16 +233,16 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
-  def handle_info({:agent_busy, agent_name, active}, socket) do
+  def handle_info({:agent_busy, agent_id, active}, socket) do
     busy_agents =
       if active do
-        MapSet.put(socket.assigns.busy_agents, agent_name)
+        MapSet.put(socket.assigns.busy_agents, agent_id)
       else
-        MapSet.delete(socket.assigns.busy_agents, agent_name)
+        MapSet.delete(socket.assigns.busy_agents, agent_id)
       end
 
     selected_agent =
-      if socket.assigns.selected_agent && socket.assigns.selected_agent_name == agent_name do
+      if socket.assigns.selected_agent && socket.assigns.selected_agent_id == agent_id do
         Map.put(socket.assigns.selected_agent, :busy, active)
       else
         socket.assigns.selected_agent
@@ -234,19 +256,19 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
-  def handle_info({:agent_created, _name}, socket) do
-    agents = Coordinator.list_agents(socket.assigns.project)
+  def handle_info({:agent_created, _id}, socket) do
+    agents = Coordinator.list_agents(socket.assigns.project.id)
     {:noreply, assign(socket, :agents, agents)}
   end
 
   @impl true
-  def handle_info({:agent_updated, name}, socket) do
-    project = socket.assigns.project
-    agents = Coordinator.list_agents(project)
+  def handle_info({:agent_updated, agent_id}, socket) do
+    project_id = socket.assigns.project.id
+    agents = Coordinator.list_agents(project_id)
 
     selected_agent =
-      if socket.assigns.selected_agent_name == name do
-        case Coordinator.get_agent(project, name) do
+      if socket.assigns.selected_agent_id == agent_id do
+        case Coordinator.get_agent(project_id, agent_id) do
           {:ok, agent} -> agent
           _ -> socket.assigns.selected_agent
         end
@@ -258,49 +280,32 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
-  def handle_info({:agent_renamed, old_name, new_name}, socket) do
-    project = socket.assigns.project
-    agents = Coordinator.list_agents(project)
+  def handle_info({:agent_renamed, agent_id, _old_name, _new_name}, socket) do
+    project_id = socket.assigns.project.id
+    agents = Coordinator.list_agents(project_id)
 
-    if socket.assigns.selected_agent_name == old_name do
-      case Coordinator.get_agent(project, new_name) do
-        {:ok, agent} ->
-          if connected?(socket) do
-            Phoenix.PubSub.unsubscribe(
-              Shire.PubSub,
-              "project:#{project}:agent:#{old_name}"
-            )
-
-            Phoenix.PubSub.subscribe(
-              Shire.PubSub,
-              "project:#{project}:agent:#{new_name}"
-            )
-          end
-
-          {:noreply,
-           assign(socket,
-             agents: agents,
-             selected_agent_name: new_name,
-             selected_agent: agent
-           )}
-
-        _ ->
-          {:noreply, assign(socket, agents: agents)}
+    selected_agent =
+      if socket.assigns.selected_agent_id == agent_id do
+        case Coordinator.get_agent(project_id, agent_id) do
+          {:ok, agent} -> agent
+          _ -> socket.assigns.selected_agent
+        end
+      else
+        socket.assigns.selected_agent
       end
-    else
-      {:noreply, assign(socket, :agents, agents)}
-    end
+
+    {:noreply, assign(socket, agents: agents, selected_agent: selected_agent)}
   end
 
   @impl true
-  def handle_info({:agent_deleted, name}, socket) do
-    agents = Coordinator.list_agents(socket.assigns.project)
+  def handle_info({:agent_deleted, agent_id}, socket) do
+    agents = Coordinator.list_agents(socket.assigns.project.id)
 
-    if socket.assigns.selected_agent_name == name do
+    if socket.assigns.selected_agent_id == agent_id do
       {:noreply,
        assign(socket,
          agents: agents,
-         selected_agent_name: nil,
+         selected_agent_id: nil,
          selected_agent: nil,
          messages: []
        )}
@@ -310,11 +315,11 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
-  def handle_info({:agent_status, agent_name, status}, socket) do
-    statuses = Map.put(socket.assigns.agent_statuses, agent_name, status)
+  def handle_info({:agent_status, agent_id, status}, socket) do
+    statuses = Map.put(socket.assigns.agent_statuses, agent_id, status)
 
     selected_agent =
-      if socket.assigns.selected_agent && socket.assigns.selected_agent_name == agent_name do
+      if socket.assigns.selected_agent && socket.assigns.selected_agent_id == agent_id do
         Map.put(socket.assigns.selected_agent, :status, status)
       else
         socket.assigns.selected_agent
@@ -327,10 +332,10 @@ defmodule ShireWeb.AgentLive.Index do
   def render(assigns) do
     agents_with_busy =
       Enum.map(assigns.agents, fn agent ->
-        status = Map.get(assigns.agent_statuses, agent.name, agent.status)
+        status = Map.get(assigns.agent_statuses, agent.id, agent.status)
 
         agent
-        |> Map.put(:busy, MapSet.member?(assigns.busy_agents, agent.name))
+        |> Map.put(:busy, MapSet.member?(assigns.busy_agents, agent.id))
         |> Map.put(:status, status)
       end)
 

--- a/lib/shire_web/live/agent_live/show.ex
+++ b/lib/shire_web/live/agent_live/show.ex
@@ -2,32 +2,42 @@ defmodule ShireWeb.AgentLive.Show do
   use ShireWeb, :live_view
 
   alias Shire.Agent.Coordinator
+  alias Shire.Projects
   alias Shire.ProjectManager
 
   @impl true
-  def mount(%{"project" => project, "name" => name}, _session, socket) do
-    case ProjectManager.lookup_coordinator(project) do
+  def mount(%{"project_id" => project_id, "agent_id" => agent_id}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project_id) do
       {:error, :not_found} ->
         {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
 
       {:ok, _pid} ->
+        project = Projects.get_project!(project_id)
+
         agent =
           try do
-            case Coordinator.get_agent(project, name) do
-              {:ok, data} -> data
-              {:error, _} -> %{name: name, status: Coordinator.agent_status(project, name)}
+            case Coordinator.get_agent(project_id, agent_id) do
+              {:ok, data} ->
+                data
+
+              {:error, _} ->
+                %{
+                  id: agent_id,
+                  name: agent_id,
+                  status: Coordinator.agent_status(project_id, agent_id)
+                }
             end
           catch
-            :exit, _ -> %{name: name, status: :created}
+            :exit, _ -> %{id: agent_id, name: agent_id, status: :created}
           end
 
         if connected?(socket) do
-          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:agent:#{name}")
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
         end
 
         {:ok,
          assign(socket,
-           project: project,
+           project: %{id: project.id, name: project.name},
            agent: agent,
            agent_status: agent.status
          )}
@@ -41,10 +51,10 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("start-agent", _params, socket) do
-    project = socket.assigns.project
-    name = socket.assigns.agent.name
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.agent.id
 
-    case Coordinator.restart_agent(project, name) do
+    case Coordinator.restart_agent(project_id, agent_id) do
       :ok ->
         {:noreply, put_flash(socket, :info, "Agent starting...")}
 
@@ -58,15 +68,15 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("delete-agent", _params, socket) do
-    project = socket.assigns.project
-    name = socket.assigns.agent.name
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.agent.id
 
-    case Coordinator.delete_agent(project, name) do
+    case Coordinator.delete_agent(project_id, agent_id) do
       :ok ->
         {:noreply,
          socket
          |> put_flash(:info, "Agent deleted")
-         |> redirect(to: ~p"/projects/#{project}")}
+         |> redirect(to: ~p"/projects/#{project_id}")}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed to delete: #{inspect(reason)}")}
@@ -75,29 +85,21 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("update-agent", params, socket) do
-    project = socket.assigns.project
-    name = socket.assigns.agent.name
-    new_name = extract_name_from_recipe(params["recipe_yaml"])
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.agent.id
 
-    case Coordinator.update_agent(project, name, params) do
+    case Coordinator.update_agent(project_id, agent_id, params) do
       :ok ->
-        if new_name && new_name != name do
-          {:noreply,
-           socket
-           |> put_flash(:info, "Agent renamed to #{new_name}")
-           |> push_navigate(to: ~p"/projects/#{project}/agents/#{new_name}")}
-        else
-          agent =
-            case Coordinator.get_agent(project, name) do
-              {:ok, data} -> data
-              _ -> socket.assigns.agent
-            end
+        agent =
+          case Coordinator.get_agent(project_id, agent_id) do
+            {:ok, data} -> data
+            _ -> socket.assigns.agent
+          end
 
-          {:noreply,
-           socket
-           |> assign(:agent, agent)
-           |> put_flash(:info, "Agent updated")}
-        end
+        {:noreply,
+         socket
+         |> assign(:agent, agent)
+         |> put_flash(:info, "Agent updated")}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed to update: #{inspect(reason)}")}
@@ -106,10 +108,10 @@ defmodule ShireWeb.AgentLive.Show do
 
   @impl true
   def handle_event("restart-agent", _params, socket) do
-    project = socket.assigns.project
-    name = socket.assigns.agent.name
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.agent.id
 
-    case Coordinator.restart_agent(project, name) do
+    case Coordinator.restart_agent(project_id, agent_id) do
       :ok ->
         {:noreply, put_flash(socket, :info, "Agent restarting...")}
 
@@ -129,23 +131,20 @@ defmodule ShireWeb.AgentLive.Show do
   end
 
   @impl true
-  def handle_info({:agent_busy, _agent_name, active}, socket) do
+  def handle_info({:agent_busy, _agent_id, active}, socket) do
     agent = Map.put(socket.assigns.agent, :busy, active)
     {:noreply, assign(socket, :agent, agent)}
   end
 
   @impl true
-  def handle_info({:agent_event, _agent_name, _event}, socket) do
-    {:noreply, socket}
+  def handle_info({:agent_renamed, _agent_id, _old_name, new_name}, socket) do
+    agent = Map.put(socket.assigns.agent, :name, new_name)
+    {:noreply, assign(socket, :agent, agent)}
   end
 
-  defp extract_name_from_recipe(nil), do: nil
-
-  defp extract_name_from_recipe(recipe_yaml) do
-    case YamlElixir.read_from_string(recipe_yaml) do
-      {:ok, %{"name" => name}} when is_binary(name) -> name
-      _ -> nil
-    end
+  @impl true
+  def handle_info({:agent_event, _agent_id, _event}, socket) do
+    {:noreply, socket}
   end
 
   @impl true

--- a/lib/shire_web/live/project_live/index.ex
+++ b/lib/shire_web/live/project_live/index.ex
@@ -42,8 +42,8 @@ defmodule ShireWeb.ProjectLive.Index do
   end
 
   @impl true
-  def handle_event("delete-project", %{"name" => name}, socket) do
-    case ProjectManager.destroy_project(name) do
+  def handle_event("delete-project", %{"id" => project_id}, socket) do
+    case ProjectManager.destroy_project(project_id) do
       :ok ->
         projects = ProjectManager.list_projects()
 
@@ -58,13 +58,13 @@ defmodule ShireWeb.ProjectLive.Index do
   end
 
   @impl true
-  def handle_info({:project_created, _name}, socket) do
+  def handle_info({:project_created, _id}, socket) do
     projects = ProjectManager.list_projects()
     {:noreply, assign(socket, :projects, projects)}
   end
 
   @impl true
-  def handle_info({:project_destroyed, _name}, socket) do
+  def handle_info({:project_destroyed, _id}, socket) do
     projects = ProjectManager.list_projects()
     {:noreply, assign(socket, :projects, projects)}
   end

--- a/lib/shire_web/live/settings_live/index.ex
+++ b/lib/shire_web/live/settings_live/index.ex
@@ -2,34 +2,36 @@ defmodule ShireWeb.SettingsLive.Index do
   use ShireWeb, :live_view
 
   alias Shire.Agents
+  alias Shire.Projects
   alias Shire.Agent.TerminalSession
   alias Shire.ProjectManager
   alias Shire.WorkspaceSettings
 
   @impl true
-  def mount(%{"project" => project}, _session, socket) do
-    case ProjectManager.lookup_coordinator(project) do
+  def mount(%{"project_id" => project_id}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project_id) do
       {:error, :not_found} ->
         {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
 
       {:ok, _pid} ->
-        {messages, has_more} = Agents.list_inter_agent_messages(project, limit: 100)
+        project = Projects.get_project!(project_id)
+        {messages, has_more} = Agents.list_inter_agent_messages(project_id, limit: 100)
 
         env_content =
-          case WorkspaceSettings.read_env(project) do
+          case WorkspaceSettings.read_env(project_id) do
             {:ok, content} -> content
             _ -> ""
           end
 
         scripts =
-          case WorkspaceSettings.read_all_scripts(project) do
+          case WorkspaceSettings.read_all_scripts(project_id) do
             {:ok, list} -> list
             _ -> []
           end
 
         {:ok,
          assign(socket,
-           project: project,
+           project: %{id: project.id, name: project.name},
            messages: messages,
            has_more_messages: has_more,
            env_content: env_content,
@@ -48,7 +50,7 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("save-env", %{"content" => content}, socket) do
-    case WorkspaceSettings.write_env(socket.assigns.project, content) do
+    case WorkspaceSettings.write_env(socket.assigns.project.id, content) do
       :ok ->
         {:noreply,
          socket
@@ -64,11 +66,11 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("save-script", %{"name" => name, "content" => content}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    case WorkspaceSettings.write_script(project, name, content) do
+    case WorkspaceSettings.write_script(project_id, name, content) do
       :ok ->
-        scripts = refresh_scripts(project)
+        scripts = refresh_scripts(project_id)
 
         {:noreply,
          socket
@@ -82,17 +84,17 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("delete-script", %{"name" => name}, socket) do
-    :ok = WorkspaceSettings.delete_script(socket.assigns.project, name)
+    :ok = WorkspaceSettings.delete_script(socket.assigns.project.id, name)
 
     {:noreply,
      socket
-     |> assign(:scripts, refresh_scripts(socket.assigns.project))
+     |> assign(:scripts, refresh_scripts(socket.assigns.project.id))
      |> put_flash(:info, "Script deleted")}
   end
 
   @impl true
   def handle_event("run-script", %{"name" => name}, socket) do
-    case WorkspaceSettings.run_script(socket.assigns.project, name) do
+    case WorkspaceSettings.run_script(socket.assigns.project.id, name) do
       {:ok, output} ->
         {:noreply, put_flash(socket, :info, "Script output:\n#{String.slice(output, 0, 500)}")}
 
@@ -107,13 +109,13 @@ defmodule ShireWeb.SettingsLive.Index do
         %{"old_name" => old_name, "new_name" => new_name, "content" => content},
         socket
       ) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    with :ok <- WorkspaceSettings.write_script(project, new_name, content),
-         :ok <- WorkspaceSettings.delete_script(project, old_name) do
+    with :ok <- WorkspaceSettings.write_script(project_id, new_name, content),
+         :ok <- WorkspaceSettings.delete_script(project_id, old_name) do
       {:noreply,
        socket
-       |> assign(:scripts, refresh_scripts(project))
+       |> assign(:scripts, refresh_scripts(project_id))
        |> put_flash(:info, "Script renamed")}
     else
       {:error, reason} ->
@@ -126,7 +128,7 @@ defmodule ShireWeb.SettingsLive.Index do
   @impl true
   def handle_event("load-more-messages", %{"before" => before}, socket) do
     {new_messages, has_more} =
-      Agents.list_inter_agent_messages(socket.assigns.project, before: before, limit: 100)
+      Agents.list_inter_agent_messages(socket.assigns.project.id, before: before, limit: 100)
 
     all_messages = socket.assigns.messages ++ new_messages
 
@@ -141,14 +143,14 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("connect-terminal", _params, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    case TerminalSession.find(project) do
+    case TerminalSession.find(project_id) do
       {:ok, _pid} ->
         {:noreply, subscribe_terminal(socket)}
 
       :error ->
-        case start_terminal(project) do
+        case start_terminal(project_id) do
           {:ok, _pid} ->
             {:noreply, subscribe_terminal(socket)}
 
@@ -163,7 +165,7 @@ defmodule ShireWeb.SettingsLive.Index do
     if socket.assigns.terminal_subscribed do
       Phoenix.PubSub.unsubscribe(
         Shire.PubSub,
-        "project:#{socket.assigns.project}:terminal"
+        "project:#{socket.assigns.project.id}:terminal"
       )
     end
 
@@ -172,10 +174,10 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("terminal-input", %{"data" => data}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    case TerminalSession.find(project) do
-      {:ok, _pid} -> TerminalSession.write(project, data)
+    case TerminalSession.find(project_id) do
+      {:ok, _pid} -> TerminalSession.write(project_id, data)
       :error -> :ok
     end
 
@@ -184,10 +186,10 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("terminal-resize", %{"rows" => rows, "cols" => cols}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    case TerminalSession.find(project) do
-      {:ok, _pid} -> TerminalSession.resize(project, rows, cols)
+    case TerminalSession.find(project_id) do
+      {:ok, _pid} -> TerminalSession.resize(project_id, rows, cols)
       :error -> :ok
     end
 
@@ -205,21 +207,21 @@ defmodule ShireWeb.SettingsLive.Index do
   end
 
   defp subscribe_terminal(socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
     unless socket.assigns.terminal_subscribed do
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project}:terminal")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:terminal")
     end
 
     assign(socket, :terminal_subscribed, true)
   end
 
-  defp start_terminal(project) do
-    sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project}}}
+  defp start_terminal(project_id) do
+    sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}}
 
     DynamicSupervisor.start_child(
       sup,
-      {TerminalSession, project_name: project}
+      {TerminalSession, project_id: project_id}
     )
   end
 
@@ -250,8 +252,8 @@ defmodule ShireWeb.SettingsLive.Index do
     end)
   end
 
-  defp refresh_scripts(project) do
-    case WorkspaceSettings.read_all_scripts(project) do
+  defp refresh_scripts(project_id) do
+    case WorkspaceSettings.read_all_scripts(project_id) do
       {:ok, list} -> list
       _ -> []
     end

--- a/lib/shire_web/live/shared_drive_live/index.ex
+++ b/lib/shire_web/live/shared_drive_live/index.ex
@@ -1,23 +1,26 @@
 defmodule ShireWeb.SharedDriveLive.Index do
   use ShireWeb, :live_view
 
+  alias Shire.Projects
   alias Shire.ProjectManager
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
   @drive_path "/workspace/shared"
 
   @impl true
-  def mount(%{"project" => project}, _session, socket) do
-    case ProjectManager.lookup_coordinator(project) do
+  def mount(%{"project_id" => project_id}, _session, socket) do
+    case ProjectManager.lookup_coordinator(project_id) do
       {:error, :not_found} ->
         {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
 
       {:ok, _pid} ->
+        project = Projects.get_project!(project_id)
+
         {:ok,
          socket
-         |> assign(:project, project)
+         |> assign(:project, %{id: project.id, name: project.name})
          |> assign(:current_path, "/")
-         |> assign(:files, list_files(project, "/"))}
+         |> assign(:files, list_files(project_id, "/"))}
     end
   end
 
@@ -28,24 +31,24 @@ defmodule ShireWeb.SharedDriveLive.Index do
 
   @impl true
   def handle_event("navigate", %{"path" => path}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
     {:noreply,
      socket
      |> assign(:current_path, path)
-     |> assign(:files, list_files(project, path))}
+     |> assign(:files, list_files(project_id, path))}
   end
 
   def handle_event("create-directory", %{"name" => name}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
     path = join_path(socket.assigns.current_path, name)
 
-    case @vm.mkdir_p(project, to_vm_path(path)) do
+    case @vm.mkdir_p(project_id, to_vm_path(path)) do
       :ok ->
         {:noreply,
          socket
          |> put_flash(:info, "Directory created")
-         |> assign(:files, list_files(project, socket.assigns.current_path))}
+         |> assign(:files, list_files(project_id, socket.assigns.current_path))}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed: #{inspect(reason)}")}
@@ -53,11 +56,11 @@ defmodule ShireWeb.SharedDriveLive.Index do
   end
 
   def handle_event("delete-file", %{"path" => path}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    case @vm.rm(project, to_vm_path(path)) do
+    case @vm.rm(project_id, to_vm_path(path)) do
       :ok ->
-        {:noreply, assign(socket, :files, list_files(project, socket.assigns.current_path))}
+        {:noreply, assign(socket, :files, list_files(project_id, socket.assigns.current_path))}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed: #{inspect(reason)}")}
@@ -65,11 +68,11 @@ defmodule ShireWeb.SharedDriveLive.Index do
   end
 
   def handle_event("delete-directory", %{"path" => path}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
 
-    case @vm.rm_rf(project, to_vm_path(path)) do
+    case @vm.rm_rf(project_id, to_vm_path(path)) do
       :ok ->
-        {:noreply, assign(socket, :files, list_files(project, socket.assigns.current_path))}
+        {:noreply, assign(socket, :files, list_files(project_id, socket.assigns.current_path))}
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed: #{inspect(reason)}")}
@@ -77,19 +80,19 @@ defmodule ShireWeb.SharedDriveLive.Index do
   end
 
   def handle_event("upload-file", %{"name" => name, "content" => content}, socket) do
-    project = socket.assigns.project
+    project_id = socket.assigns.project.id
     path = join_path(socket.assigns.current_path, name)
 
     case Base.decode64(content) do
       {:ok, decoded} ->
         vm_path = to_vm_path(path)
 
-        with :ok <- @vm.mkdir_p(project, Path.dirname(vm_path)),
-             :ok <- @vm.write(project, vm_path, decoded) do
+        with :ok <- @vm.mkdir_p(project_id, Path.dirname(vm_path)),
+             :ok <- @vm.write(project_id, vm_path, decoded) do
           {:noreply,
            socket
            |> put_flash(:info, "File uploaded")
-           |> assign(:files, list_files(project, socket.assigns.current_path))}
+           |> assign(:files, list_files(project_id, socket.assigns.current_path))}
         else
           {:error, reason} ->
             {:noreply, put_flash(socket, :error, "Upload failed: #{inspect(reason)}")}
@@ -100,10 +103,10 @@ defmodule ShireWeb.SharedDriveLive.Index do
     end
   end
 
-  defp list_files(project, path) do
+  defp list_files(project_id, path) do
     vm_path = to_vm_path(path)
 
-    case @vm.ls(project, vm_path) do
+    case @vm.ls(project_id, vm_path) do
       {:ok, entries} when is_list(entries) ->
         entries
         |> Enum.sort_by(fn entry -> entry["name"] || to_string(entry) end)

--- a/lib/shire_web/router.ex
+++ b/lib/shire_web/router.ex
@@ -20,19 +20,19 @@ defmodule ShireWeb.Router do
     live_session :default, layout: {ShireWeb.Layouts, :app} do
       live "/", ProjectLive.Index, :index
 
-      live "/projects/:project", AgentLive.Index, :index
-      live "/projects/:project/agents/:name", AgentLive.Show, :show
+      live "/projects/:project_id", AgentLive.Index, :index
+      live "/projects/:project_id/agents/:agent_id", AgentLive.Show, :show
 
-      live "/projects/:project/settings", SettingsLive.Index, :index
+      live "/projects/:project_id/settings", SettingsLive.Index, :index
 
-      live "/projects/:project/shared", SharedDriveLive.Index, :index
+      live "/projects/:project_id/shared", SharedDriveLive.Index, :index
     end
   end
 
   scope "/", ShireWeb do
     pipe_through :browser
 
-    get "/projects/:project/shared/download", SharedDriveController, :download
+    get "/projects/:project_id/shared/download", SharedDriveController, :download
   end
 
   # Other scopes may use custom stacks.

--- a/mix.exs
+++ b/mix.exs
@@ -69,6 +69,7 @@ defmodule Shire.MixProject do
       {:live_react, "~> 1.0.1"},
       {:dotenv_parser, "~> 2.0", only: [:dev, :test]},
       {:yaml_elixir, "~> 2.11"},
+      {:ymlr, "~> 5.0"},
       {:mox, "~> 1.1", only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -51,4 +51,5 @@
   "websock_adapter": {:hex, :websock_adapter, "0.5.9", "43dc3ba6d89ef5dec5b1d0a39698436a1e856d000d84bf31a3149862b01a287f", [:mix], [{:bandit, ">= 0.6.0", [hex: :bandit, repo: "hexpm", optional: true]}, {:plug, "~> 1.14", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.6", [hex: :plug_cowboy, repo: "hexpm", optional: true]}, {:websock, "~> 0.5", [hex: :websock, repo: "hexpm", optional: false]}], "hexpm", "5534d5c9adad3c18a0f58a9371220d75a803bf0b9a3d87e6fe072faaeed76a08"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.12.1", "d74f2d82294651b58dac849c45a82aaea639766797359baff834b64439f6b3f4", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "d9ac16563c737d55f9bfeed7627489156b91268a3a21cd55c54eb2e335207fed"},
+  "ymlr": {:hex, :ymlr, "5.1.5", "0b9207c7940be3f2bc29b77cd55109d5aa2f4dcde6575942017335769e6f5628", [:mix], [], "hexpm", "7030cb240c46850caeb3b01be745307632be319b15f03083136f6251f49b516d"},
 }

--- a/priv/repo/migrations/20260319031951_add_projects_agents_tables.exs
+++ b/priv/repo/migrations/20260319031951_add_projects_agents_tables.exs
@@ -1,0 +1,44 @@
+defmodule Shire.Repo.Migrations.AddProjectsAgentsTables do
+  use Ecto.Migration
+
+  def change do
+    # Create projects table
+    create table(:projects, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:projects, [:name])
+
+    # Create agents table
+    create table(:agents, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:agents, [:project_id, :name])
+
+    # Drop and recreate messages with FK references
+    drop table(:messages)
+
+    create table(:messages) do
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :delete_all), null: false
+      add :role, :string, null: false
+      add :content, :map, default: %{}
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:messages, [:project_id, :agent_id])
+  end
+end

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -1,6 +1,7 @@
 // agent-runner.test.ts — Tests for agent-runner with harness abstraction.
 import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, readdirSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, readdirSync, existsSync, readFileSync } from "fs";
+import yaml from "js-yaml";
 import {
   emit,
   loadConfig,
@@ -8,6 +9,7 @@ import {
   processMessage,
   processInbox,
   processOutbox,
+  writeSystemMessage,
   type MessageEnvelope,
 } from "./agent-runner";
 import type { Harness } from "./harness";
@@ -64,6 +66,10 @@ function createMockHarness(): Harness & {
     onEvent: mock(() => {}),
     isProcessing: mock(() => false),
   };
+}
+
+function readYamlFile(path: string): unknown {
+  return yaml.load(readFileSync(path, "utf-8"));
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +192,57 @@ describe("processMessage() — agent_message", () => {
 });
 
 // ---------------------------------------------------------------------------
+// processMessage() — system_message
+// ---------------------------------------------------------------------------
+
+describe("processMessage() — system_message", () => {
+  test("sends text with [System] prefix to harness", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({
+      type: "system_message",
+      from: "system",
+      payload: { text: "Your message was invalid." },
+    });
+
+    await processMessage(harness, envelope);
+
+    expect(harness.sendMessage).toHaveBeenCalledWith("[System] Your message was invalid.", undefined);
+  });
+
+  test("emits system_message_received event", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({
+      type: "system_message",
+      from: "system",
+      payload: { text: "Error details here." },
+    });
+
+    const events = await captureEmits(async () => {
+      await processMessage(harness, envelope);
+    });
+
+    const received = events.find((e) => e.type === "system_message_received");
+    expect(received).toBeDefined();
+    expect(received!.payload).toEqual({ text: "Error details here." });
+  });
+
+  test("does not emit agent_message_received for system messages", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({
+      type: "system_message",
+      from: "system",
+      payload: { text: "Error." },
+    });
+
+    const events = await captureEmits(async () => {
+      await processMessage(harness, envelope);
+    });
+
+    expect(events.find((e) => e.type === "agent_message_received")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // processMessage() — interrupt
 // ---------------------------------------------------------------------------
 
@@ -266,8 +323,8 @@ describe("processInbox()", () => {
   test("returns count of processed messages", async () => {
     const harness = createMockHarness();
     const envelope = { ts: Date.now(), type: "user_message", from: "coordinator", payload: { text: "hi" } };
-    writeFileSync(`${TEST_INBOX}/1.json`, JSON.stringify(envelope));
-    writeFileSync(`${TEST_INBOX}/2.json`, JSON.stringify(envelope));
+    writeFileSync(`${TEST_INBOX}/1.yaml`, yaml.dump(envelope));
+    writeFileSync(`${TEST_INBOX}/2.yaml`, yaml.dump(envelope));
 
     const count = await processInbox(harness, TEST_INBOX);
     expect(count).toBe(2);
@@ -277,11 +334,31 @@ describe("processInbox()", () => {
   test("removes processed files from inbox", async () => {
     const harness = createMockHarness();
     const envelope = { ts: Date.now(), type: "user_message", from: "coordinator", payload: { text: "hi" } };
-    writeFileSync(`${TEST_INBOX}/1.json`, JSON.stringify(envelope));
+    writeFileSync(`${TEST_INBOX}/1.yaml`, yaml.dump(envelope));
 
     await processInbox(harness, TEST_INBOX);
-    const remaining = readdirSync(TEST_INBOX).filter((f) => f.endsWith(".json"));
+    const remaining = readdirSync(TEST_INBOX).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
     expect(remaining).toHaveLength(0);
+  });
+
+  test("processes .yml files as well", async () => {
+    const harness = createMockHarness();
+    const envelope = { ts: Date.now(), type: "user_message", from: "coordinator", payload: { text: "hi" } };
+    writeFileSync(`${TEST_INBOX}/1.yml`, yaml.dump(envelope));
+
+    const count = await processInbox(harness, TEST_INBOX);
+    expect(count).toBe(1);
+    expect(harness.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("deletes broken inbox files to prevent infinite retry", async () => {
+    const harness = createMockHarness();
+    writeFileSync(`${TEST_INBOX}/broken.yaml`, "invalid: yaml: [unterminated");
+
+    await processInbox(harness, TEST_INBOX);
+
+    expect(existsSync(`${TEST_INBOX}/broken.yaml`)).toBe(false);
+    expect(harness.sendMessage).not.toHaveBeenCalled();
   });
 });
 
@@ -301,7 +378,7 @@ describe("loadConfig()", () => {
   });
 
   test("parses recipe.yaml into AgentConfig", async () => {
-    const yaml = `version: 1
+    const recipeYaml = `version: 1
 name: test-agent
 description: A test agent
 harness: pi
@@ -309,7 +386,7 @@ model: anthropic/claude-sonnet-4-6
 system_prompt: You are helpful.
 max_tokens: 8192
 `;
-    writeFileSync(`${TEST_AGENT_DIR}/recipe.yaml`, yaml);
+    writeFileSync(`${TEST_AGENT_DIR}/recipe.yaml`, recipeYaml);
 
     const config = await loadConfig(`${TEST_AGENT_DIR}/recipe.yaml`);
     expect(config.harness).toBe("pi");
@@ -337,10 +414,12 @@ const TEST_OUTBOX = "/tmp/test-outbox-" + process.pid;
 const TEST_AGENTS_ROOT = "/tmp/test-agents-root-" + process.pid;
 const TEST_PEERS_PATH = `${TEST_AGENTS_ROOT}/../peers.yaml`;
 const TARGET_AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const TEST_SENDER_INBOX = "/tmp/test-sender-inbox-" + process.pid;
 
 describe("processOutbox()", () => {
   beforeEach(async () => {
     mkdirSync(TEST_OUTBOX, { recursive: true });
+    mkdirSync(TEST_SENDER_INBOX, { recursive: true });
     mkdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`, { recursive: true });
     // Write peers.yaml mapping name → UUID
     const peersYaml = `- id: "${TARGET_AGENT_ID}"\n  name: "target-agent"\n  description: "test"\n`;
@@ -351,6 +430,7 @@ describe("processOutbox()", () => {
 
   afterEach(() => {
     rmSync(TEST_OUTBOX, { recursive: true, force: true });
+    rmSync(TEST_SENDER_INBOX, { recursive: true, force: true });
     rmSync(TEST_AGENTS_ROOT, { recursive: true, force: true });
     try {
       rmSync(TEST_PEERS_PATH);
@@ -360,30 +440,33 @@ describe("processOutbox()", () => {
   });
 
   test("returns 0 when outbox is empty", async () => {
-    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
+    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH, TEST_SENDER_INBOX);
     expect(count).toBe(0);
   });
 
   test("routes message to target agent inbox and removes outbox file", async () => {
-    const msg = { to: "target-agent", text: "hello there" };
-    writeFileSync(`${TEST_OUTBOX}/msg.json`, JSON.stringify(msg));
+    writeFileSync(`${TEST_OUTBOX}/msg.yaml`, yaml.dump({ to: "target-agent", text: "hello there" }));
 
     const events = await captureEmits(async () => {
-      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH, TEST_SENDER_INBOX);
     });
 
     // Outbox file removed
-    const remaining = readdirSync(TEST_OUTBOX).filter((f) => f.endsWith(".json"));
+    const remaining = readdirSync(TEST_OUTBOX).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
     expect(remaining).toHaveLength(0);
 
-    // Envelope written to target inbox (by UUID)
-    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter((f) => f.endsWith(".json"));
+    // Envelope written to target inbox as YAML
+    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter(
+      (f) => f.endsWith(".yaml") || f.endsWith(".yml"),
+    );
     expect(inboxFiles).toHaveLength(1);
 
-    const raw = Bun.file(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox/${inboxFiles[0]}`);
-    const envelope = JSON.parse(await raw.text());
+    const envelope = readYamlFile(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox/${inboxFiles[0]}`) as Record<
+      string,
+      unknown
+    >;
     expect(envelope.type).toBe("agent_message");
-    expect(envelope.payload.text).toBe("hello there");
+    expect((envelope.payload as Record<string, unknown>).text).toBe("hello there");
     expect(typeof envelope.ts).toBe("number");
 
     // Emits agent_message_sent event
@@ -396,50 +479,123 @@ describe("processOutbox()", () => {
     });
   });
 
-  test("sanitizes invalid JSON escape sequences and delivers message", async () => {
-    // Simulates bash writing \! into JSON (invalid escape)
-    writeFileSync(`${TEST_OUTBOX}/bad-escape.json`, '{"to":"target-agent","text":"Hello\\! world"}');
+  test("deletes unparseable outbox files and writes system_message to sender inbox", async () => {
+    writeFileSync(`${TEST_OUTBOX}/broken.yaml`, "invalid: yaml: [unterminated");
 
+    let count = 0;
     const events = await captureEmits(async () => {
-      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
+      count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH, TEST_SENDER_INBOX);
     });
 
-    // File should be removed from outbox (delivered successfully)
-    expect(existsSync(`${TEST_OUTBOX}/bad-escape.json`)).toBe(false);
+    // Invalid files should not count as routed
+    expect(count).toBe(0);
 
-    // Message should be delivered to target inbox
-    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter((f) => f.endsWith(".json"));
-    expect(inboxFiles).toHaveLength(1);
-
-    const sent = events.find((e) => e.type === "agent_message_sent");
-    expect(sent).toBeDefined();
-    expect(sent!.payload.text).toBe("Hello\\! world");
-  });
-
-  test("skips unparseable outbox files without deleting them", async () => {
-    writeFileSync(`${TEST_OUTBOX}/broken.json`, "not json at all {{{");
-
-    const events = await captureEmits(async () => {
-      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
-    });
-
-    // File should still exist for debugging
-    expect(existsSync(`${TEST_OUTBOX}/broken.json`)).toBe(true);
+    // Outbox file should be deleted
+    expect(existsSync(`${TEST_OUTBOX}/broken.yaml`)).toBe(false);
 
     // Should emit an error
     const error = events.find((e) => e.type === "error");
     expect(error).toBeDefined();
     expect(error!.payload.message).toContain("Invalid outbox message");
+
+    // Should write system_message to sender inbox
+    const inboxFiles = readdirSync(TEST_SENDER_INBOX).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+    expect(inboxFiles).toHaveLength(1);
+    const sysMsg = readYamlFile(`${TEST_SENDER_INBOX}/${inboxFiles[0]}`) as Record<string, unknown>;
+    expect(sysMsg.type).toBe("system_message");
+    expect((sysMsg.payload as Record<string, unknown>).text).toContain("could not be parsed as YAML");
+  });
+
+  test("deletes outbox files missing required fields and writes system_message", async () => {
+    writeFileSync(`${TEST_OUTBOX}/no-to.yaml`, yaml.dump({ text: "hello" }));
+
+    const events = await captureEmits(async () => {
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH, TEST_SENDER_INBOX);
+    });
+
+    // Outbox file should be deleted
+    expect(existsSync(`${TEST_OUTBOX}/no-to.yaml`)).toBe(false);
+
+    // Should emit an error about missing fields
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeDefined();
+    expect(error!.payload.message).toContain("missing required fields");
+
+    // Should write system_message to sender inbox
+    const inboxFiles = readdirSync(TEST_SENDER_INBOX).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+    expect(inboxFiles).toHaveLength(1);
+    const sysMsg = readYamlFile(`${TEST_SENDER_INBOX}/${inboxFiles[0]}`) as Record<string, unknown>;
+    expect(sysMsg.type).toBe("system_message");
+    expect((sysMsg.payload as Record<string, unknown>).text).toContain('"to" (string)');
+  });
+
+  test("deletes outbox files with wrong field types and writes system_message", async () => {
+    writeFileSync(`${TEST_OUTBOX}/bad-types.yaml`, yaml.dump({ to: 123, text: true }));
+
+    await captureEmits(async () => {
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH, TEST_SENDER_INBOX);
+    });
+
+    expect(existsSync(`${TEST_OUTBOX}/bad-types.yaml`)).toBe(false);
+
+    const inboxFiles = readdirSync(TEST_SENDER_INBOX).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+    expect(inboxFiles).toHaveLength(1);
+    const sysMsg = readYamlFile(`${TEST_SENDER_INBOX}/${inboxFiles[0]}`) as Record<string, unknown>;
+    expect(sysMsg.type).toBe("system_message");
+  });
+
+  test("processes .yml outbox files", async () => {
+    writeFileSync(`${TEST_OUTBOX}/msg.yml`, yaml.dump({ to: "target-agent", text: "yml test" }));
+
+    const events = await captureEmits(async () => {
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH, TEST_SENDER_INBOX);
+    });
+
+    expect(existsSync(`${TEST_OUTBOX}/msg.yml`)).toBe(false);
+    const sent = events.find((e) => e.type === "agent_message_sent");
+    expect(sent).toBeDefined();
+    expect(sent!.payload.text).toBe("yml test");
   });
 
   test("processes multiple outbox files", async () => {
-    writeFileSync(`${TEST_OUTBOX}/a.json`, JSON.stringify({ to: "target-agent", text: "first" }));
-    writeFileSync(`${TEST_OUTBOX}/b.json`, JSON.stringify({ to: "target-agent", text: "second" }));
+    writeFileSync(`${TEST_OUTBOX}/a.yaml`, yaml.dump({ to: "target-agent", text: "first" }));
+    writeFileSync(`${TEST_OUTBOX}/b.yaml`, yaml.dump({ to: "target-agent", text: "second" }));
 
-    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
+    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH, TEST_SENDER_INBOX);
     expect(count).toBe(2);
 
-    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter((f) => f.endsWith(".json"));
+    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter(
+      (f) => f.endsWith(".yaml") || f.endsWith(".yml"),
+    );
     expect(inboxFiles).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeSystemMessage() — writes system_message envelope to inbox
+// ---------------------------------------------------------------------------
+
+const TEST_SYS_INBOX = "/tmp/test-sys-inbox-" + process.pid;
+
+describe("writeSystemMessage()", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_SYS_INBOX, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_SYS_INBOX, { recursive: true, force: true });
+  });
+
+  test("writes a valid YAML system_message envelope", async () => {
+    await writeSystemMessage(TEST_SYS_INBOX, "Something went wrong.");
+
+    const files = readdirSync(TEST_SYS_INBOX).filter((f) => f.endsWith(".yaml"));
+    expect(files).toHaveLength(1);
+
+    const envelope = readYamlFile(`${TEST_SYS_INBOX}/${files[0]}`) as Record<string, unknown>;
+    expect(envelope.type).toBe("system_message");
+    expect(envelope.from).toBe("system");
+    expect(typeof envelope.ts).toBe("number");
+    expect((envelope.payload as Record<string, unknown>).text).toBe("Something went wrong.");
   });
 });

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -416,15 +416,15 @@ describe("processOutbox()", () => {
     expect(sent!.payload.text).toBe("Hello\\! world");
   });
 
-  test("deletes truly unparseable outbox files", async () => {
+  test("skips unparseable outbox files without deleting them", async () => {
     writeFileSync(`${TEST_OUTBOX}/broken.json`, "not json at all {{{");
 
     const events = await captureEmits(async () => {
       await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
     });
 
-    // File should be deleted
-    expect(existsSync(`${TEST_OUTBOX}/broken.json`)).toBe(false);
+    // File should still exist for debugging
+    expect(existsSync(`${TEST_OUTBOX}/broken.json`)).toBe(true);
 
     // Should emit an error
     const error = events.find((e) => e.type === "error");

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -1,6 +1,6 @@
 // agent-runner.test.ts — Tests for agent-runner with harness abstraction.
 import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, readdirSync, existsSync } from "fs";
 import {
   emit,
   loadConfig,
@@ -394,6 +394,42 @@ describe("processOutbox()", () => {
       to_agent_id: TARGET_AGENT_ID,
       text: "hello there",
     });
+  });
+
+  test("sanitizes invalid JSON escape sequences and delivers message", async () => {
+    // Simulates bash writing \! into JSON (invalid escape)
+    writeFileSync(`${TEST_OUTBOX}/bad-escape.json`, '{"to":"target-agent","text":"Hello\\! world"}');
+
+    const events = await captureEmits(async () => {
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
+    });
+
+    // File should be removed from outbox (delivered successfully)
+    expect(existsSync(`${TEST_OUTBOX}/bad-escape.json`)).toBe(false);
+
+    // Message should be delivered to target inbox
+    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter((f) => f.endsWith(".json"));
+    expect(inboxFiles).toHaveLength(1);
+
+    const sent = events.find((e) => e.type === "agent_message_sent");
+    expect(sent).toBeDefined();
+    expect(sent!.payload.text).toBe("Hello\\! world");
+  });
+
+  test("deletes truly unparseable outbox files", async () => {
+    writeFileSync(`${TEST_OUTBOX}/broken.json`, "not json at all {{{");
+
+    const events = await captureEmits(async () => {
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
+    });
+
+    // File should be deleted
+    expect(existsSync(`${TEST_OUTBOX}/broken.json`)).toBe(false);
+
+    // Should emit an error
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeDefined();
+    expect(error!.payload.message).toContain("Invalid outbox message");
   });
 
   test("processes multiple outbox files", async () => {

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -1,7 +1,15 @@
 // agent-runner.test.ts — Tests for agent-runner with harness abstraction.
 import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, readdirSync } from "fs";
-import { emit, loadConfig, processMessage, processInbox, processOutbox, type MessageEnvelope } from "./agent-runner";
+import {
+  emit,
+  loadConfig,
+  loadPeers,
+  processMessage,
+  processInbox,
+  processOutbox,
+  type MessageEnvelope,
+} from "./agent-runner";
 import type { Harness } from "./harness";
 import { createHarness } from "./harness";
 
@@ -327,20 +335,32 @@ max_tokens: 8192
 
 const TEST_OUTBOX = "/tmp/test-outbox-" + process.pid;
 const TEST_AGENTS_ROOT = "/tmp/test-agents-root-" + process.pid;
+const TEST_PEERS_PATH = `${TEST_AGENTS_ROOT}/../peers.yaml`;
+const TARGET_AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
 describe("processOutbox()", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mkdirSync(TEST_OUTBOX, { recursive: true });
-    mkdirSync(`${TEST_AGENTS_ROOT}/target-agent/inbox`, { recursive: true });
+    mkdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`, { recursive: true });
+    // Write peers.yaml mapping name → UUID
+    const peersYaml = `- id: "${TARGET_AGENT_ID}"\n  name: "target-agent"\n  description: "test"\n`;
+    mkdirSync(`${TEST_AGENTS_ROOT}/..`, { recursive: true });
+    writeFileSync(TEST_PEERS_PATH, peersYaml);
+    await loadPeers(TEST_PEERS_PATH);
   });
 
   afterEach(() => {
     rmSync(TEST_OUTBOX, { recursive: true, force: true });
     rmSync(TEST_AGENTS_ROOT, { recursive: true, force: true });
+    try {
+      rmSync(TEST_PEERS_PATH);
+    } catch {
+      // ignore
+    }
   });
 
   test("returns 0 when outbox is empty", async () => {
-    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT);
+    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
     expect(count).toBe(0);
   });
 
@@ -349,18 +369,18 @@ describe("processOutbox()", () => {
     writeFileSync(`${TEST_OUTBOX}/msg.json`, JSON.stringify(msg));
 
     const events = await captureEmits(async () => {
-      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT);
+      await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
     });
 
     // Outbox file removed
     const remaining = readdirSync(TEST_OUTBOX).filter((f) => f.endsWith(".json"));
     expect(remaining).toHaveLength(0);
 
-    // Envelope written to target inbox
-    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/target-agent/inbox`).filter((f) => f.endsWith(".json"));
+    // Envelope written to target inbox (by UUID)
+    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter((f) => f.endsWith(".json"));
     expect(inboxFiles).toHaveLength(1);
 
-    const raw = Bun.file(`${TEST_AGENTS_ROOT}/target-agent/inbox/${inboxFiles[0]}`);
+    const raw = Bun.file(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox/${inboxFiles[0]}`);
     const envelope = JSON.parse(await raw.text());
     expect(envelope.type).toBe("agent_message");
     expect(envelope.payload.text).toBe("hello there");
@@ -369,17 +389,21 @@ describe("processOutbox()", () => {
     // Emits agent_message_sent event
     const sent = events.find((e) => e.type === "agent_message_sent");
     expect(sent).toBeDefined();
-    expect(sent!.payload).toEqual({ to_agent: "target-agent", text: "hello there" });
+    expect(sent!.payload).toEqual({
+      to_agent: "target-agent",
+      to_agent_id: TARGET_AGENT_ID,
+      text: "hello there",
+    });
   });
 
   test("processes multiple outbox files", async () => {
     writeFileSync(`${TEST_OUTBOX}/a.json`, JSON.stringify({ to: "target-agent", text: "first" }));
     writeFileSync(`${TEST_OUTBOX}/b.json`, JSON.stringify({ to: "target-agent", text: "second" }));
 
-    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT);
+    const count = await processOutbox(TEST_OUTBOX, TEST_AGENTS_ROOT, TEST_PEERS_PATH);
     expect(count).toBe(2);
 
-    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/target-agent/inbox`).filter((f) => f.endsWith(".json"));
+    const inboxFiles = readdirSync(`${TEST_AGENTS_ROOT}/${TARGET_AGENT_ID}/inbox`).filter((f) => f.endsWith(".json"));
     expect(inboxFiles).toHaveLength(2);
   });
 });

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -153,11 +153,21 @@ export async function processOutbox(
 
   for (const file of jsonFiles) {
     const path = join(outboxDir, file);
+
+    // Sanitize invalid escape sequences (e.g. \! from bash) before parsing
+    let msg: OutboxMessage;
     try {
       const raw = await readFile(path, "utf-8");
-      const msg: OutboxMessage = JSON.parse(raw);
+      const sanitized = raw.replace(/\\(?!["\\/bfnrtu])/g, "\\\\");
+      msg = JSON.parse(sanitized);
+    } catch (err) {
+      emit("error", { message: `Invalid outbox message ${file}, deleting: ${err}` });
+      await unlink(path).catch(() => {});
+      continue;
+    }
 
-      // Resolve target name to UUID
+    // Route message — transient failures (peer not found, write error) keep file for retry
+    try {
       const targetId = peersNameToId.get(msg.to);
       if (!targetId) {
         emit("error", { message: `Peer not found: "${msg.to}". Skipping message, will retry.` });

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -104,12 +104,15 @@ export function agentName(): string {
 }
 
 export async function processMessage(harness: Harness, envelope: MessageEnvelope): Promise<void> {
-  if (envelope.type === "user_message" || envelope.type === "agent_message") {
+  if (envelope.type === "user_message" || envelope.type === "agent_message" || envelope.type === "system_message") {
     const text = envelope.payload.text as string;
     const from = envelope.type === "agent_message" ? envelope.from : undefined;
-    await harness.sendMessage(text, from);
-    if (from) {
-      emit("agent_message_received", { from_agent: from, text });
+    const prefix = envelope.type === "system_message" ? "[System] " : "";
+    await harness.sendMessage(prefix + text, from);
+    if (envelope.type === "agent_message") {
+      emit("agent_message_received", { from_agent: envelope.from, text });
+    } else if (envelope.type === "system_message") {
+      emit("system_message_received", { text });
     }
   } else if (envelope.type === "interrupt") {
     await harness.interrupt();
@@ -119,17 +122,22 @@ export async function processMessage(harness: Harness, envelope: MessageEnvelope
 
 export async function processInbox(harness: Harness, inboxDir = INBOX_DIR): Promise<number> {
   const files = await readdir(inboxDir);
-  const sorted = files.filter((f) => f.endsWith(".json")).sort();
+  const sorted = files.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).sort();
 
   for (const file of sorted) {
     const path = join(inboxDir, file);
     try {
       const raw = await readFile(path, "utf-8");
-      const envelope: MessageEnvelope = JSON.parse(raw);
+      const envelope = yaml.load(raw) as MessageEnvelope;
       await processMessage(harness, envelope);
       await unlink(path);
     } catch (err) {
       emit("error", { message: `Failed to process ${file}: ${err}` });
+      try {
+        await unlink(path);
+      } catch {
+        // File may already be gone
+      }
     }
   }
 
@@ -140,28 +148,60 @@ export async function processInbox(harness: Harness, inboxDir = INBOX_DIR): Prom
 // Outbox routing — delivers messages to target agent inboxes
 // ---------------------------------------------------------------------------
 
+export async function writeSystemMessage(inboxDir: string, text: string): Promise<void> {
+  const ts = Date.now();
+  const envelope: MessageEnvelope = {
+    ts,
+    type: "system_message",
+    from: "system",
+    payload: { text },
+  };
+  const filename = `${ts}-${Math.random().toString(36).slice(2, 6)}.yaml`;
+  await writeFile(join(inboxDir, filename), yaml.dump(envelope));
+}
+
 export async function processOutbox(
   outboxDir = OUTBOX_DIR,
   agentsRoot = AGENTS_ROOT,
   peersPath = PEERS_PATH,
+  inboxDir = INBOX_DIR,
 ): Promise<number> {
   // Reload peers on each outbox cycle to pick up changes
   await loadPeers(peersPath);
 
   const files = await readdir(outboxDir);
-  const jsonFiles = files.filter((f) => f.endsWith(".json")).sort();
+  const yamlFiles = files.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).sort();
 
-  for (const file of jsonFiles) {
+  let routed = 0;
+
+  for (const file of yamlFiles) {
     const path = join(outboxDir, file);
 
-    // Sanitize invalid escape sequences (e.g. \! from bash) before parsing
     let msg: OutboxMessage;
     try {
       const raw = await readFile(path, "utf-8");
-      const sanitized = raw.replace(/\\(?!["\\/bfnrtu])/g, "\\\\");
-      msg = JSON.parse(sanitized);
+      msg = yaml.load(raw) as OutboxMessage;
     } catch (err) {
-      emit("error", { message: `Invalid outbox message ${file}, skipping: ${err}` });
+      emit("error", { message: `Invalid outbox message ${file}: ${err}` });
+      await writeSystemMessage(
+        inboxDir,
+        `Your outbox message "${file}" could not be parsed as YAML: ${err}. Please check the format and try again.`,
+      );
+      await unlink(path);
+      continue;
+    }
+
+    // Validate required fields
+    if (!msg || typeof msg.to !== "string" || typeof msg.text !== "string") {
+      const missing: string[] = [];
+      if (!msg || typeof msg.to !== "string") missing.push('"to" (string)');
+      if (!msg || typeof msg.text !== "string") missing.push('"text" (string)');
+      emit("error", { message: `Invalid outbox message ${file}: missing required fields: ${missing.join(", ")}` });
+      await writeSystemMessage(
+        inboxDir,
+        `Your outbox message "${file}" is missing required fields: ${missing.join(", ")}. Each outbox message must have "to" (target agent name) and "text" (message content) as strings.`,
+      );
+      await unlink(path);
       continue;
     }
 
@@ -181,16 +221,17 @@ export async function processOutbox(
         from: agentName(),
         payload: { text: msg.text },
       };
-      const filename = `${ts}-${Math.random().toString(36).slice(2, 6)}.json`;
-      await writeFile(join(targetInbox, filename), JSON.stringify(envelope));
+      const filename = `${ts}-${Math.random().toString(36).slice(2, 6)}.yaml`;
+      await writeFile(join(targetInbox, filename), yaml.dump(envelope));
       emit("agent_message_sent", { to_agent: msg.to, to_agent_id: targetId, text: msg.text });
       await unlink(path);
+      routed++;
     } catch (err) {
       emit("error", { message: `Failed to route outbox ${file}: ${err}` });
     }
   }
 
-  return jsonFiles.length;
+  return routed;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +264,7 @@ async function main() {
 
   // Watch for new inbox messages
   const inboxWatcher = watch(INBOX_DIR, async (_eventType: string, filename: string | null) => {
-    if (!filename?.endsWith(".json") || processing) return;
+    if ((!filename?.endsWith(".yaml") && !filename?.endsWith(".yml")) || processing) return;
     processing = true;
     emit("processing", { active: true });
     try {
@@ -241,7 +282,7 @@ async function main() {
   let routing = false;
   await processOutbox();
   const outboxWatcher = watch(OUTBOX_DIR, async (_eventType: string, filename: string | null) => {
-    if (!filename?.endsWith(".json") || routing) return;
+    if ((!filename?.endsWith(".yaml") && !filename?.endsWith(".yml")) || routing) return;
     routing = true;
     try {
       let count: number;

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -1,5 +1,5 @@
 // agent-runner.ts — Bun daemon that watches the inbox/outbox and dispatches to configured harness.
-// Each agent runs in its own workspace directory under /workspace/agents/{name}/.
+// Each agent runs in its own workspace directory under /workspace/agents/{id}/.
 import { watch } from "fs";
 import { readFile, readdir, unlink, writeFile } from "fs/promises";
 import { basename, join } from "path";
@@ -21,6 +21,7 @@ const INBOX_DIR = join(AGENT_DIR, "inbox");
 const OUTBOX_DIR = join(AGENT_DIR, "outbox");
 const AGENTS_ROOT = join(AGENT_DIR, "../");
 const RECIPE_PATH = join(AGENT_DIR, "recipe.yaml");
+const PEERS_PATH = join(AGENTS_ROOT, "../peers.yaml");
 
 export interface AgentConfig {
   harness: HarnessType;
@@ -41,9 +42,45 @@ export interface OutboxMessage {
   text: string;
 }
 
+export interface PeerEntry {
+  id: string;
+  name: string;
+  description: string;
+}
+
 export function emit(type: string, payload: Record<string, unknown> = {}) {
   const line = JSON.stringify({ type, payload });
   process.stdout.write(line + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Peers management
+// ---------------------------------------------------------------------------
+
+let peersNameToId: Map<string, string> = new Map();
+let peersIdToName: Map<string, string> = new Map();
+
+export async function loadPeers(peersPath = PEERS_PATH): Promise<void> {
+  try {
+    const raw = await readFile(peersPath, "utf-8");
+    const entries = yaml.load(raw) as PeerEntry[] | null;
+    const nameToId = new Map<string, string>();
+    const idToName = new Map<string, string>();
+
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        if (entry.id && entry.name) {
+          nameToId.set(entry.name, entry.id);
+          idToName.set(entry.id, entry.name);
+        }
+      }
+    }
+
+    peersNameToId = nameToId;
+    peersIdToName = idToName;
+  } catch {
+    // peers.yaml may not exist yet
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -59,6 +96,11 @@ export async function loadConfig(path = RECIPE_PATH): Promise<AgentConfig> {
     system_prompt: (recipe.system_prompt as string) || "",
     max_tokens: (recipe.max_tokens as number) || 16384,
   };
+}
+
+export function agentName(): string {
+  const id = basename(AGENT_DIR);
+  return peersIdToName.get(id) || id;
 }
 
 export async function processMessage(harness: Harness, envelope: MessageEnvelope): Promise<void> {
@@ -98,11 +140,14 @@ export async function processInbox(harness: Harness, inboxDir = INBOX_DIR): Prom
 // Outbox routing — delivers messages to target agent inboxes
 // ---------------------------------------------------------------------------
 
-function agentName(): string {
-  return basename(AGENT_DIR);
-}
+export async function processOutbox(
+  outboxDir = OUTBOX_DIR,
+  agentsRoot = AGENTS_ROOT,
+  peersPath = PEERS_PATH,
+): Promise<number> {
+  // Reload peers on each outbox cycle to pick up changes
+  await loadPeers(peersPath);
 
-export async function processOutbox(outboxDir = OUTBOX_DIR, agentsRoot = AGENTS_ROOT): Promise<number> {
   const files = await readdir(outboxDir);
   const jsonFiles = files.filter((f) => f.endsWith(".json")).sort();
 
@@ -112,7 +157,14 @@ export async function processOutbox(outboxDir = OUTBOX_DIR, agentsRoot = AGENTS_
       const raw = await readFile(path, "utf-8");
       const msg: OutboxMessage = JSON.parse(raw);
 
-      const targetInbox = join(agentsRoot, msg.to, "inbox");
+      // Resolve target name to UUID
+      const targetId = peersNameToId.get(msg.to);
+      if (!targetId) {
+        emit("error", { message: `Peer not found: "${msg.to}". Skipping message, will retry.` });
+        continue; // Don't delete — retry on next cycle after peers.yaml update
+      }
+
+      const targetInbox = join(agentsRoot, targetId, "inbox");
       const ts = Date.now();
       const envelope: MessageEnvelope = {
         ts,
@@ -122,7 +174,7 @@ export async function processOutbox(outboxDir = OUTBOX_DIR, agentsRoot = AGENTS_
       };
       const filename = `${ts}-${Math.random().toString(36).slice(2, 6)}.json`;
       await writeFile(join(targetInbox, filename), JSON.stringify(envelope));
-      emit("agent_message_sent", { to_agent: msg.to, text: msg.text });
+      emit("agent_message_sent", { to_agent: msg.to, to_agent_id: targetId, text: msg.text });
       await unlink(path);
     } catch (err) {
       emit("error", { message: `Failed to route outbox ${file}: ${err}` });
@@ -138,6 +190,8 @@ export async function processOutbox(outboxDir = OUTBOX_DIR, agentsRoot = AGENTS_
 
 async function main() {
   const config = await loadConfig();
+  await loadPeers();
+
   const harness = createHarness(config.harness);
 
   harness.onEvent((event) => emit(event.type, event.payload));

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -161,8 +161,7 @@ export async function processOutbox(
       const sanitized = raw.replace(/\\(?!["\\/bfnrtu])/g, "\\\\");
       msg = JSON.parse(sanitized);
     } catch (err) {
-      emit("error", { message: `Invalid outbox message ${file}, deleting: ${err}` });
-      await unlink(path).catch(() => {});
+      emit("error", { message: `Invalid outbox message ${file}, skipping: ${err}` });
       continue;
     }
 

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -5,21 +5,31 @@ defmodule Shire.Agent.AgentManagerTest do
 
   alias Shire.Agent.AgentManager
   alias Shire.Agents
+  alias Shire.Projects
 
-  @agent_name "test-agent"
-  @project "test-project"
+  @vm Shire.VirtualMachineStub
 
   setup :set_mox_from_context
 
-  defp start_manager(opts \\ []) do
-    name = Keyword.get(opts, :agent_name, @agent_name)
+  setup do
+    {:ok, project} = Projects.create_project("test-project-#{System.unique_integer([:positive])}")
+    {:ok, agent} = Agents.create_agent_with_vm(project.id, "test-agent", "version: 1\n", @vm)
 
-    start_supervised({AgentManager, project_name: @project, agent_name: name, skip_sprite: true})
+    %{project: project, agent: agent, project_id: project.id, agent_id: agent.id}
+  end
+
+  defp start_manager(ctx, opts \\ []) do
+    agent_id = Keyword.get(opts, :agent_id, ctx.agent_id)
+
+    start_supervised(
+      {AgentManager,
+       project_id: ctx.project_id, agent_id: agent_id, agent_name: "test-agent", skip_sprite: true}
+    )
   end
 
   describe "start_link/1" do
-    test "starts the GenServer and registers with the agent name" do
-      {:ok, pid} = start_manager()
+    test "starts the GenServer and registers with the agent id", ctx do
+      {:ok, pid} = start_manager(ctx)
 
       assert Process.alive?(pid)
       assert GenServer.call(pid, :get_state) |> Map.get(:status) == :idle
@@ -27,27 +37,27 @@ defmodule Shire.Agent.AgentManagerTest do
   end
 
   describe "state management" do
-    test "get_state returns current state" do
-      {:ok, pid} = start_manager()
+    test "get_state returns current state", ctx do
+      {:ok, pid} = start_manager(ctx)
 
       state = AgentManager.get_state(pid)
-      assert state.agent_name == @agent_name
+      assert state.agent_id == ctx.agent_id
       assert state.status == :idle
     end
   end
 
   describe "send_message/4" do
-    test "returns error when agent is not active" do
-      {:ok, pid} = start_manager()
+    test "returns error when agent is not active", ctx do
+      {:ok, pid} = start_manager(ctx)
 
       assert {:error, :not_active} = GenServer.call(pid, {:send_message, "hello", :user})
     end
 
-    test "persists user message to DB when from is :user" do
+    test "persists user message to DB when from is :user", ctx do
       Mox.set_mox_global()
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      {:ok, pid} = start_manager()
+      {:ok, pid} = start_manager(ctx)
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
 
       ref = make_ref()
@@ -59,7 +69,7 @@ defmodule Shire.Agent.AgentManagerTest do
       assert {:ok, %Shire.Agents.Message{}} =
                GenServer.call(pid, {:send_message, "hello from user", :user})
 
-      {messages, _} = Agents.list_messages_for_agent(@project, @agent_name)
+      {messages, _} = Agents.list_messages_for_agent(ctx.project_id, ctx.agent_id)
       user_msgs = Enum.filter(messages, &(&1.role == "user"))
       assert length(user_msgs) == 1
       assert hd(user_msgs).content["text"] == "hello from user"
@@ -67,8 +77,8 @@ defmodule Shire.Agent.AgentManagerTest do
   end
 
   describe "responsiveness" do
-    test "get_state responds immediately even during non-idle statuses" do
-      {:ok, pid} = start_manager()
+    test "get_state responds immediately even during non-idle statuses", ctx do
+      {:ok, pid} = start_manager(ctx)
 
       :sys.replace_state(pid, fn state ->
         %{state | status: :bootstrapping}
@@ -80,8 +90,8 @@ defmodule Shire.Agent.AgentManagerTest do
   end
 
   describe "error handling" do
-    test "transitions to failed on command error" do
-      {:ok, pid} = start_manager()
+    test "transitions to failed on command error", ctx do
+      {:ok, pid} = start_manager(ctx)
 
       ref = make_ref()
       command = %{ref: ref}
@@ -100,12 +110,15 @@ defmodule Shire.Agent.AgentManagerTest do
   end
 
   describe "persist_and_broadcast (stdout event persistence)" do
-    setup do
-      {:ok, pid} = start_manager()
+    setup ctx do
+      {:ok, pid} = start_manager(ctx)
 
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agent:#{@agent_name}")
+      Phoenix.PubSub.subscribe(
+        Shire.PubSub,
+        "project:#{ctx.project_id}:agent:#{ctx.agent_id}"
+      )
 
       ref = make_ref()
       command = %{ref: ref}
@@ -117,7 +130,7 @@ defmodule Shire.Agent.AgentManagerTest do
       %{pid: pid, ref: ref}
     end
 
-    test "persists text event as agent message in DB", %{pid: pid, ref: ref} do
+    test "persists text event as agent message in DB", %{pid: pid, ref: ref} = _ctx do
       line = Jason.encode!(%{"type" => "text", "payload" => %{"text" => "Hello world"}})
       send(pid, {:stdout, %{ref: ref}, line <> "\n"})
 
@@ -128,7 +141,6 @@ defmodule Shire.Agent.AgentManagerTest do
 
       db_msg = Agents.get_message!(msg[:id])
       assert db_msg.content["text"] == "Hello world"
-      assert db_msg.agent_name == @agent_name
     end
 
     test "persists tool_use started event in DB", %{pid: pid, ref: ref} do
@@ -153,7 +165,6 @@ defmodule Shire.Agent.AgentManagerTest do
       db_msg = Agents.get_message!(msg[:id])
       assert db_msg.role == "tool_use"
       assert db_msg.content["tool"] == "Read"
-      assert db_msg.agent_name == @agent_name
     end
 
     test "updates tool_use with tool_result in DB", %{pid: pid, ref: ref} do
@@ -207,17 +218,17 @@ defmodule Shire.Agent.AgentManagerTest do
 
       db_msg = Agents.get_message!(msg[:id])
       assert db_msg.content["text"] == "Hello world"
-      assert db_msg.agent_name == @agent_name
 
       assert_receive {:agent_event, _, %{"type" => "turn_complete"}}, 1_000
     end
 
-    test "broadcasts include agent_name in 3-tuple", %{pid: pid, ref: ref} do
+    test "broadcasts include agent_id in 3-tuple", ctx do
+      %{pid: pid, ref: ref} = ctx
       line = Jason.encode!(%{"type" => "text", "payload" => %{"text" => "test"}})
       send(pid, {:stdout, %{ref: ref}, line <> "\n"})
 
-      assert_receive {:agent_event, agent_name, _event}, 1_000
-      assert agent_name == @agent_name
+      assert_receive {:agent_event, agent_id, _event}, 1_000
+      assert agent_id == ctx.agent_id
     end
 
     test "cleans up tool_use_ids after tool_result", %{pid: pid, ref: ref} do
@@ -327,10 +338,10 @@ defmodule Shire.Agent.AgentManagerTest do
   end
 
   describe "agent_message_received stdout event" do
-    test "persists inter_agent message to DB" do
+    test "persists inter_agent message to DB", ctx do
       Mox.set_mox_global()
 
-      {:ok, pid} = start_manager()
+      {:ok, pid} = start_manager(ctx)
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
 
       ref = make_ref()
@@ -350,20 +361,23 @@ defmodule Shire.Agent.AgentManagerTest do
       # Give it a moment to process
       Process.sleep(50)
 
-      {messages, _has_more} = Agents.list_messages_for_agent(@project, @agent_name)
+      {messages, _has_more} = Agents.list_messages_for_agent(ctx.project_id, ctx.agent_id)
       inter_agent = Enum.find(messages, &(&1.role == "inter_agent"))
       assert inter_agent != nil
       assert inter_agent.content["text"] == "hello from other"
       assert inter_agent.content["from_agent"] == "other-agent"
-      assert inter_agent.content["to_agent"] == @agent_name
+      assert inter_agent.content["to_agent"] == "test-agent"
     end
   end
 
   describe "runner exit" do
-    test "transitions to failed when runner exits" do
-      {:ok, pid} = start_manager()
+    test "transitions to failed when runner exits", ctx do
+      {:ok, pid} = start_manager(ctx)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agent:#{@agent_name}")
+      Phoenix.PubSub.subscribe(
+        Shire.PubSub,
+        "project:#{ctx.project_id}:agent:#{ctx.agent_id}"
+      )
 
       ref = make_ref()
 
@@ -383,15 +397,18 @@ defmodule Shire.Agent.AgentManagerTest do
   end
 
   describe "restart" do
-    test "resets state and transitions to bootstrapping" do
+    test "resets state and transitions to bootstrapping", ctx do
       Mox.set_mox_global()
       stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      {:ok, pid} = start_manager()
+      {:ok, pid} = start_manager(ctx)
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agent:#{@agent_name}")
+      Phoenix.PubSub.subscribe(
+        Shire.PubSub,
+        "project:#{ctx.project_id}:agent:#{ctx.agent_id}"
+      )
 
       ref = make_ref()
 
@@ -399,7 +416,7 @@ defmodule Shire.Agent.AgentManagerTest do
         %{state | command: %{ref: ref}, command_ref: ref, status: :active}
       end)
 
-      assert :ok = AgentManager.restart(@project, @agent_name)
+      assert :ok = AgentManager.restart(ctx.project_id, ctx.agent_id)
 
       assert_receive {:status, :bootstrapping}, 1_000
     end

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -4,8 +4,7 @@ defmodule Shire.Agent.CoordinatorTest do
   import Mox
 
   alias Shire.Agent.{AgentManager, Coordinator}
-
-  @project "test-project"
+  alias Shire.Projects
 
   setup do
     # Global mode so the Coordinator process (separate from test process) can use stubs
@@ -15,214 +14,242 @@ defmodule Shire.Agent.CoordinatorTest do
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
+    stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+      {:error, :not_available_in_test}
+    end)
+
+    # Create a DB-backed project
+    {:ok, project} = Projects.create_project("test-project")
+    project_id = project.id
+
     # Start the project-scoped DynamicSupervisor for agents
     start_supervised!(
       {DynamicSupervisor,
-       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, @project}}},
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
        strategy: :one_for_one},
       id: :agent_sup
     )
 
     # Start the Coordinator (handle_continue runs bootstrap/deploy/scan on start)
-    start_supervised!({Shire.Agent.Coordinator, project_name: @project})
+    start_supervised!({Shire.Agent.Coordinator, project_id: project_id})
 
     # Give handle_continue time to complete
     Process.sleep(50)
 
-    :ok
+    %{project_id: project_id}
   end
 
-  defp broadcast_status(agent_name, status) do
+  defp broadcast_status(project_id, agent_id, status) do
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
-      "project:#{@project}:agents:lobby",
-      {:agent_status, agent_name, status}
+      "project:#{project_id}:agents:lobby",
+      {:agent_status, agent_id, status}
     )
 
     # Give the Coordinator time to process the async message
     Process.sleep(50)
   end
 
-  defp start_agent_manager(agent_name, opts \\ []) do
-    supervisor_id = Keyword.get(opts, :id, agent_name)
+  defp start_agent_manager(project_id, agent_id, opts \\ []) do
+    supervisor_id = Keyword.get(opts, :id, agent_id)
 
     start_supervised(
-      {AgentManager, project_name: @project, agent_name: agent_name, skip_sprite: true},
+      {AgentManager,
+       project_id: project_id, agent_id: agent_id, agent_name: "test-agent", skip_sprite: true},
       id: supervisor_id
     )
   end
 
-  @agent_name "coord-test-agent"
+  defp create_db_agent(project_id, name \\ "coord-test-agent") do
+    {:ok, agent} =
+      Shire.Agents.create_agent_with_vm(
+        project_id,
+        name,
+        "version: 1\nname: #{name}\n",
+        Shire.VirtualMachineStub
+      )
+
+    agent
+  end
 
   describe "lookup/2" do
-    test "returns error when agent is not running" do
-      assert {:error, :not_found} = Coordinator.lookup(@project, "nonexistent")
+    test "returns error when agent is not running", %{project_id: project_id} do
+      assert {:error, :not_found} =
+               Coordinator.lookup(project_id, "00000000-0000-0000-0000-000000000000")
     end
 
-    test "returns {:ok, pid} for a running agent" do
-      {:ok, pid} = start_agent_manager(@agent_name)
-      assert {:ok, ^pid} = Coordinator.lookup(@project, @agent_name)
+    test "returns {:ok, pid} for a running agent", %{project_id: project_id} do
+      agent = create_db_agent(project_id)
+      {:ok, pid} = start_agent_manager(project_id, agent.id)
+      assert {:ok, ^pid} = Coordinator.lookup(project_id, agent.id)
     end
   end
 
   describe "delete_agent/2" do
-    test "succeeds even when agent is not running (deletes dir only)" do
-      assert :ok = Coordinator.delete_agent(@project, "nonexistent")
-    end
+    test "broadcasts {:agent_deleted, id} on lobby", %{project_id: project_id} do
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
 
-    test "broadcasts {:agent_deleted, name} on lobby" do
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agents:lobby")
+      agent = create_db_agent(project_id, "coord-delete-broadcast")
 
-      unique_name = "coord-delete-broadcast-#{System.unique_integer([:positive])}"
-      Coordinator.delete_agent(@project, unique_name)
+      Coordinator.delete_agent(project_id, agent.id)
 
-      assert_receive {:agent_deleted, ^unique_name}, 500
+      agent_id = agent.id
+      assert_receive {:agent_deleted, ^agent_id}, 500
     end
   end
 
   describe "restart_agent/2" do
-    test "restarts a running agent" do
-      {:ok, _pid} = start_agent_manager(@agent_name)
+    test "restarts a running agent", %{project_id: project_id} do
+      agent = create_db_agent(project_id)
+      {:ok, _pid} = start_agent_manager(project_id, agent.id)
 
-      broadcast_status(@agent_name, :failed)
-      assert :failed == Coordinator.agent_status(@project, @agent_name)
+      broadcast_status(project_id, agent.id, :failed)
+      assert :failed == Coordinator.agent_status(project_id, agent.id)
 
       # Restart should succeed for a running (failed) agent
-      result = Coordinator.restart_agent(@project, @agent_name)
+      result = Coordinator.restart_agent(project_id, agent.id)
       assert result == :ok
     end
   end
 
   describe "list_running/1" do
-    test "returns a list of strings" do
-      running = Coordinator.list_running(@project)
+    test "returns a list of strings", %{project_id: project_id} do
+      running = Coordinator.list_running(project_id)
       assert is_list(running)
-      assert Enum.all?(running, &is_binary/1)
     end
 
-    test "includes running agents" do
-      {:ok, _pid} = start_agent_manager(@agent_name)
-      running = Coordinator.list_running(@project)
-      assert @agent_name in running
+    test "includes running agents", %{project_id: project_id} do
+      agent = create_db_agent(project_id)
+      {:ok, _pid} = start_agent_manager(project_id, agent.id)
+      running = Coordinator.list_running(project_id)
+      assert agent.id in running
     end
   end
 
   describe "agent_status/2" do
-    test "returns :created for non-running agents" do
-      assert :created == Coordinator.agent_status(@project, "nonexistent")
+    test "returns :created for non-running agents", %{project_id: project_id} do
+      assert :created ==
+               Coordinator.agent_status(project_id, "00000000-0000-0000-0000-000000000000")
     end
 
-    test "returns status after PubSub broadcast" do
-      {:ok, _pid} = start_agent_manager(@agent_name)
-      broadcast_status(@agent_name, :active)
-      assert :active == Coordinator.agent_status(@project, @agent_name)
+    test "returns status after PubSub broadcast", %{project_id: project_id} do
+      agent = create_db_agent(project_id)
+      {:ok, _pid} = start_agent_manager(project_id, agent.id)
+      broadcast_status(project_id, agent.id, :active)
+      assert :active == Coordinator.agent_status(project_id, agent.id)
     end
   end
 
   describe "agent_statuses/2" do
-    test "returns status map for given agent names" do
-      {:ok, _pid} = start_agent_manager(@agent_name)
-      broadcast_status(@agent_name, :bootstrapping)
+    test "returns status map for given agent IDs", %{project_id: project_id} do
+      agent = create_db_agent(project_id)
+      {:ok, _pid} = start_agent_manager(project_id, agent.id)
+      broadcast_status(project_id, agent.id, :bootstrapping)
 
-      result = Coordinator.agent_statuses(@project, [@agent_name, "nonexistent"])
-      assert result[@agent_name] == :bootstrapping
-      assert result["nonexistent"] == :created
+      nonexistent = "00000000-0000-0000-0000-000000000000"
+      result = Coordinator.agent_statuses(project_id, [agent.id, nonexistent])
+      assert result[agent.id] == :bootstrapping
+      assert result[nonexistent] == :created
     end
   end
 
   describe "status updates via PubSub" do
-    test "coordinator updates internal state from lobby broadcasts" do
-      broadcast_status(@agent_name, :active)
-      assert :active == Coordinator.agent_status(@project, @agent_name)
+    test "coordinator updates internal state from lobby broadcasts", %{project_id: project_id} do
+      agent = create_db_agent(project_id)
+      broadcast_status(project_id, agent.id, :active)
+      assert :active == Coordinator.agent_status(project_id, agent.id)
     end
   end
 
   describe "auto-restart on init" do
-    test "handle_continue does not crash the coordinator" do
+    test "handle_continue does not crash the coordinator", %{project_id: project_id} do
       assert Process.alive?(
                GenServer.whereis(
-                 {:via, Registry, {Shire.ProjectRegistry, {:coordinator, @project}}}
+                 {:via, Registry, {Shire.ProjectRegistry, {:coordinator, project_id}}}
                )
              )
     end
   end
 
   describe "excludes terminal sessions from registry" do
-    test "list_running only returns agent entries" do
-      {:ok, _pid} = start_agent_manager(@agent_name)
+    test "list_running only returns agent entries", %{project_id: project_id} do
+      agent = create_db_agent(project_id)
+      {:ok, _pid} = start_agent_manager(project_id, agent.id)
 
       # Simulate a terminal session registering in the same registry
       {:ok, _} =
-        Registry.register(Shire.AgentRegistry, {:terminal, @agent_name}, "terminal-session")
+        Registry.register(
+          Shire.AgentRegistry,
+          {:terminal, agent.id},
+          "terminal-session"
+        )
 
-      running = Coordinator.list_running(@project)
-      assert @agent_name in running
-      refute {:terminal, @agent_name} in running
+      running = Coordinator.list_running(project_id)
+      assert agent.id in running
+      refute {:terminal, agent.id} in running
     end
   end
 
   describe "update_agent/3" do
-    test "writes recipe.yaml to the VM and returns :ok" do
+    test "writes recipe.yaml to the VM and returns :ok", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      unique_name = "coord-update-test-#{System.unique_integer([:positive])}"
+      agent = create_db_agent(project_id, "coord-update-test")
 
       result =
-        Coordinator.update_agent(@project, unique_name, %{
-          "recipe_yaml" => "version: 1\nname: updated\nharness: claude_code\n"
+        Coordinator.update_agent(project_id, agent.id, %{
+          "recipe_yaml" => "version: 1\nname: coord-update-test\nharness: claude_code\n"
         })
 
       assert result == :ok
 
       assert Process.alive?(
                GenServer.whereis(
-                 {:via, Registry, {Shire.ProjectRegistry, {:coordinator, @project}}}
+                 {:via, Registry, {Shire.ProjectRegistry, {:coordinator, project_id}}}
                )
              )
     end
 
-    test "restarts agent if it is running" do
+    test "restarts agent if it is running", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      {:ok, _pid} = start_agent_manager(@agent_name)
+      agent = create_db_agent(project_id)
+      {:ok, _pid} = start_agent_manager(project_id, agent.id)
 
       # Mark as active so restart is meaningful
-      broadcast_status(@agent_name, :active)
+      broadcast_status(project_id, agent.id, :active)
 
       result =
-        Coordinator.update_agent(@project, @agent_name, %{
-          "recipe_yaml" => "version: 1\nname: #{@agent_name}\n"
+        Coordinator.update_agent(project_id, agent.id, %{
+          "recipe_yaml" => "version: 1\nname: #{agent.name}\n"
         })
 
       assert result == :ok
     end
 
-    test "broadcasts {:agent_updated, name} on lobby" do
+    test "broadcasts {:agent_updated, id} on lobby", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agents:lobby")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
 
-      unique_name = "coord-update-broadcast-#{System.unique_integer([:positive])}"
+      agent = create_db_agent(project_id, "coord-update-broadcast")
 
-      Coordinator.update_agent(@project, unique_name, %{
-        "recipe_yaml" => "version: 1\nname: #{unique_name}\n"
+      Coordinator.update_agent(project_id, agent.id, %{
+        "recipe_yaml" => "version: 1\nname: coord-update-broadcast\n"
       })
 
-      assert_receive {:agent_updated, ^unique_name}, 500
+      agent_id = agent.id
+      assert_receive {:agent_updated, ^agent_id}, 500
     end
   end
 
   describe "get_agent/2" do
-    test "returns {:error, :not_found} when agent does not exist on VM" do
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts ->
-        {:ok, "__NOT_FOUND__"}
-      end)
-
-      result = Coordinator.get_agent(@project, "coord-get-test-nonexistent")
+    test "returns {:error, :not_found} when agent does not exist", %{project_id: project_id} do
+      result = Coordinator.get_agent(project_id, "00000000-0000-0000-0000-000000000000")
       assert {:error, :not_found} = result
     end
 
-    test "returns {:ok, agent} with correct fields when agent exists on VM" do
+    test "returns {:ok, agent} with correct fields when agent exists", %{project_id: project_id} do
       recipe_yaml = """
       name: my-agent
       description: A test agent
@@ -231,38 +258,37 @@ defmodule Shire.Agent.CoordinatorTest do
       system_prompt: You are helpful.
       """
 
+      agent = create_db_agent(project_id, "my-agent")
+
       stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts ->
         {:ok, recipe_yaml}
       end)
 
-      result = Coordinator.get_agent(@project, "my-agent")
+      result = Coordinator.get_agent(project_id, agent.id)
 
-      assert {:ok, agent} = result
-      assert agent.name == "my-agent"
-      assert agent.description == "A test agent"
-      assert agent.harness == "claude_code"
-      assert agent.model == "claude-3-haiku"
-      assert agent.system_prompt == "You are helpful."
-      assert Map.has_key?(agent, :status)
+      assert {:ok, agent_data} = result
+      assert agent_data.name == "my-agent"
+      assert agent_data.description == "A test agent"
+      assert agent_data.harness == "claude_code"
+      assert agent_data.model == "claude-3-haiku"
+      assert agent_data.system_prompt == "You are helpful."
+      assert Map.has_key?(agent_data, :status)
     end
   end
 
   describe "list_agents/1" do
-    test "returns empty list when no agents on VM" do
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts -> {:ok, ""} end)
-
-      agents = Coordinator.list_agents(@project)
-      assert agents == []
+    test "returns agent list from DB merged with statuses", %{project_id: project_id} do
+      agents = Coordinator.list_agents(project_id)
+      assert is_list(agents)
     end
 
-    test "returns agent map entries for each discovered agent dir" do
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts ->
-        {:ok, "agent-one\nagent-two\n"}
-      end)
+    test "returns agent map entries for DB agents", %{project_id: project_id} do
+      create_db_agent(project_id, "agent-one")
+      create_db_agent(project_id, "agent-two")
 
-      agents = Coordinator.list_agents(@project)
+      agents = Coordinator.list_agents(project_id)
       assert is_list(agents)
-      assert length(agents) == 2
+      assert length(agents) >= 2
 
       for agent <- agents do
         assert Map.has_key?(agent, :name)
@@ -276,157 +302,81 @@ defmodule Shire.Agent.CoordinatorTest do
   end
 
   describe "update_agent/3 with rename" do
-    test "renames workspace folder when recipe name differs from current name" do
-      old_name = "coord-rename-old-#{System.unique_integer([:positive])}"
-      new_name = "coord-rename-new-#{System.unique_integer([:positive])}"
-
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, args, _opts ->
-        case {cmd, args} do
-          {"bash", ["-c", "test -d " <> _]} -> {:ok, "missing\n"}
-          {"mv", _} -> {:ok, ""}
-          _ -> {:ok, ""}
-        end
-      end)
-
+    test "renames agent when recipe name differs from current name", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{@project}:agents:lobby")
+      agent = create_db_agent(project_id, "coord-rename-old")
+      new_name = "coord-rename-new-#{System.unique_integer([:positive])}"
+
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
 
       result =
-        Coordinator.update_agent(@project, old_name, %{
+        Coordinator.update_agent(project_id, agent.id, %{
           "recipe_yaml" => "version: 1\nname: #{new_name}\nharness: claude_code\n"
         })
 
       assert result == :ok
-      assert_receive {:agent_renamed, ^old_name, ^new_name}, 500
+
+      agent_id = agent.id
+      old_name = agent.name
+      assert_receive {:agent_renamed, ^agent_id, ^old_name, ^new_name}, 500
     end
 
-    test "returns error when target name already exists" do
-      old_name = "coord-rename-conflict-old-#{System.unique_integer([:positive])}"
-      new_name = "coord-rename-conflict-new-#{System.unique_integer([:positive])}"
-
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", ["-c", "test -d " <> _], _opts ->
-        {:ok, "exists\n"}
-      end)
-
+    test "returns error when target name already exists", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+
+      agent = create_db_agent(project_id, "coord-rename-conflict-old")
+      _agent2 = create_db_agent(project_id, "coord-rename-conflict-new")
 
       result =
-        Coordinator.update_agent(@project, old_name, %{
-          "recipe_yaml" => "version: 1\nname: #{new_name}\n"
+        Coordinator.update_agent(project_id, agent.id, %{
+          "recipe_yaml" => "version: 1\nname: coord-rename-conflict-new\n"
         })
 
-      assert {:error, :already_exists} = result
-    end
-
-    test "migrates messages to new agent name" do
-      old_name = "coord-rename-msg-old-#{System.unique_integer([:positive])}"
-      new_name = "coord-rename-msg-new-#{System.unique_integer([:positive])}"
-
-      # Create a message under the old name
-      {:ok, _msg} =
-        Shire.Agents.create_message(%{
-          project_name: @project,
-          agent_name: old_name,
-          role: "user",
-          content: %{"text" => "hello"}
-        })
-
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, _args, _opts ->
-        case cmd do
-          "bash" -> {:ok, "missing\n"}
-          "mv" -> {:ok, ""}
-          _ -> {:ok, ""}
-        end
-      end)
-
-      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
-
-      assert :ok =
-               Coordinator.update_agent(@project, old_name, %{
-                 "recipe_yaml" => "version: 1\nname: #{new_name}\n"
-               })
-
-      # Old name should have no messages
-      {old_messages, _} = Shire.Agents.list_messages_for_agent(@project, old_name)
-      assert old_messages == []
-
-      # New name should have the message
-      {new_messages, _} = Shire.Agents.list_messages_for_agent(@project, new_name)
-      assert length(new_messages) == 1
-      assert hd(new_messages).agent_name == new_name
+      assert {:error, _} = result
     end
   end
 
   describe "create_agent/2" do
-    test "creates agent directory structure on VM and starts AgentManager" do
+    test "creates agent directory structure on VM and starts AgentManager", %{
+      project_id: project_id
+    } do
       unique_name = "coord-create-test-#{System.unique_integer([:positive])}"
-      agent_dir = "/workspace/agents/#{unique_name}"
 
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, args, _opts ->
-        case {cmd, args} do
-          {"bash", ["-c", "test -d " <> _]} -> {:ok, "missing\n"}
-          {"mkdir", _} -> {:ok, ""}
-          _ -> {:ok, ""}
-        end
-      end)
-
-      stub(Shire.VirtualMachineMock, :write, fn _project, ^agent_dir <> _rest, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       result =
-        Coordinator.create_agent(@project, %{
+        Coordinator.create_agent(project_id, %{
           "name" => unique_name,
           "recipe_yaml" => "version: 1\nname: #{unique_name}\ndescription: A test agent\n"
         })
 
       assert {:ok, pid} = result
       assert is_pid(pid)
-
-      # Clean up
-      Coordinator.delete_agent(@project, unique_name)
     end
 
-    test "returns {:error, :already_exists} for duplicate names" do
+    test "returns {:error, :already_exists} for duplicate names", %{project_id: project_id} do
       unique_name = "coord-dup-test-#{System.unique_integer([:positive])}"
-      agent_dir = "/workspace/agents/#{unique_name}"
 
-      # First call: agent does not exist
-      # Second call: agent already exists
-      call_count = :counters.new(1, [])
-
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, args, _opts ->
-        case {cmd, args} do
-          {"bash", ["-c", "test -d " <> _]} ->
-            :counters.add(call_count, 1, 1)
-            n = :counters.get(call_count, 1)
-            if n <= 1, do: {:ok, "missing\n"}, else: {:ok, "exists\n"}
-
-          {"mkdir", _} ->
-            {:ok, ""}
-
-          _ ->
-            {:ok, ""}
-        end
-      end)
-
-      stub(Shire.VirtualMachineMock, :write, fn _project, ^agent_dir <> _rest, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       recipe = "version: 1\nname: #{unique_name}\n"
 
       {:ok, _pid} =
-        Coordinator.create_agent(@project, %{"name" => unique_name, "recipe_yaml" => recipe})
+        Coordinator.create_agent(project_id, %{"name" => unique_name, "recipe_yaml" => recipe})
 
       result =
-        Coordinator.create_agent(@project, %{"name" => unique_name, "recipe_yaml" => recipe})
+        Coordinator.create_agent(project_id, %{"name" => unique_name, "recipe_yaml" => recipe})
 
       assert {:error, :already_exists} = result
-
-      # Clean up
-      Coordinator.delete_agent(@project, unique_name)
     end
 
-    test "returns {:error, :missing_name_or_recipe} for incomplete attrs" do
-      result = Coordinator.create_agent(@project, %{"name" => "no-recipe"})
+    test "returns {:error, :missing_name_or_recipe} for incomplete attrs", %{
+      project_id: project_id
+    } do
+      result = Coordinator.create_agent(project_id, %{"name" => "no-recipe"})
       assert {:error, :missing_name_or_recipe} = result
     end
   end

--- a/test/shire/agent/terminal_session_test.exs
+++ b/test/shire/agent/terminal_session_test.exs
@@ -3,11 +3,11 @@ defmodule Shire.Agent.TerminalSessionTest do
 
   alias Shire.Agent.TerminalSession
 
-  @project "test-project"
+  @project_id "test-project"
 
   describe "find/1" do
     test "returns :error when no session exists" do
-      assert :error = TerminalSession.find(@project)
+      assert :error = TerminalSession.find(@project_id)
     end
   end
 
@@ -18,8 +18,8 @@ defmodule Shire.Agent.TerminalSessionTest do
   end
 
   describe "registry" do
-    test "uses {:terminal, project_name} as registry key" do
-      assert [] = Registry.lookup(Shire.ProjectRegistry, {:terminal, @project})
+    test "uses {:terminal, project_id} as registry key" do
+      assert [] = Registry.lookup(Shire.ProjectRegistry, {:terminal, @project_id})
     end
   end
 end

--- a/test/shire/agents_test.exs
+++ b/test/shire/agents_test.exs
@@ -127,7 +127,7 @@ defmodule Shire.AgentsTest do
       project: project,
       agent: agent
     } do
-      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-1.json"
+      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-1.yaml"
       envelope = %{"role" => "user", "content" => "hello"}
 
       assert {:ok, msg} =
@@ -168,7 +168,7 @@ defmodule Shire.AgentsTest do
         def destroy_vm(_p), do: :ok
       end
 
-      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-2.json"
+      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-2.yaml"
       envelope = %{"role" => "user", "content" => "fail"}
 
       assert {:error, :disk_full} =

--- a/test/shire/agents_test.exs
+++ b/test/shire/agents_test.exs
@@ -2,68 +2,83 @@ defmodule Shire.AgentsTest do
   use Shire.DataCase, async: true
 
   alias Shire.Agents
+  alias Shire.Projects
 
-  @project "test-project"
+  @vm Shire.VirtualMachineStub
+
+  setup do
+    {:ok, project} = Projects.create_project("test-project")
+    {:ok, agent} = Agents.create_agent_with_vm(project.id, "test-agent", "version: 1\n", @vm)
+    {:ok, agent2} = Agents.create_agent_with_vm(project.id, "chat-agent", "version: 1\n", @vm)
+
+    %{project: project, agent: agent, agent2: agent2}
+  end
 
   describe "messages" do
-    test "create_message/1 with valid data" do
+    test "create_message/1 with valid data", %{project: project, agent: agent} do
       assert {:ok, msg} =
                Agents.create_message(%{
-                 project_name: @project,
-                 agent_name: "test-agent",
+                 project_id: project.id,
+                 agent_id: agent.id,
                  role: "user",
                  content: %{"text" => "hi"}
                })
 
       assert msg.role == "user"
       assert msg.content == %{"text" => "hi"}
-      assert msg.agent_name == "test-agent"
-      assert msg.project_name == @project
+      assert msg.agent_id == agent.id
+      assert msg.project_id == project.id
     end
 
-    test "create_message/1 requires project_name, agent_name and role" do
+    test "create_message/1 requires project_id, agent_id and role" do
       assert {:error, changeset} = Agents.create_message(%{})
-      assert "can't be blank" in errors_on(changeset).project_name
-      assert "can't be blank" in errors_on(changeset).agent_name
+      assert "can't be blank" in errors_on(changeset).project_id
+      assert "can't be blank" in errors_on(changeset).agent_id
       assert "can't be blank" in errors_on(changeset).role
     end
 
-    test "list_messages_for_agent/2 returns messages oldest first" do
+    test "list_messages_for_agent/2 returns messages oldest first", %{
+      project: project,
+      agent2: agent
+    } do
       {:ok, _} =
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "chat-agent",
+          project_id: project.id,
+          agent_id: agent.id,
           role: "user",
           content: %{"text" => "first"}
         })
 
       {:ok, _} =
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "chat-agent",
+          project_id: project.id,
+          agent_id: agent.id,
           role: "agent",
           content: %{"text" => "second"}
         })
 
-      {messages, _has_more} = Agents.list_messages_for_agent(@project, "chat-agent")
+      {messages, _has_more} = Agents.list_messages_for_agent(project.id, agent.id)
       assert length(messages) == 2
       assert Enum.at(messages, 0).content["text"] == "first"
       assert Enum.at(messages, 1).content["text"] == "second"
     end
 
-    test "list_inter_agent_messages/1 returns only inter_agent messages" do
+    test "list_inter_agent_messages/1 returns only inter_agent messages", %{
+      project: project,
+      agent2: agent
+    } do
       {:ok, _} =
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "chat-agent",
+          project_id: project.id,
+          agent_id: agent.id,
           role: "user",
           content: %{"text" => "hi"}
         })
 
       {:ok, _} =
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "chat-agent",
+          project_id: project.id,
+          agent_id: agent.id,
           role: "inter_agent",
           content: %{
             "text" => "Hello from Alice",
@@ -72,17 +87,20 @@ defmodule Shire.AgentsTest do
           }
         })
 
-      {messages, _has_more} = Agents.list_inter_agent_messages(@project)
+      {messages, _has_more} = Agents.list_inter_agent_messages(project.id)
       assert length(messages) == 1
       assert hd(messages).role == "inter_agent"
       assert hd(messages).content["from_agent"] == "Alice"
     end
 
-    test "list_inter_agent_messages/2 supports cursor-based pagination" do
+    test "list_inter_agent_messages/2 supports cursor-based pagination", %{
+      project: project,
+      agent2: agent
+    } do
       for i <- 1..3 do
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "chat-agent",
+          project_id: project.id,
+          agent_id: agent.id,
           role: "inter_agent",
           content: %{
             "text" => "msg-#{i}",
@@ -92,80 +110,110 @@ defmodule Shire.AgentsTest do
         })
       end
 
-      {first_page, has_more} = Agents.list_inter_agent_messages(@project, limit: 2)
+      {first_page, has_more} = Agents.list_inter_agent_messages(project.id, limit: 2)
       assert length(first_page) == 2
       assert has_more
 
       oldest_id = List.last(first_page).id
 
       {second_page, has_more2} =
-        Agents.list_inter_agent_messages(@project, before: oldest_id, limit: 2)
+        Agents.list_inter_agent_messages(project.id, before: oldest_id, limit: 2)
 
       assert length(second_page) == 1
       refute has_more2
     end
 
-    test "rename_agent_messages/3 updates agent_name on all messages" do
-      {:ok, _} =
-        Agents.create_message(%{
-          project_name: @project,
-          agent_name: "old-agent",
-          role: "user",
-          content: %{"text" => "hello"}
-        })
+    test "send_message_with_inbox/6 inserts message and writes inbox file", %{
+      project: project,
+      agent: agent
+    } do
+      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-1.json"
+      envelope = %{"role" => "user", "content" => "hello"}
 
-      {:ok, _} =
-        Agents.create_message(%{
-          project_name: @project,
-          agent_name: "old-agent",
-          role: "agent",
-          content: %{"text" => "reply"}
-        })
+      assert {:ok, msg} =
+               Agents.send_message_with_inbox(
+                 project.id,
+                 agent.id,
+                 "hello",
+                 inbox_path,
+                 envelope,
+                 @vm
+               )
 
-      {:ok, _} =
-        Agents.create_message(%{
-          project_name: @project,
-          agent_name: "unrelated-agent",
-          role: "user",
-          content: %{"text" => "keep me"}
-        })
-
-      {count, _} = Agents.rename_agent_messages(@project, "old-agent", "new-agent")
-      assert count == 2
-
-      {old_msgs, _} = Agents.list_messages_for_agent(@project, "old-agent")
-      assert old_msgs == []
-
-      {new_msgs, _} = Agents.list_messages_for_agent(@project, "new-agent")
-      assert length(new_msgs) == 2
-
-      {unrelated_msgs, _} = Agents.list_messages_for_agent(@project, "unrelated-agent")
-      assert length(unrelated_msgs) == 1
+      assert msg.role == "user"
+      assert msg.content == %{"text" => "hello"}
+      assert msg.agent_id == agent.id
+      assert msg.project_id == project.id
     end
 
-    test "delete_messages_for_agent/2 deletes all messages for an agent" do
+    test "send_message_with_inbox/6 rolls back message on VM write failure", %{
+      project: project,
+      agent: agent
+    } do
+      defmodule FailingWriteVM do
+        @behaviour Shire.VirtualMachine
+        def cmd(_p, _c, _a \\ [], _o \\ []), do: {:ok, ""}
+        def cmd!(_p, _c, _a \\ [], _o \\ []), do: ""
+        def read(_p, _path), do: {:ok, ""}
+        def write(_p, _path, _content), do: {:error, :disk_full}
+        def mkdir_p(_p, _path), do: :ok
+        def rm(_p, _path), do: :ok
+        def rm_rf(_p, _path), do: :ok
+        def ls(_p, _path), do: {:ok, []}
+        def stat(_p, _path), do: {:ok, %{type: :file, size: 0}}
+        def spawn_command(_p, _c, _a \\ [], _o \\ []), do: {:error, :not_available}
+        def write_stdin(_c, _d), do: :ok
+        def resize(_c, _r, _cols), do: :ok
+
+        def destroy_vm(_p), do: :ok
+      end
+
+      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-2.json"
+      envelope = %{"role" => "user", "content" => "fail"}
+
+      assert {:error, :disk_full} =
+               Agents.send_message_with_inbox(
+                 project.id,
+                 agent.id,
+                 "fail",
+                 inbox_path,
+                 envelope,
+                 FailingWriteVM
+               )
+
+      # Message should not have been persisted
+      {messages, _} = Agents.list_messages_for_agent(project.id, agent.id)
+      refute Enum.any?(messages, &(&1.content["text"] == "fail"))
+    end
+
+    test "delete_agent_with_vm/3 deletes agent and its messages", %{project: project} do
+      {:ok, del_agent} =
+        Agents.create_agent_with_vm(project.id, "delete-test", "version: 1\n", @vm)
+
       {:ok, _} =
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "delete-test",
+          project_id: project.id,
+          agent_id: del_agent.id,
           role: "user",
           content: %{"text" => "hi"}
         })
 
+      {:ok, other_agent} =
+        Agents.create_agent_with_vm(project.id, "other-agent", "version: 1\n", @vm)
+
       {:ok, _} =
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "other-agent",
+          project_id: project.id,
+          agent_id: other_agent.id,
           role: "user",
           content: %{"text" => "keep me"}
         })
 
-      Agents.delete_messages_for_agent(@project, "delete-test")
+      :ok = Agents.delete_agent_with_vm(project.id, del_agent, @vm)
 
-      {msgs, _} = Agents.list_messages_for_agent(@project, "delete-test")
-      assert msgs == []
+      assert {:error, :not_found} = Agents.get_agent(del_agent.id)
 
-      {other_msgs, _} = Agents.list_messages_for_agent(@project, "other-agent")
+      {other_msgs, _} = Agents.list_messages_for_agent(project.id, other_agent.id)
       assert length(other_msgs) == 1
     end
   end

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -15,7 +15,6 @@ defmodule Shire.ProjectManagerTest do
       {:error, :not_available_in_test}
     end)
 
-    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
 
     start_supervised!(ProjectManager)
@@ -37,97 +36,111 @@ defmodule Shire.ProjectManagerTest do
     end
 
     test "returns projects with :running status after creation" do
-      {:ok, _pid} = ProjectManager.create_project("my-project")
+      {:ok, project} = ProjectManager.create_project("my-project")
 
       projects = ProjectManager.list_projects()
       assert length(projects) == 1
       assert hd(projects).name == "my-project"
+      assert hd(projects).id == project.id
       assert hd(projects).status == :running
     end
   end
 
   describe "create_project/1" do
-    test "creates a project and returns {:ok, pid}" do
-      assert {:ok, pid} = ProjectManager.create_project("test-proj")
-      assert is_pid(pid)
+    test "creates a project and returns {:ok, project}" do
+      assert {:ok, project} = ProjectManager.create_project("test-proj")
+      assert is_binary(project.id)
+      assert project.name == "test-proj"
     end
 
     test "returns {:error, :already_exists} for duplicate name" do
-      {:ok, _pid} = ProjectManager.create_project("dup-proj")
+      {:ok, _project} = ProjectManager.create_project("dup-proj")
       assert {:error, :already_exists} = ProjectManager.create_project("dup-proj")
     end
 
-    test "broadcasts {:project_created, name} via PubSub" do
+    test "broadcasts {:project_created, project} via PubSub" do
       Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
 
-      {:ok, _pid} = ProjectManager.create_project("broadcast-proj")
+      {:ok, project} = ProjectManager.create_project("broadcast-proj")
 
-      assert_receive {:project_created, "broadcast-proj"}
+      assert_receive {:project_created, ^project}
     end
   end
 
   describe "destroy_project/1" do
     test "removes a project from the list" do
-      {:ok, _pid} = ProjectManager.create_project("destroy-me")
-      assert :ok = ProjectManager.destroy_project("destroy-me")
+      {:ok, project} = ProjectManager.create_project("destroy-me")
+      assert :ok = ProjectManager.destroy_project(project.id)
       assert ProjectManager.list_projects() == []
     end
 
     test "returns {:error, :not_found} for non-existent project" do
-      assert {:error, :not_found} = ProjectManager.destroy_project("nope")
+      assert {:error, :not_found} =
+               ProjectManager.destroy_project("00000000-0000-0000-0000-000000000000")
     end
 
-    test "broadcasts {:project_destroyed, name} via PubSub" do
-      {:ok, _pid} = ProjectManager.create_project("destroy-broadcast")
+    test "broadcasts {:project_destroyed, project_id} via PubSub" do
+      {:ok, project} = ProjectManager.create_project("destroy-broadcast")
 
       Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
 
-      :ok = ProjectManager.destroy_project("destroy-broadcast")
+      :ok = ProjectManager.destroy_project(project.id)
 
-      assert_receive {:project_destroyed, "destroy-broadcast"}
+      project_id = project.id
+      assert_receive {:project_destroyed, ^project_id}
     end
   end
 
   describe "lookup_coordinator/1" do
     test "returns {:ok, pid} for existing project" do
-      {:ok, _pid} = ProjectManager.create_project("lookup-proj")
+      {:ok, project} = ProjectManager.create_project("lookup-proj")
       Process.sleep(50)
 
-      assert {:ok, pid} = ProjectManager.lookup_coordinator("lookup-proj")
+      assert {:ok, pid} = ProjectManager.lookup_coordinator(project.id)
       assert is_pid(pid)
     end
 
     test "returns {:error, :not_found} for non-existent project" do
-      assert {:error, :not_found} = ProjectManager.lookup_coordinator("nope")
+      assert {:error, :not_found} =
+               ProjectManager.lookup_coordinator("00000000-0000-0000-0000-000000000000")
     end
   end
 
   describe "lookup_vm/1" do
     test "returns {:ok, pid} for existing project" do
-      {:ok, _pid} = ProjectManager.create_project("vm-proj")
+      {:ok, project} = ProjectManager.create_project("vm-proj")
       Process.sleep(50)
 
-      assert {:ok, pid} = ProjectManager.lookup_vm("vm-proj")
+      assert {:ok, pid} = ProjectManager.lookup_vm(project.id)
       assert is_pid(pid)
     end
 
     test "returns {:error, :not_found} for non-existent project" do
-      assert {:error, :not_found} = ProjectManager.lookup_vm("nope")
+      assert {:error, :not_found} =
+               ProjectManager.lookup_vm("00000000-0000-0000-0000-000000000000")
     end
   end
 
   describe "supervisor monitoring" do
-    test "removes project when supervisor goes down" do
-      {:ok, sup_pid} = ProjectManager.create_project("monitor-proj")
+    test "marks project as stopped when supervisor goes down" do
+      {:ok, project} = ProjectManager.create_project("monitor-proj")
 
       Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
+
+      # Get the supervisor pid from the ProjectManager state
+      projects_state = :sys.get_state(ProjectManager)
+      sup_pid = Map.get(projects_state.projects, project.id)
 
       # Kill the supervisor
       Process.exit(sup_pid, :kill)
 
-      assert_receive {:project_destroyed, "monitor-proj"}, 1000
+      project_id = project.id
+      assert_receive {:project_destroyed, ^project_id}, 1000
 
-      assert ProjectManager.list_projects() == []
+      # DB record still exists but status is :stopped (no running supervisor)
+      projects = ProjectManager.list_projects()
+      assert length(projects) == 1
+      assert hd(projects).status == :stopped
     end
   end
 end

--- a/test/shire/projects_test.exs
+++ b/test/shire/projects_test.exs
@@ -1,0 +1,81 @@
+defmodule Shire.ProjectsTest do
+  use Shire.DataCase, async: true
+
+  alias Shire.Projects
+
+  describe "create_project/1" do
+    test "creates a project with valid name" do
+      assert {:ok, project} = Projects.create_project("my-project")
+      assert project.name == "my-project"
+      assert project.id
+    end
+
+    test "rejects duplicate names" do
+      {:ok, _} = Projects.create_project("unique-name")
+      assert {:error, changeset} = Projects.create_project("unique-name")
+      assert "has already been taken" in errors_on(changeset).name
+    end
+
+    test "requires name" do
+      assert {:error, changeset} = Projects.create_project(nil)
+      assert "can't be blank" in errors_on(changeset).name
+    end
+  end
+
+  describe "get_project!/1" do
+    test "returns project by id" do
+      {:ok, project} = Projects.create_project("get-test")
+      assert Projects.get_project!(project.id).name == "get-test"
+    end
+
+    test "raises on missing id" do
+      assert_raise Ecto.NoResultsError, fn ->
+        Projects.get_project!(Ecto.UUID.generate())
+      end
+    end
+  end
+
+  describe "get_project_by_id/1" do
+    test "returns project or nil" do
+      {:ok, project} = Projects.create_project("by-id-test")
+      assert Projects.get_project_by_id(project.id).name == "by-id-test"
+      assert Projects.get_project_by_id(Ecto.UUID.generate()) == nil
+    end
+  end
+
+  describe "get_project_by_name/1" do
+    test "returns project or nil" do
+      {:ok, _} = Projects.create_project("by-name-test")
+      assert Projects.get_project_by_name("by-name-test").name == "by-name-test"
+      assert Projects.get_project_by_name("nonexistent") == nil
+    end
+  end
+
+  describe "list_projects/0" do
+    test "returns projects ordered by name" do
+      {:ok, _} = Projects.create_project("zeta")
+      {:ok, _} = Projects.create_project("alpha")
+      {:ok, _} = Projects.create_project("mid")
+
+      names = Projects.list_projects() |> Enum.map(& &1.name)
+      assert names == ["alpha", "mid", "zeta"]
+    end
+  end
+
+  describe "rename_project/2" do
+    test "updates the project name" do
+      {:ok, project} = Projects.create_project("old-name")
+      assert {:ok, renamed} = Projects.rename_project(project, "new-name")
+      assert renamed.name == "new-name"
+      assert Projects.get_project!(project.id).name == "new-name"
+    end
+  end
+
+  describe "delete_project/1" do
+    test "deletes the project" do
+      {:ok, project} = Projects.create_project("delete-me")
+      assert {:ok, _} = Projects.delete_project(project)
+      assert Projects.get_project_by_id(project.id) == nil
+    end
+  end
+end

--- a/test/shire/virtual_machine_test.exs
+++ b/test/shire/virtual_machine_test.exs
@@ -3,7 +3,7 @@ defmodule Shire.VirtualMachineImplTest do
 
   alias Shire.VirtualMachineImpl, as: VM
 
-  @project "test-project"
+  @project_id "test-project"
 
   describe "build_filesystem/1 patches base_url" do
     test "adds /v1/sprites/{name} prefix to base_url" do
@@ -56,7 +56,7 @@ defmodule Shire.VirtualMachineImplTest do
       import ExUnit.CaptureLog
 
       assert capture_log([level: :info], fn ->
-               VM.terminate(:shutdown, %{sprite: nil, fs: nil, project_name: @project})
+               VM.terminate(:shutdown, %{sprite: nil, fs: nil, project_id: @project_id})
                Logger.flush()
              end) =~ "VirtualMachineImpl stopping (no VM"
     end
@@ -65,7 +65,7 @@ defmodule Shire.VirtualMachineImplTest do
       import ExUnit.CaptureLog
 
       assert capture_log([level: :info], fn ->
-               VM.terminate(:shutdown, %{sprite: :fake, fs: :fake, project_name: @project})
+               VM.terminate(:shutdown, %{sprite: :fake, fs: :fake, project_id: @project_id})
                Logger.flush()
              end) =~ "VirtualMachineImpl stopping"
     end
@@ -99,7 +99,7 @@ defmodule Shire.VirtualMachineImplTest do
     end
 
     test "touch_keepalive is triggered by VM calls (via get_sprite)" do
-      pid = start_supervised!({VM, [project_name: @project]}, id: :keepalive_test_vm)
+      pid = start_supervised!({VM, [project_id: @project_id]}, id: :keepalive_test_vm)
 
       _sprite = GenServer.call(pid, :get_sprite)
 
@@ -109,7 +109,7 @@ defmodule Shire.VirtualMachineImplTest do
     end
 
     test "subsequent VM calls extend ping_until" do
-      pid = start_supervised!({VM, [project_name: @project]}, id: :keepalive_extend_vm)
+      pid = start_supervised!({VM, [project_id: @project_id]}, id: :keepalive_extend_vm)
 
       GenServer.call(pid, :get_sprite)
       state1 = :sys.get_state(pid)

--- a/test/shire_web/controllers/page_controller_test.exs
+++ b/test/shire_web/controllers/page_controller_test.exs
@@ -1,11 +1,7 @@
 defmodule ShireWeb.PageControllerTest do
   use ShireWeb.ConnCase, async: false
 
-  import Mox
-
   setup do
-    Mox.set_mox_global()
-    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
     start_supervised!(Shire.ProjectManager)
     :ok
   end

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -14,7 +14,6 @@ defmodule ShireWeb.AgentLiveTest do
       {:error, :not_available_in_test}
     end)
 
-
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
 
     start_supervised!(Shire.ProjectManager)

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -4,8 +4,6 @@ defmodule ShireWeb.AgentLiveTest do
   import Phoenix.LiveViewTest
   import Mox
 
-  @project "test-project"
-
   setup do
     Mox.set_mox_global()
 
@@ -16,29 +14,27 @@ defmodule ShireWeb.AgentLiveTest do
       {:error, :not_available_in_test}
     end)
 
-    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
+
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
 
     start_supervised!(Shire.ProjectManager)
 
+    # Create a DB-backed project
+    {:ok, project} = Shire.Projects.create_project("test-project")
+    project_id = project.id
+
+    # Start the coordinator and agent supervisor for this project
     start_supervised!(
       {DynamicSupervisor,
-       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, @project}}},
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
        strategy: :one_for_one},
       id: :agent_sup
     )
 
-    start_supervised!({Shire.Agent.Coordinator, project_name: @project})
+    start_supervised!({Shire.Agent.Coordinator, project_id: project_id})
     Process.sleep(50)
 
-    on_exit(fn ->
-      for {_, pid, _, _} <- DynamicSupervisor.which_children(Shire.ProjectSupervisor),
-          is_pid(pid) do
-        DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, pid)
-      end
-    end)
-
-    :ok
+    %{project_id: project_id}
   end
 
   describe "Index" do
@@ -47,17 +43,20 @@ defmodule ShireWeb.AgentLiveTest do
                live(conn, ~p"/projects/nonexistent")
     end
 
-    test "renders agent list page", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}")
+    test "renders agent list page", %{conn: conn, project_id: project_id} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_id}")
       assert html =~ "AgentDashboard"
     end
 
-    test "handles {:agent_status, agent_name, status} from lobby", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "handles {:agent_status, agent_id, status} from lobby", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agents:lobby",
+        "project:#{project_id}:agents:lobby",
         {:agent_status, "test-agent", :active}
       )
 
@@ -65,12 +64,15 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentDashboard"
     end
 
-    test "handles agent_busy broadcast without crashing", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "handles agent_busy broadcast without crashing", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agents:lobby",
+        "project:#{project_id}:agents:lobby",
         {:agent_busy, "test-agent", true}
       )
 
@@ -80,11 +82,13 @@ defmodule ShireWeb.AgentLiveTest do
 
     # --- select-agent ---
 
-    test "select-agent with nonexistent agent shows error flash", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "select-agent with nonexistent agent shows error flash", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
-      # In test env, Coordinator has no VM, so get_agent returns {:error, :no_vm}
-      render_hook(view, "select-agent", %{"name" => "nonexistent-agent"})
+      render_hook(view, "select-agent", %{"id" => "00000000-0000-0000-0000-000000000000"})
 
       html = render(view)
       assert html =~ "AgentDashboard"
@@ -92,30 +96,10 @@ defmodule ShireWeb.AgentLiveTest do
 
     # --- delete-agent ---
 
-    test "delete-agent succeeds and refreshes agents list", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "delete-agent does not crash the view", %{conn: conn, project_id: project_id} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
-      render_hook(view, "delete-agent", %{"name" => "some-agent"})
-
-      html = render(view)
-      assert html =~ "AgentDashboard"
-    end
-
-    test "delete-agent clears selection when deleted agent was selected", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
-
-      # First try selecting (will fail due to no VM, but that's ok)
-      # Then delete the agent that was "selected" — verifying it clears
-      render_hook(view, "delete-agent", %{"name" => "selected-agent"})
-
-      html = render(view)
-      assert html =~ "AgentDashboard"
-    end
-
-    test "delete-agent preserves selection when different agent is deleted", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
-
-      render_hook(view, "delete-agent", %{"name" => "other-agent"})
+      render_hook(view, "delete-agent", %{"id" => "00000000-0000-0000-0000-000000000000"})
 
       html = render(view)
       assert html =~ "AgentDashboard"
@@ -123,23 +107,22 @@ defmodule ShireWeb.AgentLiveTest do
 
     # --- update-agent ---
 
-    test "update-agent does not crash the view", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "update-agent does not crash the view", %{conn: conn, project_id: project_id} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       render_hook(view, "update-agent", %{
-        "name" => "test-agent",
+        "id" => "00000000-0000-0000-0000-000000000000",
         "recipe_yaml" => "version: 1\nname: test-agent\ndescription: Updated desc\n"
       })
 
       html = render(view)
-      # Result depends on VM availability: either "Agent updated" or "Failed to update"
       assert html =~ "AgentDashboard"
     end
 
     # --- create-agent ---
 
-    test "create-agent does not crash the view", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "create-agent does not crash the view", %{conn: conn, project_id: project_id} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       name = "create-test-#{System.unique_integer([:positive])}"
 
@@ -154,8 +137,8 @@ defmodule ShireWeb.AgentLiveTest do
 
     # --- load-more ---
 
-    test "load-more with no selected agent is a no-op", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "load-more with no selected agent is a no-op", %{conn: conn, project_id: project_id} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       render_hook(view, "load-more", %{"before" => "999"})
 
@@ -165,10 +148,13 @@ defmodule ShireWeb.AgentLiveTest do
 
     # --- edit-agent ---
 
-    test "edit-agent with nonexistent agent shows error flash", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "edit-agent with nonexistent agent shows error flash", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
-      render_hook(view, "edit-agent", %{"name" => "nonexistent"})
+      render_hook(view, "edit-agent", %{"id" => "00000000-0000-0000-0000-000000000000"})
 
       html = render(view)
       assert html =~ "AgentDashboard"
@@ -176,28 +162,33 @@ defmodule ShireWeb.AgentLiveTest do
 
     # --- PubSub: agent_status updates statuses map ---
 
-    test "agent_status broadcast updates agent_statuses assign", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "agent_status broadcast updates agent_statuses assign", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agents:lobby",
+        "project:#{project_id}:agents:lobby",
         {:agent_status, "my-agent", :bootstrapping}
       )
 
-      # Give it a moment to process
       html = render(view)
       assert html =~ "AgentDashboard"
     end
 
     # --- PubSub: agent_updated refreshes agents list ---
 
-    test "agent_updated broadcast refreshes agents list", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "agent_updated broadcast refreshes agents list", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agents:lobby",
+        "project:#{project_id}:agents:lobby",
         {:agent_updated, "some-agent"}
       )
 
@@ -207,12 +198,15 @@ defmodule ShireWeb.AgentLiveTest do
 
     # --- PubSub: agent_deleted refreshes agents list ---
 
-    test "agent_deleted broadcast refreshes agents list", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "agent_deleted broadcast refreshes agents list", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agents:lobby",
+        "project:#{project_id}:agents:lobby",
         {:agent_deleted, "some-agent"}
       )
 
@@ -220,12 +214,15 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentDashboard"
     end
 
-    test "agent_event for non-selected agent is ignored", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}")
+    test "agent_event for non-selected agent is ignored", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agents:lobby",
+        "project:#{project_id}:agents:lobby",
         {:agent_event, "unselected-agent", %{"type" => "text_delta"}}
       )
 
@@ -235,42 +232,55 @@ defmodule ShireWeb.AgentLiveTest do
   end
 
   describe "Show" do
-    test "renders agent show page", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/agents/test-agent")
+    test "renders agent show page", %{conn: conn, project_id: project_id} do
+      agent = create_db_agent(project_id, "test-agent-show")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_id}/agents/#{agent.id}")
       assert html =~ "AgentShow"
     end
 
-    test "mount sets agent with status", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/agents/my-agent")
+    test "mount sets agent with status", %{conn: conn, project_id: project_id} do
+      agent = create_db_agent(project_id, "my-agent-show")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_id}/agents/#{agent.id}")
       assert html =~ "AgentShow"
     end
 
-    test "update-agent handler does not crash the view", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/test-agent")
+    test "update-agent handler does not crash the view", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      agent = create_db_agent(project_id, "test-agent-update")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}/agents/#{agent.id}")
 
       render_hook(view, "update-agent", %{
         "recipe_yaml" =>
-          "version: 1\nname: test-agent\ndescription: new desc\nharness: claude_code\n"
+          "version: 1\nname: test-agent-update\ndescription: new desc\nharness: claude_code\n"
       })
 
       html = render(view)
-      # Result depends on VM availability
       assert html =~ "AgentShow"
     end
 
-    test "delete-agent handler redirects to project index", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/delete-me")
+    test "delete-agent handler redirects to project index", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      agent = create_db_agent(project_id, "delete-me")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}/agents/#{agent.id}")
 
       render_hook(view, "delete-agent", %{})
-      assert_redirect(view, "/projects/#{@project}")
+      assert_redirect(view, "/projects/#{project_id}")
     end
 
-    test "status broadcast updates agent status assign", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/status-agent")
+    test "status broadcast updates agent status assign", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      agent = create_db_agent(project_id, "status-agent")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}/agents/#{agent.id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agent:status-agent",
+        "project:#{project_id}:agent:#{agent.id}",
         {:status, :active}
       )
 
@@ -278,12 +288,16 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentShow"
     end
 
-    test "status broadcast updates the agent map with new status", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/status-agent")
+    test "status broadcast updates the agent map with new status", %{
+      conn: conn,
+      project_id: project_id
+    } do
+      agent = create_db_agent(project_id, "status-agent-2")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}/agents/#{agent.id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agent:status-agent",
+        "project:#{project_id}:agent:#{agent.id}",
         {:status, :failed}
       )
 
@@ -291,17 +305,30 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentShow"
     end
 
-    test "agent_event broadcast does not crash", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{@project}/agents/test-agent")
+    test "agent_event broadcast does not crash", %{conn: conn, project_id: project_id} do
+      agent = create_db_agent(project_id, "test-agent-event")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}/agents/#{agent.id}")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{@project}:agent:test-agent",
-        {:agent_event, "test-agent", %{"type" => "text_delta", "payload" => %{"delta" => "hi"}}}
+        "project:#{project_id}:agent:#{agent.id}",
+        {:agent_event, agent.id, %{"type" => "text_delta", "payload" => %{"delta" => "hi"}}}
       )
 
       html = render(view)
       assert html =~ "AgentShow"
     end
+  end
+
+  defp create_db_agent(project_id, name) do
+    {:ok, agent} =
+      Shire.Agents.create_agent_with_vm(
+        project_id,
+        name,
+        "version: 1\nname: #{name}\n",
+        Shire.VirtualMachineStub
+      )
+
+    agent
   end
 end

--- a/test/shire_web/live/project_live_test.exs
+++ b/test/shire_web/live/project_live_test.exs
@@ -14,7 +14,6 @@ defmodule ShireWeb.ProjectLiveTest do
       {:error, :not_available_in_test}
     end)
 
-    stub(Shire.VirtualMachineMock, :list_vms, fn -> {:ok, []} end)
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
 
     start_supervised!(Shire.ProjectManager)
@@ -46,7 +45,7 @@ defmodule ShireWeb.ProjectLiveTest do
     end
 
     test "create-project with duplicate name shows error", %{conn: conn} do
-      {:ok, _pid} = Shire.ProjectManager.create_project("existing")
+      {:ok, _project} = Shire.ProjectManager.create_project("existing")
       {:ok, view, _html} = live(conn, ~p"/")
 
       render_hook(view, "create-project", %{"name" => "existing"})
@@ -56,10 +55,10 @@ defmodule ShireWeb.ProjectLiveTest do
     end
 
     test "delete-project event removes a project", %{conn: conn} do
-      {:ok, _pid} = Shire.ProjectManager.create_project("delete-me")
+      {:ok, project} = Shire.ProjectManager.create_project("delete-me")
       {:ok, view, _html} = live(conn, ~p"/")
 
-      render_hook(view, "delete-project", %{"name" => "delete-me"})
+      render_hook(view, "delete-project", %{"id" => project.id})
 
       assert Shire.ProjectManager.list_projects() == []
     end
@@ -67,7 +66,7 @@ defmodule ShireWeb.ProjectLiveTest do
     test "PubSub project_created message refreshes list", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/")
 
-      {:ok, _pid} = Shire.ProjectManager.create_project("pubsub-proj")
+      {:ok, _project} = Shire.ProjectManager.create_project("pubsub-proj")
 
       # The PubSub broadcast from create_project should refresh the LiveView
       html = render(view)
@@ -75,10 +74,10 @@ defmodule ShireWeb.ProjectLiveTest do
     end
 
     test "PubSub project_destroyed message refreshes list", %{conn: conn} do
-      {:ok, _pid} = Shire.ProjectManager.create_project("destroy-proj")
+      {:ok, project} = Shire.ProjectManager.create_project("destroy-proj")
       {:ok, view, _html} = live(conn, ~p"/")
 
-      :ok = Shire.ProjectManager.destroy_project("destroy-proj")
+      :ok = Shire.ProjectManager.destroy_project(project.id)
 
       html = render(view)
       assert html =~ "ProjectDashboard"

--- a/test/shire_web/live/settings_live_test.exs
+++ b/test/shire_web/live/settings_live_test.exs
@@ -6,8 +6,6 @@ defmodule ShireWeb.SettingsLiveTest do
 
   alias Shire.Agents
 
-  @project "test-project"
-
   setup do
     Mox.set_mox_global()
 
@@ -18,29 +16,42 @@ defmodule ShireWeb.SettingsLiveTest do
       {:error, :not_available_in_test}
     end)
 
+    # Create a DB-backed project
+    {:ok, project} = Shire.Projects.create_project("test-project-settings")
+    project_id = project.id
+
     start_supervised!(
       {DynamicSupervisor,
-       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, @project}}},
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
        strategy: :one_for_one},
       id: :agent_sup
     )
 
-    start_supervised!({Shire.Agent.Coordinator, project_name: @project})
+    start_supervised!({Shire.Agent.Coordinator, project_id: project_id})
     Process.sleep(50)
-    :ok
+
+    %{project_id: project_id}
   end
 
   describe "Index" do
-    test "renders settings page", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/settings")
+    test "renders settings page", %{conn: conn, project_id: project_id} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_id}/settings")
       assert html =~ "SettingsPage"
     end
 
-    test "loads inter-agent messages", %{conn: conn} do
+    test "loads inter-agent messages", %{conn: conn, project_id: project_id} do
+      {:ok, agent} =
+        Agents.create_agent_with_vm(
+          project_id,
+          "test-agent",
+          "version: 1\n",
+          Shire.VirtualMachineStub
+        )
+
       {:ok, _msg} =
         Agents.create_message(%{
-          project_name: @project,
-          agent_name: "test-agent",
+          project_id: project_id,
+          agent_id: agent.id,
           role: "inter_agent",
           content: %{
             "text" => "Hello from Alice",
@@ -49,7 +60,7 @@ defmodule ShireWeb.SettingsLiveTest do
           }
         })
 
-      {:ok, _view, html} = live(conn, ~p"/projects/#{@project}/settings")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_id}/settings")
       assert html =~ "Hello from Alice"
       assert html =~ "Alice"
     end

--- a/test/support/vm_stub.ex
+++ b/test/support/vm_stub.ex
@@ -6,34 +6,34 @@ defmodule Shire.VirtualMachineStub do
   @behaviour Shire.VirtualMachine
 
   @impl true
-  def cmd(_project_name, _command, _args \\ [], _opts \\ []), do: {:ok, ""}
+  def cmd(_project_id, _command, _args \\ [], _opts \\ []), do: {:ok, ""}
 
   @impl true
-  def cmd!(_project_name, _command, _args \\ [], _opts \\ []), do: ""
+  def cmd!(_project_id, _command, _args \\ [], _opts \\ []), do: ""
 
   @impl true
-  def read(_project_name, _path), do: {:ok, ""}
+  def read(_project_id, _path), do: {:ok, ""}
 
   @impl true
-  def write(_project_name, _path, _content), do: :ok
+  def write(_project_id, _path, _content), do: :ok
 
   @impl true
-  def mkdir_p(_project_name, _path), do: :ok
+  def mkdir_p(_project_id, _path), do: :ok
 
   @impl true
-  def rm(_project_name, _path), do: :ok
+  def rm(_project_id, _path), do: :ok
 
   @impl true
-  def rm_rf(_project_name, _path), do: :ok
+  def rm_rf(_project_id, _path), do: :ok
 
   @impl true
-  def ls(_project_name, _path), do: {:ok, []}
+  def ls(_project_id, _path), do: {:ok, []}
 
   @impl true
-  def stat(_project_name, _path), do: {:ok, %{type: :file, size: 0}}
+  def stat(_project_id, _path), do: {:ok, %{type: :file, size: 0}}
 
   @impl true
-  def spawn_command(_project_name, _command, _args \\ [], _opts \\ []),
+  def spawn_command(_project_id, _command, _args \\ [], _opts \\ []),
     do: {:error, :not_available_in_test}
 
   @impl true
@@ -43,8 +43,5 @@ defmodule Shire.VirtualMachineStub do
   def resize(_command, _rows, _cols), do: :ok
 
   @impl true
-  def list_vms, do: {:ok, []}
-
-  @impl true
-  def destroy_vm(_project_name), do: :ok
+  def destroy_vm(_project_id), do: :ok
 end


### PR DESCRIPTION
## Summary
- **Persist projects and agents in PostgreSQL** — new `projects` and `agents` tables with Ecto schemas, contexts, and migration
- **Migrate inter-agent messaging from JSON to YAML** — inbox/outbox files now use `.yaml`/`.yml` format, parsed with `js-yaml` (TS) and `yaml_elixir`/`ymlr` (Elixir) for robustness against agent-written malformed JSON
- **System message feedback loop** — when an agent writes an invalid outbox message (unparseable YAML, missing fields, wrong types), the system writes an error notification back to the agent's inbox explaining what went wrong, rendered as a collapsible "System notification" in the chat UI
- **Validation and cleanup** — outbox messages validated for required `to`/`text` fields, broken inbox files deleted to prevent infinite retry on startup

## Test plan
- [x] All 108 frontend tests pass (`bun run test` in assets/)
- [x] All 57 agent-runner tests pass (`bun test` in priv/sprite/)
- [x] All 142 Elixir tests pass (`mix test`)
- [x] TypeScript typecheck clean (`bun run tsc --noEmit`)
- [x] ESLint clean (assets/ and priv/sprite/)
- [x] Prettier clean (assets/ and priv/sprite/)
- [x] Elixir format clean (`mix format --check-formatted`)
- [x] Elixir compile clean (`mix compile --warnings-as-errors`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)