### PR TITLE
fix: simplify outbox prompt to prevent wrong format

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -34,19 +34,11 @@ defmodule Shire.Agent.AgentManager do
 
     **Format:**
     ```yaml
-    to: <target-agent-name>
-    text: "<your message>"
+    to: target-agent-name
+    text: Your message here
     ```
 
-    Example using Bash:
-    ```bash
-    cat > /workspace/agents/#{agent_id}/outbox/msg.yaml <<'EOF'
-    to: target-agent
-    text: "Hello, can you help me with X?"
-    EOF
-    ```
-
-    **Note:** Always quote the `text` value if it contains special characters like `:`, `#`, `{`, `}`, or newlines.
+    Quote the `text` value if it contains special YAML characters (`:`, `#`, `{`, `}`).
 
     The system delivers the message to the target agent automatically.
     If your message is invalid (unparseable YAML or missing required fields), you will receive a system notification with the error details.

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -199,7 +199,7 @@ export async function processOutbox(
       emit("error", { message: `Invalid outbox message ${file}: missing required fields: ${missing.join(", ")}` });
       await writeSystemMessage(
         inboxDir,
-        `Your outbox message "${file}" is missing required fields: ${missing.join(", ")}. Each outbox message must have "to" (target agent name) and "text" (message content) as strings.`,
+        `Your outbox message "${file}" is missing required fields: ${missing.join(", ")}. Each outbox message must be a valid YAML file with "to" and "text" on separate lines. Example:\nto: agent-name\ntext: Your message here`,
       );
       await unlink(path);
       continue;


### PR DESCRIPTION
## Summary
- Removed misleading bash heredoc example from the agent comms prompt — agents copied it and wrote literal `\n` escape sequences instead of real newlines, causing YAML parse failures
- Simplified the format section to just show the clean YAML format
- Improved the validation error message to include a concrete correct example so agents can self-correct on retry

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 189 tests, 0 failures
- [x] `bun test` (priv/sprite) — 59 tests pass
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)