### PR TITLE
feat: add Project Details page with PROJECT.md editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ mix precommit
 
 ## Guidelines
 
+- **Always use a git worktree for new features and bug fixes** — before creating the worktree, pull latest main (`git pull origin main`) to ensure you're building on the latest codebase
 - Use `bun` for all JS package management and scripts, never `npm` or `node`
 - Use `Req` for HTTP requests, never httpoison/tesla/httpc
 - Use `yaml_elixir` for YAML parsing in Elixir

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -16,6 +16,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
+import { FileText, Settings, FolderOpen } from "lucide-react";
 import ProjectSwitcher from "./ProjectSwitcher";
 import { navigate } from "./lib/navigate";
 import { type Agent, type AgentStatus, type Project } from "./types";
@@ -120,45 +121,33 @@ export default function AgentSidebar({
         <Button variant="outline" size="sm" className="w-full" onClick={onNewAgent}>
           + New Agent
         </Button>
-        <button
-          type="button"
-          className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start gap-2 text-muted-foreground"
+          onClick={() => navigate(`/projects/${project.name}/details`)}
+        >
+          <FileText className="h-4 w-4" />
+          Project Details
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start gap-2 text-muted-foreground"
           onClick={() => navigate(`/projects/${project.name}/settings`)}
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-            <circle cx="12" cy="12" r="3" />
-          </svg>
+          <Settings className="h-4 w-4" />
           Settings
-        </button>
-        <button
-          type="button"
-          className="flex items-center gap-2 w-full px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground rounded hover:bg-muted"
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start gap-2 text-muted-foreground"
           onClick={() => navigate(`/projects/${project.name}/shared`)}
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-          </svg>
+          <FolderOpen className="h-4 w-4" />
           Shared Drive
-        </button>
+        </Button>
       </div>
 
       <AlertDialog

--- a/assets/react-components/ProjectDetailsPage.tsx
+++ b/assets/react-components/ProjectDetailsPage.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import { Button } from "./components/ui/button";
+import { Textarea } from "./components/ui/textarea";
+import { Input } from "./components/ui/input";
+import { Label } from "./components/ui/label";
+import { ChevronLeft } from "lucide-react";
+import AppLayout from "./components/AppLayout";
+import { navigate } from "./lib/navigate";
+
+interface ProjectDetailsPageProps {
+  project: { id: string; name: string };
+  project_doc: string;
+  pushEvent: (event: string, payload: Record<string, unknown>) => void;
+}
+
+export default function ProjectDetailsPage({ project, project_doc, pushEvent }: ProjectDetailsPageProps) {
+  const [nameValue, setNameValue] = React.useState(project.name);
+  const [docValue, setDocValue] = React.useState(project_doc);
+
+  const slugRegex = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+  const isValidSlug = nameValue.length >= 1 && nameValue.length <= 63 && slugRegex.test(nameValue);
+  const nameDirty = nameValue !== project.name;
+  const docDirty = docValue !== project_doc;
+
+  React.useEffect(() => {
+    setNameValue(project.name);
+  }, [project.name]);
+
+  React.useEffect(() => {
+    setDocValue(project_doc);
+  }, [project_doc]);
+
+  const handleRename = () => {
+    pushEvent("rename-project", { name: nameValue });
+  };
+
+  const handleSaveDoc = () => {
+    pushEvent("save-project-doc", { content: docValue });
+  };
+
+  return (
+    <AppLayout>
+      <div className="space-y-8">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="gap-1 text-muted-foreground"
+          onClick={() => navigate(`/projects/${project.name}`)}
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Back to dashboard
+        </Button>
+
+        <div>
+          <h1 className="text-2xl font-bold">Project Details</h1>
+          <p className="text-sm text-muted-foreground mt-1">Manage project name and documentation.</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="project-name">Project Name</Label>
+          <div className="flex gap-2">
+            <Input
+              id="project-name"
+              value={nameValue}
+              onChange={(e) => setNameValue(e.target.value)}
+              placeholder="project-name"
+              className="max-w-sm"
+            />
+            <Button onClick={handleRename} disabled={!nameDirty || !isValidSlug}>
+              Rename
+            </Button>
+          </div>
+          {nameDirty && !isValidSlug && nameValue.length > 0 && (
+            <p className="text-xs text-destructive">
+              Invalid name. Use lowercase letters, numbers, and hyphens (1-63 chars).
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Lowercase letters, numbers, and hyphens only. Renaming will change the project URL.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="project-doc">PROJECT.md</Label>
+          <p className="text-xs text-muted-foreground">
+            Shared project context visible to all agents. Agents check this before starting and after completing tasks.
+          </p>
+          <Textarea
+            id="project-doc"
+            value={docValue}
+            onChange={(e) => setDocValue(e.target.value)}
+            className="min-h-[400px] font-mono text-sm"
+            placeholder="# Project&#10;&#10;Describe your project here..."
+          />
+          <div className="flex justify-end">
+            <Button onClick={handleSaveDoc} disabled={!docDirty}>
+              Save Document
+            </Button>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/assets/react-components/index.ts
+++ b/assets/react-components/index.ts
@@ -2,7 +2,16 @@ import AgentDashboard from "./AgentDashboard";
 import AgentForm from "./AgentForm";
 import AgentShow from "./AgentShow";
 import ProjectDashboard from "./ProjectDashboard";
+import ProjectDetailsPage from "./ProjectDetailsPage";
 import SettingsPage from "./SettingsPage";
 import SharedDrive from "./SharedDrive";
 
-export default { AgentDashboard, AgentForm, AgentShow, ProjectDashboard, SettingsPage, SharedDrive };
+export default {
+  AgentDashboard,
+  AgentForm,
+  AgentShow,
+  ProjectDashboard,
+  ProjectDetailsPage,
+  SettingsPage,
+  SharedDrive,
+};

--- a/assets/test/AgentSidebar.test.tsx
+++ b/assets/test/AgentSidebar.test.tsx
@@ -69,6 +69,11 @@ describe("AgentSidebar", () => {
     expect(onNewAgent).toHaveBeenCalled();
   });
 
+  it("renders Project Details link", () => {
+    render(<AgentSidebar {...defaultProps} agents={agents} />);
+    expect(screen.getByText("Project Details")).toBeInTheDocument();
+  });
+
   it("renders Settings link", () => {
     render(<AgentSidebar {...defaultProps} agents={agents} />);
     expect(screen.getByText("Settings")).toBeInTheDocument();

--- a/assets/test/ProjectDetailsPage.test.tsx
+++ b/assets/test/ProjectDetailsPage.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import ProjectDetailsPage from "../react-components/ProjectDetailsPage";
+
+const defaultProps = {
+  project: { id: "p1", name: "test-project" },
+  project_doc: "# My Project\n\nSome content here.",
+  pushEvent: vi.fn(),
+};
+
+describe("ProjectDetailsPage", () => {
+  it("renders with Project Details heading", () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    expect(screen.getByRole("heading", { name: "Project Details" })).toBeInTheDocument();
+  });
+
+  it("renders back link", () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    expect(screen.getByText("Back to dashboard")).toBeInTheDocument();
+  });
+
+  it("shows project name in input", () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    const input = screen.getByLabelText("Project Name");
+    expect(input).toHaveValue("test-project");
+  });
+
+  it("shows Rename button disabled when name is unchanged", () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "Rename" })).toBeDisabled();
+  });
+
+  it("enables Rename button after changing name", async () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    const input = screen.getByLabelText("Project Name");
+    await userEvent.clear(input);
+    await userEvent.type(input, "new-name");
+    expect(screen.getByRole("button", { name: "Rename" })).toBeEnabled();
+  });
+
+  it("calls pushEvent with rename-project on Rename click", async () => {
+    const pushEvent = vi.fn();
+    render(<ProjectDetailsPage {...defaultProps} pushEvent={pushEvent} />);
+    const input = screen.getByLabelText("Project Name");
+    await userEvent.clear(input);
+    await userEvent.type(input, "new-name");
+    await userEvent.click(screen.getByRole("button", { name: "Rename" }));
+    expect(pushEvent).toHaveBeenCalledWith("rename-project", { name: "new-name" });
+  });
+
+  it("disables Rename button when slug is invalid", async () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    const input = screen.getByLabelText("Project Name");
+    await userEvent.clear(input);
+    await userEvent.type(input, "INVALID NAME!");
+    expect(screen.getByRole("button", { name: "Rename" })).toBeDisabled();
+    expect(screen.getByText(/invalid name/i)).toBeInTheDocument();
+  });
+
+  it("shows PROJECT.md content in textarea", () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    const textarea = screen.getByLabelText("PROJECT.md");
+    expect(textarea).toHaveValue("# My Project\n\nSome content here.");
+  });
+
+  it("shows Save Document button disabled when doc is unchanged", () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "Save Document" })).toBeDisabled();
+  });
+
+  it("enables Save Document button after editing", async () => {
+    render(<ProjectDetailsPage {...defaultProps} />);
+    const textarea = screen.getByLabelText("PROJECT.md");
+    await userEvent.type(textarea, " updated");
+    expect(screen.getByRole("button", { name: "Save Document" })).toBeEnabled();
+  });
+
+  it("calls pushEvent with save-project-doc on Save Document click", async () => {
+    const pushEvent = vi.fn();
+    render(<ProjectDetailsPage {...defaultProps} pushEvent={pushEvent} />);
+    const textarea = screen.getByLabelText("PROJECT.md");
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, "new content");
+    await userEvent.click(screen.getByRole("button", { name: "Save Document" }));
+    expect(pushEvent).toHaveBeenCalledWith("save-project-doc", { content: "new content" });
+  });
+
+  it("syncs name when project prop changes", () => {
+    const { rerender } = render(<ProjectDetailsPage {...defaultProps} />);
+    rerender(<ProjectDetailsPage {...defaultProps} project={{ id: "p1", name: "renamed" }} />);
+    expect(screen.getByLabelText("Project Name")).toHaveValue("renamed");
+  });
+
+  it("syncs doc when project_doc prop changes", () => {
+    const { rerender } = render(<ProjectDetailsPage {...defaultProps} />);
+    rerender(<ProjectDetailsPage {...defaultProps} project_doc="updated doc" />);
+    expect(screen.getByLabelText("PROJECT.md")).toHaveValue("updated doc");
+  });
+});

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -60,6 +60,11 @@ defmodule Shire.Agent.AgentManager do
     All agents can read and write files in `/workspace/shared/`. Use this for sharing documents,
     data, or artifacts that multiple agents need access to.
 
