### PR TITLE
docs: add worktree guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ mix precommit
 
 ## Guidelines
 
+- **Always use a git worktree for new features and bug fixes** — before creating the worktree, pull latest main (`git pull origin main`) to ensure you're building on the latest codebase
 - Use `bun` for all JS package management and scripts, never `npm` or `node`
 - Use `Req` for HTTP requests, never httpoison/tesla/httpc
 - Use `yaml_elixir` for YAML parsing in Elixir


### PR DESCRIPTION
## Summary
- Add guideline requiring git worktrees for new features and bug fixes
- Enforce pulling latest main before creating a worktree to ensure work builds on the latest codebase

## Test plan
- [x] Verify CLAUDE.md renders correctly with the new guideline

🤖 Generated with [Claude Code](https://claude.com/claude-code)