### PR TITLE
feat: enforce slug validation for project and agent names

### DIFF
--- a/assets/react-components/AgentForm.tsx
+++ b/assets/react-components/AgentForm.tsx
@@ -56,6 +56,8 @@ function parseRecipeYaml(yaml: string) {
   }
 }
 
+const SLUG_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
 export default function AgentForm({ open, title, agent, pushEvent, onClose }: AgentFormProps) {
   const [name, setName] = React.useState("");
   const [description, setDescription] = React.useState("");
@@ -65,6 +67,8 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
   const [skills, setSkills] = React.useState<Skill[]>([]);
   const [rawMode, setRawMode] = React.useState(false);
   const [rawYaml, setRawYaml] = React.useState("");
+
+  const nameValid = name === "" || SLUG_REGEX.test(name);
 
   React.useEffect(() => {
     setName(agent?.name || "");
@@ -89,6 +93,7 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
       finalName = parsed.name || name;
       recipeYaml = rawYaml;
     } else {
+      if (!SLUG_REGEX.test(name)) return;
       recipeYaml = buildRecipeYaml({ name, description, harness, model, systemPrompt, skills });
     }
 
@@ -192,7 +197,17 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
             <>
               <div className="space-y-2">
                 <Label htmlFor="name">Name</Label>
-                <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Agent name" />
+                <Input
+                  id="name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value.toLowerCase())}
+                  placeholder="my-agent"
+                />
+                {name && !nameValid && (
+                  <p className="text-sm text-destructive">
+                    Use lowercase letters, numbers, and hyphens only. Must start and end with a letter or number.
+                  </p>
+                )}
               </div>
               <div className="space-y-2">
                 <Label htmlFor="description">Description</Label>

--- a/assets/react-components/AgentForm.tsx
+++ b/assets/react-components/AgentForm.tsx
@@ -93,9 +93,10 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
       finalName = parsed.name || name;
       recipeYaml = rawYaml;
     } else {
-      if (!SLUG_REGEX.test(name)) return;
       recipeYaml = buildRecipeYaml({ name, description, harness, model, systemPrompt, skills });
     }
+
+    if (!SLUG_REGEX.test(finalName)) return;
 
     const event = agent ? "update-agent" : "create-agent";
     const payload: Record<string, unknown> = {

--- a/assets/test/AgentForm.test.tsx
+++ b/assets/test/AgentForm.test.tsx
@@ -146,6 +146,44 @@ describe("AgentForm", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not submit in raw YAML mode when name is not a valid slug", async () => {
+    const localPushEvent = vi.fn();
+    render(<AgentForm open={true} title="New Agent" agent={null} pushEvent={localPushEvent} onClose={vi.fn()} />);
+
+    const user = userEvent.setup();
+
+    // Switch to raw YAML mode
+    await user.click(screen.getByText("Raw YAML"));
+
+    // Enter YAML with an invalid name
+    const yamlInput = screen.getByLabelText("Recipe YAML");
+    await user.clear(yamlInput);
+    await user.paste('version: 1\nname: "Invalid Name!"');
+
+    await user.click(screen.getByText("Save Agent"));
+
+    expect(localPushEvent).not.toHaveBeenCalled();
+  });
+
+  it("submits in raw YAML mode when name is a valid slug", async () => {
+    const localPushEvent = vi.fn();
+    render(<AgentForm open={true} title="New Agent" agent={null} pushEvent={localPushEvent} onClose={vi.fn()} />);
+
+    const user = userEvent.setup();
+
+    // Switch to raw YAML mode
+    await user.click(screen.getByText("Raw YAML"));
+
+    // Enter YAML with a valid slug name
+    const yamlInput = screen.getByLabelText("Recipe YAML");
+    await user.clear(yamlInput);
+    await user.paste("version: 1\nname: valid-agent");
+
+    await user.click(screen.getByText("Save Agent"));
+
+    expect(localPushEvent).toHaveBeenCalledWith("create-agent", expect.objectContaining({ name: "valid-agent" }));
+  });
+
   it("submits update-agent event with recipe_yaml for existing agent", async () => {
     const agent: Agent = {
       id: "a-existing",

--- a/assets/test/AgentForm.test.tsx
+++ b/assets/test/AgentForm.test.tsx
@@ -94,6 +94,58 @@ describe("AgentForm", () => {
     expect(screen.getByPlaceholderText("Reference content...")).toBeInTheDocument();
   });
 
+  it("shows validation error for invalid agent name", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.clear(nameInput);
+    await user.paste("Invalid Name!");
+
+    expect(
+      screen.getByText("Use lowercase letters, numbers, and hyphens only. Must start and end with a letter or number."),
+    ).toBeInTheDocument();
+  });
+
+  it("auto-lowercases the name input", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "MyAgent");
+
+    expect(nameInput).toHaveValue("myagent");
+  });
+
+  it("does not submit when name is invalid", async () => {
+    const localPushEvent = vi.fn();
+    render(<AgentForm open={true} title="New Agent" agent={null} pushEvent={localPushEvent} onClose={vi.fn()} />);
+
+    const user = userEvent.setup();
+    const nameInput = screen.getByLabelText("Name");
+    await user.clear(nameInput);
+    await user.paste("-invalid");
+    await user.click(screen.getByText("Save Agent"));
+
+    expect(localPushEvent).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid slug names", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.clear(nameInput);
+    await user.paste("my-valid-agent");
+
+    expect(
+      screen.queryByText(
+        "Use lowercase letters, numbers, and hyphens only. Must start and end with a letter or number.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("submits update-agent event with recipe_yaml for existing agent", async () => {
     const agent: Agent = {
       id: "a-existing",

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -133,39 +133,43 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_call({:create_agent, %{"name" => name, "recipe_yaml" => recipe_yaml}}, _from, state) do
-    case Agents.create_agent_with_vm(state.project_id, name, recipe_yaml) do
-      {:ok, agent} ->
-        # Post-commit: write peers.yaml and start agent manager
-        write_peers_yaml(state.project_id)
+    unless Shire.Slug.valid?(name) do
+      {:reply, {:error, :invalid_name}, state}
+    else
+      case Agents.create_agent_with_vm(state.project_id, name, recipe_yaml) do
+        {:ok, agent} ->
+          # Post-commit: write peers.yaml and start agent manager
+          write_peers_yaml(state.project_id)
 
-        case start_agent_manager(state.project_id, agent.id, agent.name, state.monitors) do
-          {:ok, pid, monitors} ->
-            Phoenix.PubSub.broadcast(
-              Shire.PubSub,
-              "project:#{state.project_id}:agents:lobby",
-              {:agent_created, agent.id}
-            )
+          case start_agent_manager(state.project_id, agent.id, agent.name, state.monitors) do
+            {:ok, pid, monitors} ->
+              Phoenix.PubSub.broadcast(
+                Shire.PubSub,
+                "project:#{state.project_id}:agents:lobby",
+                {:agent_created, agent.id}
+              )
 
-            {:reply, {:ok, pid}, %{state | monitors: monitors}}
+              {:reply, {:ok, pid}, %{state | monitors: monitors}}
 
-          {:error, reason} ->
-            {:reply, {:error, reason}, state}
-        end
+            {:error, reason} ->
+              {:reply, {:error, reason}, state}
+          end
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        unique_error? =
-          Enum.any?(changeset.errors, fn {_field, {_msg, opts}} ->
-            opts[:constraint] == :unique
-          end)
+        {:error, %Ecto.Changeset{} = changeset} ->
+          unique_error? =
+            Enum.any?(changeset.errors, fn {_field, {_msg, opts}} ->
+              opts[:constraint] == :unique
+            end)
 
-        if unique_error? do
-          {:reply, {:error, :already_exists}, state}
-        else
-          {:reply, {:error, changeset}, state}
-        end
+          if unique_error? do
+            {:reply, {:error, :already_exists}, state}
+          else
+            {:reply, {:error, changeset}, state}
+          end
 
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+        {:error, reason} ->
+          {:reply, {:error, reason}, state}
+      end
     end
   end
 
@@ -183,44 +187,48 @@ defmodule Shire.Agent.Coordinator do
         # Update DB name if it changed
         name_changed = new_name && new_name != agent.name
 
-        with :ok <- maybe_rename(agent, new_name, name_changed),
-             :ok <-
-               @vm.write(
-                 state.project_id,
-                 "/workspace/agents/#{agent_id}/recipe.yaml",
-                 recipe_yaml
-               ) do
-          case lookup(state.project_id, agent_id) do
-            {:ok, _pid} -> AgentManager.restart(state.project_id, agent_id)
-            {:error, :not_found} -> :ok
-          end
+        if name_changed && !Shire.Slug.valid?(new_name) do
+          {:reply, {:error, :invalid_name}, state}
+        else
+          with :ok <- maybe_rename(agent, new_name, name_changed),
+               :ok <-
+                 @vm.write(
+                   state.project_id,
+                   "/workspace/agents/#{agent_id}/recipe.yaml",
+                   recipe_yaml
+                 ) do
+            case lookup(state.project_id, agent_id) do
+              {:ok, _pid} -> AgentManager.restart(state.project_id, agent_id)
+              {:error, :not_found} -> :ok
+            end
 
-          # Rewrite peers.yaml in case name or description changed
-          write_peers_yaml(state.project_id)
+            # Rewrite peers.yaml in case name or description changed
+            write_peers_yaml(state.project_id)
 
-          event =
-            if name_changed,
-              do: {:agent_renamed, agent_id, agent.name, new_name},
-              else: {:agent_updated, agent_id}
+            event =
+              if name_changed,
+                do: {:agent_renamed, agent_id, agent.name, new_name},
+                else: {:agent_updated, agent_id}
 
-          Phoenix.PubSub.broadcast(
-            Shire.PubSub,
-            "project:#{state.project_id}:agents:lobby",
-            event
-          )
-
-          # Also broadcast on agent-specific topic so show page gets the event
-          if name_changed do
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "project:#{state.project_id}:agent:#{agent_id}",
+              "project:#{state.project_id}:agents:lobby",
               event
             )
-          end
 
-          {:reply, :ok, state}
-        else
-          {:error, reason} -> {:reply, {:error, reason}, state}
+            # Also broadcast on agent-specific topic so show page gets the event
+            if name_changed do
+              Phoenix.PubSub.broadcast(
+                Shire.PubSub,
+                "project:#{state.project_id}:agent:#{agent_id}",
+                event
+              )
+            end
+
+            {:reply, :ok, state}
+          else
+            {:error, reason} -> {:reply, {:error, reason}, state}
+          end
         end
 
       {:error, :not_found} ->

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -107,33 +107,37 @@ defmodule Shire.ProjectManager do
 
   @impl true
   def handle_call({:create_project, name}, _from, state) do
-    # Check DB first
-    if Projects.get_project_by_name(name) do
-      {:reply, {:error, :already_exists}, state}
+    unless Shire.Slug.valid?(name) do
+      {:reply, {:error, :invalid_name}, state}
     else
-      case Projects.create_project(name) do
-        {:ok, project} ->
-          case start_project_subtree(project.id) do
-            {:ok, pid} ->
-              Process.monitor(pid)
-              projects = Map.put(state.projects, project.id, pid)
+      # Check DB first
+      if Projects.get_project_by_name(name) do
+        {:reply, {:error, :already_exists}, state}
+      else
+        case Projects.create_project(name) do
+          {:ok, project} ->
+            case start_project_subtree(project.id) do
+              {:ok, pid} ->
+                Process.monitor(pid)
+                projects = Map.put(state.projects, project.id, pid)
 
-              Phoenix.PubSub.broadcast(
-                Shire.PubSub,
-                "projects:lobby",
-                {:project_created, project}
-              )
+                Phoenix.PubSub.broadcast(
+                  Shire.PubSub,
+                  "projects:lobby",
+                  {:project_created, project}
+                )
 
-              {:reply, {:ok, project}, %{state | projects: projects}}
+                {:reply, {:ok, project}, %{state | projects: projects}}
 
-            {:error, reason} ->
-              # Subtree failed — clean up DB record
-              Projects.delete_project(project)
-              {:reply, {:error, reason}, state}
-          end
+              {:error, reason} ->
+                # Subtree failed — clean up DB record
+                Projects.delete_project(project)
+                {:reply, {:error, reason}, state}
+            end
 
-        {:error, changeset} ->
-          {:reply, {:error, changeset}, state}
+          {:error, changeset} ->
+            {:reply, {:error, changeset}, state}
+        end
       end
     end
   end

--- a/lib/shire/slug.ex
+++ b/lib/shire/slug.ex
@@ -1,0 +1,31 @@
+defmodule Shire.Slug do
+  @moduledoc """
+  Shared slug validation for project and agent names.
+  Slugs must be lowercase alphanumeric with dashes, starting and ending with a letter or number.
+  """
+
+  @regex ~r/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+
+  @doc "Returns the slug validation regex."
+  def regex, do: @regex
+
+  @doc "Returns true if the given string is a valid slug."
+  def valid?(name) when is_binary(name) do
+    String.length(name) >= 1 and String.length(name) <= 63 and
+      Regex.match?(@regex, name)
+  end
+
+  def valid?(_), do: false
+
+  @doc """
+  Slugifies a string: lowercases, replaces non-alphanumeric chars with dashes,
+  strips leading/trailing dashes, and collapses consecutive dashes.
+  """
+  def slugify(name) when is_binary(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9-]/, "-")
+    |> String.replace(~r/-+/, "-")
+    |> String.trim("-")
+  end
+end

--- a/priv/repo/migrations/20260319000001_enforce_agent_name_slugs.exs
+++ b/priv/repo/migrations/20260319000001_enforce_agent_name_slugs.exs
@@ -2,7 +2,11 @@ defmodule Shire.Repo.Migrations.EnforceAgentNameSlugs do
   use Ecto.Migration
 
   def up do
-    # Slugify existing non-compliant agent names in messages table
+    # Slugify existing non-compliant agent names in messages table.
+    # Note: this bulk UPDATE can produce collisions if two names like "My Agent"
+    # and "my-agent" both exist. This is intentional — agent_name in the messages
+    # table is not unique-constrained (multiple messages reference the same agent),
+    # so collisions simply normalize different spellings to the canonical slug form.
     execute("""
     UPDATE messages
     SET agent_name = LOWER(

--- a/priv/repo/migrations/20260319000001_enforce_agent_name_slugs.exs
+++ b/priv/repo/migrations/20260319000001_enforce_agent_name_slugs.exs
@@ -1,0 +1,25 @@
+defmodule Shire.Repo.Migrations.EnforceAgentNameSlugs do
+  use Ecto.Migration
+
+  def up do
+    # Slugify existing non-compliant agent names in messages table
+    execute("""
+    UPDATE messages
+    SET agent_name = LOWER(
+      TRIM(BOTH '-' FROM
+        REGEXP_REPLACE(
+          REGEXP_REPLACE(LOWER(agent_name), '[^a-z0-9-]', '-', 'g'),
+          '-+', '-', 'g'
+        )
+      )
+    )
+    WHERE agent_name !~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'
+      AND agent_name !~ '^[a-z0-9]$'
+    """)
+  end
+
+  def down do
+    # Data migration — cannot be reversed
+    :ok
+  end
+end

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -430,5 +430,68 @@ defmodule Shire.Agent.CoordinatorTest do
       result = Coordinator.create_agent(project_id, %{"name" => "no-recipe"})
       assert {:error, :missing_name_or_recipe} = result
     end
+
+    test "rejects agent name with uppercase letters" do
+      result =
+        Coordinator.create_agent(@project, %{
+          "name" => "MyAgent",
+          "recipe_yaml" => "version: 1\nname: MyAgent\n"
+        })
+
+      assert {:error, :invalid_name} = result
+    end
+
+    test "rejects agent name with spaces" do
+      result =
+        Coordinator.create_agent(@project, %{
+          "name" => "my agent",
+          "recipe_yaml" => "version: 1\nname: my agent\n"
+        })
+
+      assert {:error, :invalid_name} = result
+    end
+
+    test "rejects agent name with leading dash" do
+      result =
+        Coordinator.create_agent(@project, %{
+          "name" => "-invalid",
+          "recipe_yaml" => "version: 1\nname: -invalid\n"
+        })
+
+      assert {:error, :invalid_name} = result
+    end
+
+    test "rejects agent name with trailing dash" do
+      result =
+        Coordinator.create_agent(@project, %{
+          "name" => "invalid-",
+          "recipe_yaml" => "version: 1\nname: invalid-\n"
+        })
+
+      assert {:error, :invalid_name} = result
+    end
+
+    test "rejects agent name with underscores" do
+      result =
+        Coordinator.create_agent(@project, %{
+          "name" => "my_agent",
+          "recipe_yaml" => "version: 1\nname: my_agent\n"
+        })
+
+      assert {:error, :invalid_name} = result
+    end
+  end
+
+  describe "update_agent/3 with invalid new name" do
+    test "rejects rename to an invalid slug" do
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+
+      result =
+        Coordinator.update_agent(@project, "old-name", %{
+          "recipe_yaml" => "version: 1\nname: Invalid Name!\n"
+        })
+
+      assert {:error, :invalid_name} = result
+    end
   end
 end

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -431,9 +431,9 @@ defmodule Shire.Agent.CoordinatorTest do
       assert {:error, :missing_name_or_recipe} = result
     end
 
-    test "rejects agent name with uppercase letters" do
+    test "rejects agent name with uppercase letters", %{project_id: project_id} do
       result =
-        Coordinator.create_agent(@project, %{
+        Coordinator.create_agent(project_id, %{
           "name" => "MyAgent",
           "recipe_yaml" => "version: 1\nname: MyAgent\n"
         })
@@ -441,9 +441,9 @@ defmodule Shire.Agent.CoordinatorTest do
       assert {:error, :invalid_name} = result
     end
 
-    test "rejects agent name with spaces" do
+    test "rejects agent name with spaces", %{project_id: project_id} do
       result =
-        Coordinator.create_agent(@project, %{
+        Coordinator.create_agent(project_id, %{
           "name" => "my agent",
           "recipe_yaml" => "version: 1\nname: my agent\n"
         })
@@ -451,9 +451,9 @@ defmodule Shire.Agent.CoordinatorTest do
       assert {:error, :invalid_name} = result
     end
 
-    test "rejects agent name with leading dash" do
+    test "rejects agent name with leading dash", %{project_id: project_id} do
       result =
-        Coordinator.create_agent(@project, %{
+        Coordinator.create_agent(project_id, %{
           "name" => "-invalid",
           "recipe_yaml" => "version: 1\nname: -invalid\n"
         })
@@ -461,9 +461,9 @@ defmodule Shire.Agent.CoordinatorTest do
       assert {:error, :invalid_name} = result
     end
 
-    test "rejects agent name with trailing dash" do
+    test "rejects agent name with trailing dash", %{project_id: project_id} do
       result =
-        Coordinator.create_agent(@project, %{
+        Coordinator.create_agent(project_id, %{
           "name" => "invalid-",
           "recipe_yaml" => "version: 1\nname: invalid-\n"
         })
@@ -471,9 +471,9 @@ defmodule Shire.Agent.CoordinatorTest do
       assert {:error, :invalid_name} = result
     end
 
-    test "rejects agent name with underscores" do
+    test "rejects agent name with underscores", %{project_id: project_id} do
       result =
-        Coordinator.create_agent(@project, %{
+        Coordinator.create_agent(project_id, %{
           "name" => "my_agent",
           "recipe_yaml" => "version: 1\nname: my_agent\n"
         })
@@ -483,11 +483,13 @@ defmodule Shire.Agent.CoordinatorTest do
   end
 
   describe "update_agent/3 with invalid new name" do
-    test "rejects rename to an invalid slug" do
+    test "rejects rename to an invalid slug", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
+      agent = create_db_agent(project_id, "coord-valid-slug")
+
       result =
-        Coordinator.update_agent(@project, "old-name", %{
+        Coordinator.update_agent(project_id, agent.id, %{
           "recipe_yaml" => "version: 1\nname: Invalid Name!\n"
         })
 

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -65,6 +65,30 @@ defmodule Shire.ProjectManagerTest do
 
       assert_receive {:project_created, ^project}
     end
+
+    test "rejects project name with uppercase letters" do
+      assert {:error, :invalid_name} = ProjectManager.create_project("MyProject")
+    end
+
+    test "rejects project name with spaces" do
+      assert {:error, :invalid_name} = ProjectManager.create_project("my project")
+    end
+
+    test "rejects project name with leading dash" do
+      assert {:error, :invalid_name} = ProjectManager.create_project("-invalid")
+    end
+
+    test "rejects project name with trailing dash" do
+      assert {:error, :invalid_name} = ProjectManager.create_project("invalid-")
+    end
+
+    test "rejects project name with underscores" do
+      assert {:error, :invalid_name} = ProjectManager.create_project("my_project")
+    end
+
+    test "rejects empty project name" do
+      assert {:error, :invalid_name} = ProjectManager.create_project("")
+    end
   end
 
   describe "destroy_project/1" do

--- a/test/shire/slug_test.exs
+++ b/test/shire/slug_test.exs
@@ -1,0 +1,103 @@
+defmodule Shire.SlugTest do
+  use ExUnit.Case, async: true
+
+  alias Shire.Slug
+
+  describe "valid?/1" do
+    test "accepts simple lowercase name" do
+      assert Slug.valid?("hello")
+    end
+
+    test "accepts name with numbers" do
+      assert Slug.valid?("agent1")
+    end
+
+    test "accepts name with dashes" do
+      assert Slug.valid?("my-agent")
+    end
+
+    test "accepts single character" do
+      assert Slug.valid?("a")
+    end
+
+    test "accepts single digit" do
+      assert Slug.valid?("1")
+    end
+
+    test "accepts name with multiple dashes" do
+      assert Slug.valid?("my-cool-agent")
+    end
+
+    test "rejects uppercase letters" do
+      refute Slug.valid?("MyAgent")
+    end
+
+    test "rejects spaces" do
+      refute Slug.valid?("my agent")
+    end
+
+    test "rejects special characters" do
+      refute Slug.valid?("my_agent")
+      refute Slug.valid?("my.agent")
+      refute Slug.valid?("my@agent")
+    end
+
+    test "rejects leading dash" do
+      refute Slug.valid?("-agent")
+    end
+
+    test "rejects trailing dash" do
+      refute Slug.valid?("agent-")
+    end
+
+    test "rejects empty string" do
+      refute Slug.valid?("")
+    end
+
+    test "rejects nil" do
+      refute Slug.valid?(nil)
+    end
+
+    test "rejects name longer than 63 characters" do
+      refute Slug.valid?(String.duplicate("a", 64))
+    end
+
+    test "accepts name with exactly 63 characters" do
+      assert Slug.valid?(String.duplicate("a", 63))
+    end
+  end
+
+  describe "slugify/1" do
+    test "lowercases the string" do
+      assert Slug.slugify("MyAgent") == "myagent"
+    end
+
+    test "replaces spaces with dashes" do
+      assert Slug.slugify("my agent") == "my-agent"
+    end
+
+    test "replaces underscores with dashes" do
+      assert Slug.slugify("my_agent") == "my-agent"
+    end
+
+    test "replaces special characters with dashes" do
+      assert Slug.slugify("my@agent") == "my-agent"
+    end
+
+    test "collapses consecutive dashes" do
+      assert Slug.slugify("my--agent") == "my-agent"
+    end
+
+    test "strips leading and trailing dashes" do
+      assert Slug.slugify("-my-agent-") == "my-agent"
+    end
+
+    test "handles complex case" do
+      assert Slug.slugify("  My Cool Agent! ") == "my-cool-agent"
+    end
+
+    test "result is a valid slug" do
+      assert Slug.valid?(Slug.slugify("Hello World 123"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Added `Shire.Slug` module with `valid?/1`, `slugify/1`, and `regex/0` for consistent slug validation (`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`, 1-63 chars)
- Server-side validation in Coordinator rejects non-slug agent names on create/rename
- Server-side validation in ProjectManager rejects non-slug project names on create
- Frontend validation in AgentForm applies to both structured and raw YAML modes (auto-lowercase, inline error)
- Data migration normalizes existing non-compliant agent names in messages table
- Idiomatic Elixir: replaced `if not` with `unless` in coordinator

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test` — 170 tests, 0 failures
- [x] `bun run tsc --noEmit` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run test` — 111 tests, 12 suites, all passing
- [ ] Manual: create agent with invalid name (uppercase, spaces) — should be rejected
- [ ] Manual: create agent in raw YAML mode with invalid name — should be rejected
- [ ] Manual: create agent with valid slug name — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)