### PR TITLE
feat: disable Pi harness option (Coming soon)

### DIFF
--- a/assets/react-components/AgentForm.tsx
+++ b/assets/react-components/AgentForm.tsx
@@ -227,7 +227,9 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="claude_code">Claude Code</SelectItem>
-                    <SelectItem value="pi">Pi</SelectItem>
+                    <SelectItem value="pi" disabled>
+                      Pi (Coming soon)
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/assets/react-components/types.ts
+++ b/assets/react-components/types.ts
@@ -66,6 +66,6 @@ export const harnessLabel = (harness: HarnessType): string => {
     case "claude_code":
       return "Claude Code";
     case "pi":
-      return "Pi";
+      return "Pi (Coming soon)";
   }
 };

--- a/assets/test/AgentShow.test.tsx
+++ b/assets/test/AgentShow.test.tsx
@@ -170,7 +170,7 @@ describe("AgentShow", () => {
         pushEvent={vi.fn()}
       />,
     );
-    expect(screen.getByText("Pi")).toBeInTheDocument();
+    expect(screen.getByText("Pi (Coming soon)")).toBeInTheDocument();
   });
 
   it("shows Edit button and opens edit form dialog", async () => {


### PR DESCRIPTION
## Summary
- Disable the Pi harness option in the agent form dropdown and label it as "Coming soon"
- Update `harnessLabel` to show "Pi (Coming soon)" wherever the harness type is displayed
- Update test to match the new label

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All 132 Vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)