+    ## Project Document
+    Before starting any task, read `/workspace/PROJECT.md` for project context, goals, and conventions.
+    After completing a task, review the document and update it if your work changes any project-level
+    context (e.g., new conventions, completed milestones, architectural decisions).
+
     ## Guidelines
     - Read `/workspace/peers.yaml` before messaging to confirm the target agent exists
     - Be specific about what you need from the other agent

--- a/lib/shire/workspace_settings.ex
+++ b/lib/shire/workspace_settings.ex
@@ -122,6 +122,24 @@ defmodule Shire.WorkspaceSettings do
     end
   end
 
+  # --- Project Document ---
+
+  @doc "Reads `/workspace/PROJECT.md` from the VM."
+  def read_project_doc(project_id) do
+    case @vm.read(project_id, "/workspace/PROJECT.md") do
+      {:ok, content} -> {:ok, content}
+      {:error, _} -> {:ok, ""}
+    end
+  end
+
+  @doc "Writes the given string to `/workspace/PROJECT.md` on the VM."
+  def write_project_doc(project_id, content) do
+    case @vm.write(project_id, "/workspace/PROJECT.md", content) do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   # --- Bootstrap ---
 
   @doc "Runs the bootstrap script to initialize `/workspace` directories on the VM."

--- a/lib/shire_web/live/project_details_live/index.ex
+++ b/lib/shire_web/live/project_details_live/index.ex
@@ -1,0 +1,87 @@
+defmodule ShireWeb.ProjectDetailsLive.Index do
+  use ShireWeb, :live_view
+
+  alias Shire.Projects
+  alias Shire.ProjectManager
+  alias Shire.Slug
+  alias Shire.WorkspaceSettings
+
+  @impl true
+  def mount(%{"project_name" => project_name}, _session, socket) do
+    project = Projects.get_project_by_name!(project_name)
+
+    case ProjectManager.lookup_coordinator(project.id) do
+      {:error, :not_found} ->
+        {:ok, socket |> put_flash(:error, "Project not found") |> redirect(to: ~p"/")}
+
+      {:ok, _pid} ->
+        project_doc =
+          case WorkspaceSettings.read_project_doc(project.id) do
+            {:ok, content} -> content
+            _ -> ""
+          end
+
+        {:ok,
+         assign(socket,
+           project: %{id: project.id, name: project.name},
+           project_doc: project_doc
+         )}
+    end
+  end
+
+  @impl true
+  def handle_params(_params, _url, socket) do
+    {:noreply, assign(socket, :page_title, "Project Details")}
+  end
+
+  @impl true
+  def handle_event("save-project-doc", %{"content" => content}, socket) do
+    case WorkspaceSettings.write_project_doc(socket.assigns.project.id, content) do
+      :ok ->
+        {:noreply,
+         socket
+         |> assign(:project_doc, content)
+         |> put_flash(:info, "Project document saved")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Failed to save: #{inspect(reason)}")}
+    end
+  end
+
+  @impl true
+  def handle_event("rename-project", %{"name" => new_name}, socket) do
+    project = Projects.get_project!(socket.assigns.project.id)
+
+    if Slug.valid?(new_name) do
+      case Projects.rename_project(project, new_name) do
+        {:ok, updated} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Project renamed to #{updated.name}")
+           |> redirect(to: ~p"/projects/#{updated.name}/details")}
+
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to rename. Name may already be taken.")}
+      end
+    else
+      {:noreply,
+       put_flash(
+         socket,
+         :error,
+         "Invalid name. Use lowercase letters, numbers, and hyphens (2-63 chars)."
+       )}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.react
+      name="ProjectDetailsPage"
+      project={@project}
+      project_doc={@project_doc}
+      socket={@socket}
+    />
+    """
+  end
+end

--- a/lib/shire_web/router.ex
+++ b/lib/shire_web/router.ex
@@ -25,6 +25,8 @@ defmodule ShireWeb.Router do
 
       live "/projects/:project_name/settings", SettingsLive.Index, :index
 
+      live "/projects/:project_name/details", ProjectDetailsLive.Index, :index
+
       live "/projects/:project_name/shared", SharedDriveLive.Index, :index
     end
   end

--- a/priv/sprite/bootstrap.sh
+++ b/priv/sprite/bootstrap.sh
@@ -18,4 +18,13 @@ if [ -f /workspace/.env ]; then
 fi
 BASHRC
 
+# Create default PROJECT.md if it doesn't exist
+if [ ! -f /workspace/PROJECT.md ]; then
+  cat > /workspace/PROJECT.md << 'PROJECTMD'
+# Project
+
+Describe your project here. All agents will check this document for context before starting tasks and update it after completing work.
+PROJECTMD
+fi
+
 echo "Bootstrap complete"

--- a/test/shire/workspace_settings_test.exs
+++ b/test/shire/workspace_settings_test.exs
@@ -126,6 +126,52 @@ defmodule Shire.WorkspaceSettingsTest do
     end
   end
 
+  describe "read_project_doc/1" do
+    test "returns {:ok, string} with VM content" do
+      stub(Shire.VirtualMachineMock, :read, fn @project, "/workspace/PROJECT.md" ->
+        {:ok, "# My Project\n"}
+      end)
+
+      assert {:ok, "# My Project\n"} = WorkspaceSettings.read_project_doc(@project)
+    end
+
+    test "returns {:ok, empty string} when PROJECT.md does not exist" do
+      stub(Shire.VirtualMachineMock, :read, fn @project, "/workspace/PROJECT.md" ->
+        {:error, :not_found}
+      end)
+
+      assert {:ok, ""} = WorkspaceSettings.read_project_doc(@project)
+    end
+
+    test "returns {:ok, empty string} on VM error" do
+      stub(Shire.VirtualMachineMock, :read, fn @project, "/workspace/PROJECT.md" ->
+        {:error, :timeout}
+      end)
+
+      assert {:ok, ""} = WorkspaceSettings.read_project_doc(@project)
+    end
+  end
+
+  describe "write_project_doc/2" do
+    test "writes content to the VM" do
+      expect(Shire.VirtualMachineMock, :write, fn @project,
+                                                  "/workspace/PROJECT.md",
+                                                  "# Updated" ->
+        :ok
+      end)
+
+      assert :ok = WorkspaceSettings.write_project_doc(@project, "# Updated")
+    end
+
+    test "returns error on failure" do
+      expect(Shire.VirtualMachineMock, :write, fn @project, "/workspace/PROJECT.md", _content ->
+        {:error, :write_failed}
+      end)
+
+      assert {:error, :write_failed} = WorkspaceSettings.write_project_doc(@project, "# Updated")
+    end
+  end
+
   describe "run_script/2" do
     test "runs script and returns output" do
       expect(Shire.VirtualMachineMock, :cmd, fn @project, "bash", ["-c", cmd], _opts ->

--- a/test/shire_web/live/project_details_live_test.exs
+++ b/test/shire_web/live/project_details_live_test.exs
@@ -1,0 +1,86 @@
+defmodule ShireWeb.ProjectDetailsLiveTest do
+  use ShireWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mox
+
+  setup do
+    Mox.set_mox_global()
+
+    stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+
+    stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+      {:error, :not_available_in_test}
+    end)
+
+    {:ok, project} = Shire.Projects.create_project("test-project-details")
+    project_id = project.id
+
+    start_supervised!(
+      {DynamicSupervisor,
+       name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
+       strategy: :one_for_one},
+      id: :agent_sup
+    )
+
+    start_supervised!({Shire.Agent.Coordinator, project_id: project_id})
+    Process.sleep(50)
+
+    %{project_id: project_id, project_name: "test-project-details"}
+  end
+
+  describe "Index" do
+    test "renders project details page", %{conn: conn, project_name: project_name} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_name}/details")
+      assert html =~ "ProjectDetailsPage"
+    end
+
+    test "saves project document", %{conn: conn, project_name: project_name} do
+      expect(Shire.VirtualMachineMock, :write, fn _project,
+                                                  "/workspace/PROJECT.md",
+                                                  "# Updated content" ->
+        :ok
+      end)
+
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/details")
+
+      view
+      |> render_hook("save-project-doc", %{"content" => "# Updated content"})
+
+      assert render(view) =~ "Project document saved"
+    end
+
+    test "renames project and redirects", %{conn: conn, project_name: project_name} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/details")
+
+      assert {:error, {:redirect, %{to: "/projects/renamed-project/details"}}} =
+               view |> render_hook("rename-project", %{"name" => "renamed-project"})
+    end
+
+    test "shows error when save-project-doc fails", %{conn: conn, project_name: project_name} do
+      expect(Shire.VirtualMachineMock, :write, fn _project,
+                                                  "/workspace/PROJECT.md",
+                                                  "bad content" ->
+        {:error, :write_failed}
+      end)
+
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/details")
+
+      view
+      |> render_hook("save-project-doc", %{"content" => "bad content"})
+
+      assert render(view) =~ "Failed to save"
+    end
+
+    test "rejects invalid project name", %{conn: conn, project_name: project_name} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/details")
+
+      view
+      |> render_hook("rename-project", %{"name" => "INVALID NAME!"})
+
+      assert render(view) =~ "Invalid name"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a **Project Details** page (`/projects/:name/details`) with a PROJECT.md editor and project rename functionality
- Agents read `/workspace/PROJECT.md` before starting tasks and update it after completing work — provides shared project context
- Bootstrap creates a default `PROJECT.md` on new VMs; agent communication prompt references the document
- Sidebar navigation uses shadcn `Button` components with lucide-react icons (replaces inline SVGs)
- Client-side slug validation with inline error messages for the rename field
- Redirects to the new URL after project rename (prevents stale URL 404s)

## Test plan
- [x] Elixir: `mix compile --warnings-as-errors` — 0 warnings
- [x] Elixir: `mix format --check-formatted` — clean
- [x] Elixir: `mix test` — 22 tests pass (workspace_settings + project_details_live)
- [x] Frontend: `bun run tsc --noEmit` — clean
- [x] Frontend: `bun run lint` — clean
- [x] Frontend: `bun run format:check` — clean
- [x] Frontend: `bun run test` — 132 tests pass (13 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)