### PR TITLE
Fix inter-agent message streaming and chat ordering

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -133,6 +133,8 @@ export default function ChatPanel({
   const prevScrollHeightRef = React.useRef(0);
   const initialScrollDone = React.useRef(false);
 
+  const sortedMessages = React.useMemo(() => [...messages].sort((a, b) => (a.id ?? 0) - (b.id ?? 0)), [messages]);
+
   // Auto-scroll to bottom on initial load and new messages
   React.useEffect(() => {
     const prevLen = prevMessagesLengthRef.current;
@@ -177,13 +179,13 @@ export default function ChatPanel({
   const handleScroll = React.useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container || !hasMore || loadingMore) return;
-    if (container.scrollTop === 0 && messages.length > 0) {
-      const oldest = messages[0];
+    if (container.scrollTop === 0 && sortedMessages.length > 0) {
+      const oldest = sortedMessages[0];
       if (oldest.id != null) {
         pushEvent("load-more", { before: oldest.id });
       }
     }
-  }, [hasMore, loadingMore, pushEvent, messages]);
+  }, [hasMore, loadingMore, pushEvent, sortedMessages]);
 
   const handleSend = () => {
     const text = input.trim();
@@ -210,7 +212,7 @@ export default function ChatPanel({
             <p className="text-sm text-muted-foreground">No messages yet. Send a message to talk to the agent.</p>
           </div>
         )}
-        {messages.map((msg, i) =>
+        {sortedMessages.map((msg, i) =>
           msg.role === "tool_use" ? (
             <ToolCallMessage key={msg.id ?? `msg-${i}`} msg={msg} />
           ) : msg.role === "inter_agent" ? (

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -217,6 +217,23 @@ describe("ChatPanel", () => {
     expect(screen.queryByText("Your outbox message was invalid")).not.toBeInTheDocument();
   });
 
+  it("sorts messages by id for display", () => {
+    const unorderedMessages: Message[] = [
+      { id: 3, role: "agent", text: "Third", ts: "2026-03-17T00:00:03Z" },
+      { id: 1, role: "user", text: "First", ts: "2026-03-17T00:00:01Z" },
+      { id: 2, role: "inter_agent", text: "Second", from_agent: "other", ts: "2026-03-17T00:00:02Z" },
+    ];
+    const { container } = render(<ChatPanel agent={activeAgent} messages={unorderedMessages} pushEvent={vi.fn()} />);
+    const textElements = container.querySelectorAll(".rounded-lg");
+    const texts = Array.from(textElements).map((el) => el.textContent);
+    // "First" should appear before "Second" (collapsed) which should appear before "Third"
+    const firstIdx = texts.findIndex((t) => t?.includes("First"));
+    const secondIdx = texts.findIndex((t) => t?.includes("Message from other"));
+    const thirdIdx = texts.findIndex((t) => t?.includes("Third"));
+    expect(firstIdx).toBeLessThan(secondIdx);
+    expect(secondIdx).toBeLessThan(thirdIdx);
+  });
+
   it("shows thinking indicator when agent is busy", () => {
     const busyAgent = { ...activeAgent, busy: true };
     render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -287,16 +287,28 @@ defmodule Shire.Agent.AgentManager do
              "type" => "agent_message_received",
              "payload" => %{"from_agent" => from_agent, "text" => text}
            }} ->
-            Agents.create_message(%{
-              project_id: acc.project_id,
-              agent_id: acc.agent_id,
-              role: "inter_agent",
-              content: %{
-                "text" => text,
-                "from_agent" => from_agent,
-                "to_agent" => acc.agent_name
-              }
-            })
+            case Agents.create_message(%{
+                   project_id: acc.project_id,
+                   agent_id: acc.agent_id,
+                   role: "inter_agent",
+                   content: %{
+                     "text" => text,
+                     "from_agent" => from_agent,
+                     "to_agent" => acc.agent_name
+                   }
+                 }) do
+              {:ok, msg} ->
+                event = %{
+                  "type" => "inter_agent_message",
+                  "payload" => %{"from_agent" => from_agent, "text" => text},
+                  "message" => serialize_message(msg)
+                }
+
+                broadcast(acc, {:agent_event, acc.agent_id, event})
+
+              {:error, _} ->
+                :ok
+            end
 
             acc
 
@@ -759,6 +771,12 @@ defmodule Shire.Agent.AgentManager do
           input: msg.content["input"],
           output: msg.content["output"],
           is_error: msg.content["is_error"] || false
+        })
+
+      "inter_agent" ->
+        Map.merge(base, %{
+          text: msg.content["text"],
+          from_agent: msg.content["from_agent"]
         })
 
       _ ->

--- a/lib/shire_web/live/agent_live/agent_streaming.ex
+++ b/lib/shire_web/live/agent_live/agent_streaming.ex
@@ -102,6 +102,9 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
         # Fallback: no message included
         {messages, nil}
 
+      %{"type" => "inter_agent_message", "message" => msg} ->
+        {messages ++ [msg], streaming_text}
+
       %{"type" => "system_message", "message" => msg} ->
         {messages ++ [msg], streaming_text}
 

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -338,11 +338,16 @@ defmodule Shire.Agent.AgentManagerTest do
   end
 
   describe "agent_message_received stdout event" do
-    test "persists inter_agent message to DB", ctx do
+    setup ctx do
       Mox.set_mox_global()
 
       {:ok, pid} = start_manager(ctx)
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
+
+      Phoenix.PubSub.subscribe(
+        Shire.PubSub,
+        "project:#{ctx.project_id}:agent:#{ctx.agent_id}"
+      )
 
       ref = make_ref()
 
@@ -350,13 +355,17 @@ defmodule Shire.Agent.AgentManagerTest do
         %{state | command: %{ref: ref}, command_ref: ref, status: :active}
       end)
 
+      %{pid: pid, ref: ref}
+    end
+
+    test "persists inter_agent message to DB", ctx do
       event =
         Jason.encode!(%{
           "type" => "agent_message_received",
           "payload" => %{"from_agent" => "other-agent", "text" => "hello from other"}
         })
 
-      send(pid, {:stdout, %{ref: ref}, event <> "\n"})
+      send(ctx.pid, {:stdout, %{ref: ctx.ref}, event <> "\n"})
 
       # Give it a moment to process
       Process.sleep(50)
@@ -367,6 +376,24 @@ defmodule Shire.Agent.AgentManagerTest do
       assert inter_agent.content["text"] == "hello from other"
       assert inter_agent.content["from_agent"] == "other-agent"
       assert inter_agent.content["to_agent"] == "test-agent"
+    end
+
+    test "broadcasts inter_agent_message event via PubSub", ctx do
+      event =
+        Jason.encode!(%{
+          "type" => "agent_message_received",
+          "payload" => %{"from_agent" => "other-agent", "text" => "hello from other"}
+        })
+
+      send(ctx.pid, {:stdout, %{ref: ctx.ref}, event <> "\n"})
+
+      assert_receive {:agent_event, _, %{"type" => "inter_agent_message", "message" => msg}},
+                     1_000
+
+      assert msg[:role] == "inter_agent"
+      assert msg[:text] == "hello from other"
+      assert msg[:from_agent] == "other-agent"
+      assert msg[:id]
     end
   end
 

--- a/test/shire_web/live/agent_streaming_test.exs
+++ b/test/shire_web/live/agent_streaming_test.exs
@@ -131,6 +131,34 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
     end
   end
 
+  describe "process_agent_event/2 with inter_agent_message" do
+    test "appends inter-agent message and preserves streaming text" do
+      msg = %{
+        id: 5,
+        role: "inter_agent",
+        text: "hello from other",
+        from_agent: "other-agent",
+        ts: "2024-01-01T00:00:00Z"
+      }
+
+      socket = mock_socket(%{streaming_text: "partial"})
+
+      event = %{
+        "type" => "inter_agent_message",
+        "payload" => %{"from_agent" => "other-agent", "text" => "hello from other"},
+        "message" => msg
+      }
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      # Inter-agent message appended before the ephemeral streaming entry
+      inter_agent = Enum.find(socket.assigns.messages, &(&1[:role] == "inter_agent"))
+      assert inter_agent[:text] == "hello from other"
+      assert inter_agent[:from_agent] == "other-agent"
+      # Streaming text preserved
+      assert socket.assigns.streaming_text == "partial"
+    end
+  end
+
   describe "process_agent_event/2 with turn_complete" do
     test "clears streaming text" do
       socket = mock_socket(%{streaming_text: "partial text"})


### PR DESCRIPTION
## Summary
- **Inter-agent messages now stream in real-time** — previously they were saved to DB but never broadcast via PubSub, so they only appeared after page refresh
- **Fixed `serialize_message/1`** in AgentManager to handle `inter_agent` role (includes `from_agent` field)
- **Added defensive client-side sort** by message `id` in ChatPanel to prevent ordering issues from concurrent DB inserts

## Test plan
- [ ] Verify inter-agent messages appear in real-time during a live chat session (no page refresh needed)
- [ ] Verify message ordering is correct after page reload
- [ ] Verify system messages still stream correctly (no regression)
- [ ] All Elixir tests pass (`mix test` — 187 tests, 0 failures)
- [ ] All frontend tests pass (`bun run test` — 119 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)