### PR TITLE
fix: send oldest message ID in load-more event

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -177,10 +177,13 @@ export default function ChatPanel({
   const handleScroll = React.useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container || !hasMore || loadingMore) return;
-    if (container.scrollTop === 0) {
-      pushEvent("load-more", {});
+    if (container.scrollTop === 0 && messages.length > 0) {
+      const oldest = messages[0];
+      if (oldest.id != null) {
+        pushEvent("load-more", { before: oldest.id });
+      }
     }
-  }, [hasMore, loadingMore, pushEvent]);
+  }, [hasMore, loadingMore, pushEvent, messages]);
 
   const handleSend = () => {
     const text = input.trim();

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -100,6 +100,28 @@ describe("ChatPanel", () => {
     expect(screen.getByText("done")).toBeInTheDocument();
   });
 
+  it("sends load-more with before param when scrolled to top", () => {
+    const pushEvent = vi.fn();
+    const { container } = render(<ChatPanel agent={activeAgent} messages={messages} hasMore pushEvent={pushEvent} />);
+
+    const scrollContainer = container.querySelector(".overflow-y-auto")!;
+    Object.defineProperty(scrollContainer, "scrollTop", { value: 0, writable: true });
+    fireEvent.scroll(scrollContainer);
+
+    expect(pushEvent).toHaveBeenCalledWith("load-more", { before: 1 });
+  });
+
+  it("does not send load-more when no messages", () => {
+    const pushEvent = vi.fn();
+    const { container } = render(<ChatPanel agent={activeAgent} messages={[]} hasMore pushEvent={pushEvent} />);
+
+    const scrollContainer = container.querySelector(".overflow-y-auto")!;
+    Object.defineProperty(scrollContainer, "scrollTop", { value: 0, writable: true });
+    fireEvent.scroll(scrollContainer);
+
+    expect(pushEvent).not.toHaveBeenCalled();
+  });
+
   it("shows loading indicator when loadingMore", () => {
     render(<ChatPanel agent={activeAgent} messages={messages} hasMore loadingMore pushEvent={vi.fn()} />);
     expect(screen.getByText("Loading older messages...")).toBeInTheDocument();

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -201,6 +201,10 @@ defmodule ShireWeb.AgentLive.Index do
     end
   end
 
+  def handle_event("load-more", _params, socket) do
+    {:noreply, socket}
+  end
+
   @impl true
   def handle_event("restart-agent", _params, socket) do
     project_id = socket.assigns.project.id

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -145,6 +145,15 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentDashboard"
     end
 
+    test "load-more with empty params does not crash", %{conn: conn, project_id: project_id} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_id}")
+
+      render_hook(view, "load-more", %{})
+
+      html = render(view)
+      assert html =~ "AgentDashboard"
+    end
+
     # --- edit-agent ---
 
     test "edit-agent with nonexistent agent shows error flash", %{


### PR DESCRIPTION
## Summary
- ChatPanel was sending `pushEvent("load-more", {})` with no params, causing a `FunctionClauseError` in `AgentLive.Index` which pattern-matched on `%{"before" => before}`
- Now sends `{ before: oldest.id }` from the React side, with guards for empty messages and missing IDs
- Added a defensive fallback clause in Elixir for `"load-more"` with unexpected params

## Test plan
- [x] New Vitest test: `load-more` event includes `{ before: <id> }` when scrolled to top
- [x] New Vitest test: `load-more` not sent when messages are empty
- [x] New ExUnit test: `"load-more"` with empty params doesn't crash the LiveView
- [x] All 107 frontend tests pass
- [x] All 24 LiveView tests pass
- [x] TypeScript, ESLint, Prettier, Elixir format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)