### PR TITLE
Fix message ordering: emit events before sendMessage

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -133,8 +133,6 @@ export default function ChatPanel({
   const prevScrollHeightRef = React.useRef(0);
   const initialScrollDone = React.useRef(false);
 
-  const sortedMessages = React.useMemo(() => [...messages].sort((a, b) => (a.id ?? 0) - (b.id ?? 0)), [messages]);
-
   // Auto-scroll to bottom on initial load and new messages
   React.useEffect(() => {
     const prevLen = prevMessagesLengthRef.current;
@@ -179,13 +177,13 @@ export default function ChatPanel({
   const handleScroll = React.useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container || !hasMore || loadingMore) return;
-    if (container.scrollTop === 0 && sortedMessages.length > 0) {
-      const oldest = sortedMessages[0];
+    if (container.scrollTop === 0 && messages.length > 0) {
+      const oldest = messages[0];
       if (oldest.id != null) {
         pushEvent("load-more", { before: oldest.id });
       }
     }
-  }, [hasMore, loadingMore, pushEvent, sortedMessages]);
+  }, [hasMore, loadingMore, pushEvent, messages]);
 
   const handleSend = () => {
     const text = input.trim();
@@ -212,7 +210,7 @@ export default function ChatPanel({
             <p className="text-sm text-muted-foreground">No messages yet. Send a message to talk to the agent.</p>
           </div>
         )}
-        {sortedMessages.map((msg, i) =>
+        {messages.map((msg, i) =>
           msg.role === "tool_use" ? (
             <ToolCallMessage key={msg.id ?? `msg-${i}`} msg={msg} />
           ) : msg.role === "inter_agent" ? (

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -217,23 +217,6 @@ describe("ChatPanel", () => {
     expect(screen.queryByText("Your outbox message was invalid")).not.toBeInTheDocument();
   });
 
-  it("sorts messages by id for display", () => {
-    const unorderedMessages: Message[] = [
-      { id: 3, role: "agent", text: "Third", ts: "2026-03-17T00:00:03Z" },
-      { id: 1, role: "user", text: "First", ts: "2026-03-17T00:00:01Z" },
-      { id: 2, role: "inter_agent", text: "Second", from_agent: "other", ts: "2026-03-17T00:00:02Z" },
-    ];
-    const { container } = render(<ChatPanel agent={activeAgent} messages={unorderedMessages} pushEvent={vi.fn()} />);
-    const textElements = container.querySelectorAll(".rounded-lg");
-    const texts = Array.from(textElements).map((el) => el.textContent);
-    // "First" should appear before "Second" (collapsed) which should appear before "Third"
-    const firstIdx = texts.findIndex((t) => t?.includes("First"));
-    const secondIdx = texts.findIndex((t) => t?.includes("Message from other"));
-    const thirdIdx = texts.findIndex((t) => t?.includes("Third"));
-    expect(firstIdx).toBeLessThan(secondIdx);
-    expect(secondIdx).toBeLessThan(thirdIdx);
-  });
-
   it("shows thinking indicator when agent is busy", () => {
     const busyAgent = { ...activeAgent, busy: true };
     render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -179,6 +179,32 @@ describe("processMessage() — agent_message", () => {
     expect(received!.payload).toEqual({ from_agent: "researcher-bot", text: "Here is data." });
   });
 
+  test("emits agent_message_received before calling harness.sendMessage", async () => {
+    const callOrder: string[] = [];
+    const harness = createMockHarness();
+    harness.sendMessage = mock(async () => {
+      callOrder.push("sendMessage");
+    });
+    const origWrite = process.stdout.write.bind(process.stdout);
+    const spy = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      if (typeof chunk === "string" && chunk.includes("agent_message_received")) {
+        callOrder.push("emit");
+      }
+      return origWrite(chunk as string);
+    });
+
+    const envelope = makeEnvelope({
+      type: "agent_message",
+      from: "researcher-bot",
+      payload: { text: "Here is data." },
+    });
+
+    await processMessage(harness, envelope);
+    spy.mockRestore();
+
+    expect(callOrder).toEqual(["emit", "sendMessage"]);
+  });
+
   test("does not emit agent_message_received for user messages", async () => {
     const harness = createMockHarness();
     const envelope = makeEnvelope({ type: "user_message", payload: { text: "Hi" } });
@@ -224,6 +250,32 @@ describe("processMessage() — system_message", () => {
     const received = events.find((e) => e.type === "system_message_received");
     expect(received).toBeDefined();
     expect(received!.payload).toEqual({ text: "Error details here." });
+  });
+
+  test("emits system_message_received before calling harness.sendMessage", async () => {
+    const callOrder: string[] = [];
+    const harness = createMockHarness();
+    harness.sendMessage = mock(async () => {
+      callOrder.push("sendMessage");
+    });
+    const origWrite = process.stdout.write.bind(process.stdout);
+    const spy = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      if (typeof chunk === "string" && chunk.includes("system_message_received")) {
+        callOrder.push("emit");
+      }
+      return origWrite(chunk as string);
+    });
+
+    const envelope = makeEnvelope({
+      type: "system_message",
+      from: "system",
+      payload: { text: "Error details here." },
+    });
+
+    await processMessage(harness, envelope);
+    spy.mockRestore();
+
+    expect(callOrder).toEqual(["emit", "sendMessage"]);
   });
 
   test("does not emit agent_message_received for system messages", async () => {

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -108,12 +108,12 @@ export async function processMessage(harness: Harness, envelope: MessageEnvelope
     const text = envelope.payload.text as string;
     const from = envelope.type === "agent_message" ? envelope.from : undefined;
     const prefix = envelope.type === "system_message" ? "[System] " : "";
-    await harness.sendMessage(prefix + text, from);
     if (envelope.type === "agent_message") {
       emit("agent_message_received", { from_agent: envelope.from, text });
     } else if (envelope.type === "system_message") {
       emit("system_message_received", { text });
     }
+    await harness.sendMessage(prefix + text, from);
   } else if (envelope.type === "interrupt") {
     await harness.interrupt();
     emit("interrupted", {});


### PR DESCRIPTION
## Summary
- **Root cause**: `agent-runner.ts` emitted `agent_message_received` and `system_message_received` AFTER `await harness.sendMessage()`, so the agent's entire response (text, tool_use events) got lower DB IDs than the incoming message notification — making inter-agent/system messages appear after the agent's response to them
- **Fix**: Move `emit()` calls before `sendMessage()` so they arrive on the Elixir side first and get correct DB ordering
- **Cleanup**: Reverts the client-side `sortedMessages` useMemo that was masking this bug

## Test plan
- [ ] Verify inter-agent messages appear before the agent's response to them in chat timeline
- [ ] Verify system messages appear before the agent's response to them
- [ ] All agent runner tests pass (59 tests, 0 failures) — includes new emit-order tests
- [ ] All Elixir tests pass (189 tests, 0 failures)
- [ ] All frontend tests pass (118 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)