### PR TITLE
feat: extend VM keepalive on agent stdout activity

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -73,6 +73,7 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @max_auto_restarts 3
+  @keepalive_touch_interval :timer.seconds(30)
 
   defstruct [
     :agent_id,
@@ -85,7 +86,8 @@ defmodule Shire.Agent.AgentManager do
     buffer: "",
     streaming_text: nil,
     tool_use_ids: %{},
-    auto_restart_count: 0
+    auto_restart_count: 0,
+    last_keepalive_touch: nil
   ]
 
   # --- Public API ---
@@ -242,7 +244,7 @@ defmodule Shire.Agent.AgentManager do
     kill_existing_runner(state.project_id, state.agent_id)
 
     state =
-      %{state | command: nil, command_ref: nil}
+      %{state | command: nil, command_ref: nil, last_keepalive_touch: nil}
       |> transition_status(:bootstrapping)
 
     {:reply, :ok, state, {:continue, :spawn_runner}}
@@ -260,7 +262,7 @@ defmodule Shire.Agent.AgentManager do
       end
 
     state =
-      %{state | command: nil, command_ref: nil, agent_name: agent_name}
+      %{state | command: nil, command_ref: nil, agent_name: agent_name, last_keepalive_touch: nil}
       |> transition_status(:bootstrapping)
 
     Task.start_link(fn ->
@@ -374,7 +376,8 @@ defmodule Shire.Agent.AgentManager do
         end
       end)
 
-    {:noreply, %{state | buffer: buffer}}
+    state = %{state | buffer: buffer}
+    {:noreply, maybe_touch_keepalive(state)}
   end
 
   # Agent runner exited
@@ -569,6 +572,18 @@ defmodule Shire.Agent.AgentManager do
 
   defp broadcast(state, message) do
     Phoenix.PubSub.broadcast(Shire.PubSub, state.pubsub_topic, message)
+  end
+
+  defp maybe_touch_keepalive(state) do
+    now = System.monotonic_time(:millisecond)
+
+    if is_nil(state.last_keepalive_touch) ||
+         now - state.last_keepalive_touch >= @keepalive_touch_interval do
+      @vm.touch_keepalive(state.project_id)
+      %{state | last_keepalive_touch: now}
+    else
+      state
+    end
   end
 
   defp load_env_vars(project_id) do

--- a/lib/shire/virtual_machine.ex
+++ b/lib/shire/virtual_machine.ex
@@ -18,6 +18,7 @@ defmodule Shire.VirtualMachine do
   @callback rm_rf(String.t(), binary()) :: fs_result()
   @callback ls(String.t(), binary()) :: {:ok, [map()]} | {:error, term()}
   @callback stat(String.t(), binary()) :: {:ok, map()} | {:error, term()}
+  @callback touch_keepalive(String.t()) :: :ok
   @callback spawn_command(String.t(), binary(), [binary()], keyword()) ::
               {:ok, Sprites.Command.t()} | {:error, term()}
   @callback write_stdin(Sprites.Command.t(), binary()) :: :ok | {:error, term()}

--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -88,6 +88,14 @@ defmodule Shire.VirtualMachineImpl do
     GenServer.call(via(project_id), {:stat, path})
   end
 
+  # --- Public API: Keepalive ---
+
+  @impl Shire.VirtualMachine
+  def touch_keepalive(project_id) do
+    GenServer.cast(via(project_id), :touch_keepalive)
+    :ok
+  end
+
   # --- Public API: Interactive Process ---
 
   @impl Shire.VirtualMachine
@@ -204,7 +212,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call({:read, _path}, _from, %{fs: nil} = state) do
@@ -222,7 +230,7 @@ defmodule Shire.VirtualMachineImpl do
           err
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call({:write, _path, _content}, _from, %{fs: nil} = state) do
@@ -240,7 +248,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call({:mkdir_p, _path}, _from, %{fs: nil} = state) do
@@ -258,7 +266,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call({:rm, _path}, _from, %{fs: nil} = state) do
@@ -276,7 +284,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call({:rm_rf, _path}, _from, %{fs: nil} = state) do
@@ -294,7 +302,7 @@ defmodule Shire.VirtualMachineImpl do
           {:error, e}
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call({:ls, _path}, _from, %{fs: nil} = state) do
@@ -312,7 +320,7 @@ defmodule Shire.VirtualMachineImpl do
           err
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call({:stat, _path}, _from, %{fs: nil} = state) do
@@ -330,11 +338,16 @@ defmodule Shire.VirtualMachineImpl do
           err
       end
 
-    {:reply, result, touch_keepalive(state)}
+    {:reply, result, extend_keepalive(state)}
   end
 
   def handle_call(:get_sprite, _from, state) do
-    {:reply, state.sprite, touch_keepalive(state)}
+    {:reply, state.sprite, extend_keepalive(state)}
+  end
+
+  @impl GenServer
+  def handle_cast(:touch_keepalive, state) do
+    {:noreply, extend_keepalive(state)}
   end
 
   @impl GenServer
@@ -438,7 +451,7 @@ defmodule Shire.VirtualMachineImpl do
     %{state | ping_timer: timer}
   end
 
-  defp touch_keepalive(state) do
+  defp extend_keepalive(state) do
     ping_until = System.monotonic_time(:millisecond) + @keepalive_duration
     was_idle = is_nil(state.ping_timer)
     state = %{state | ping_until: ping_until}

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -12,6 +12,8 @@ defmodule Shire.Agent.AgentManagerTest do
   setup :set_mox_from_context
 
   setup do
+    stub(Shire.VirtualMachineMock, :touch_keepalive, fn _project_id -> :ok end)
+
     {:ok, project} = Projects.create_project("test-project-#{System.unique_integer([:positive])}")
     {:ok, agent} = Agents.create_agent_with_vm(project.id, "test-agent", "version: 1\n", @vm)
 
@@ -21,10 +23,23 @@ defmodule Shire.Agent.AgentManagerTest do
   defp start_manager(ctx, opts \\ []) do
     agent_id = Keyword.get(opts, :agent_id, ctx.agent_id)
 
-    start_supervised(
-      {AgentManager,
-       project_id: ctx.project_id, agent_id: agent_id, agent_name: "test-agent", skip_sprite: true}
-    )
+    result =
+      start_supervised(
+        {AgentManager,
+         project_id: ctx.project_id,
+         agent_id: agent_id,
+         agent_name: "test-agent",
+         skip_sprite: true}
+      )
+
+    case result do
+      {:ok, pid} ->
+        Mox.allow(Shire.VirtualMachineMock, self(), pid)
+        {:ok, pid}
+
+      other ->
+        other
+    end
   end
 
   describe "start_link/1" do
@@ -462,6 +477,68 @@ defmodule Shire.Agent.AgentManagerTest do
       assert :ok = AgentManager.restart(ctx.project_id, ctx.agent_id)
 
       assert_receive {:status, :bootstrapping}, 1_000
+    end
+  end
+
+  describe "keepalive touch on stdout" do
+    test "touches keepalive on first stdout", ctx do
+      test_pid = self()
+
+      expect(Shire.VirtualMachineMock, :touch_keepalive, fn _project_id ->
+        send(test_pid, :keepalive_touched)
+        :ok
+      end)
+
+      {:ok, pid} = start_manager(ctx)
+      ref = make_ref()
+
+      :sys.replace_state(pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      state_before = AgentManager.get_state(pid)
+      assert state_before.last_keepalive_touch == nil
+
+      line = Jason.encode!(%{"type" => "text_delta", "payload" => %{"delta" => "hi"}})
+      send(pid, {:stdout, %{ref: ref}, line <> "\n"})
+
+      assert_receive :keepalive_touched, 1_000
+
+      state_after = AgentManager.get_state(pid)
+      assert state_after.last_keepalive_touch != nil
+    end
+
+    test "throttles keepalive touches within interval", ctx do
+      test_pid = self()
+
+      # Expect exactly one call despite two stdout messages
+      expect(Shire.VirtualMachineMock, :touch_keepalive, 1, fn _project_id ->
+        send(test_pid, :keepalive_touched)
+        :ok
+      end)
+
+      {:ok, pid} = start_manager(ctx)
+      ref = make_ref()
+
+      :sys.replace_state(pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      line = Jason.encode!(%{"type" => "text_delta", "payload" => %{"delta" => "a"}})
+      send(pid, {:stdout, %{ref: ref}, line <> "\n"})
+
+      assert_receive :keepalive_touched, 1_000
+
+      state_after_first = AgentManager.get_state(pid)
+      first_touch = state_after_first.last_keepalive_touch
+      assert first_touch != nil
+
+      # Second stdout within 30s should NOT trigger another touch
+      send(pid, {:stdout, %{ref: ref}, line <> "\n"})
+
+      Process.sleep(50)
+      state_after_second = AgentManager.get_state(pid)
+      assert state_after_second.last_keepalive_touch == first_touch
     end
   end
 

--- a/test/shire_web/live/project_live_test.exs
+++ b/test/shire_web/live/project_live_test.exs
@@ -15,8 +15,10 @@ defmodule ShireWeb.ProjectLiveTest do
     end)
 
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
+    stub(Shire.VirtualMachineMock, :touch_keepalive, fn _project_id -> :ok end)
 
-    start_supervised!(Shire.ProjectManager)
+    pid = start_supervised!(Shire.ProjectManager)
+    Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
 
     on_exit(fn ->
       for {_, pid, _, _} <- DynamicSupervisor.which_children(Shire.ProjectSupervisor),

--- a/test/support/vm_stub.ex
+++ b/test/support/vm_stub.ex
@@ -33,6 +33,9 @@ defmodule Shire.VirtualMachineStub do
   def stat(_project_id, _path), do: {:ok, %{type: :file, size: 0}}
 
   @impl true
+  def touch_keepalive(_project_id), do: :ok
+
+  @impl true
   def spawn_command(_project_id, _command, _args \\ [], _opts \\ []),
     do: {:error, :not_available_in_test}
 


### PR DESCRIPTION
## Summary
- Added `touch_keepalive/1` to the VM behaviour and VirtualMachineImpl (fire-and-forget GenServer cast)
- AgentManager now calls `touch_keepalive` when processing agent stdout, with a 30-second throttle to avoid flooding the GenServer during streaming output
- Resets `last_keepalive_touch` on agent restart so the first stdout after restart always triggers a keepalive touch
- Fixed pre-existing test failure in ProjectLiveTest (DB sandbox ownership issue)

## Test plan
- [x] New test: first stdout triggers `touch_keepalive` (verified via Mox expect)
- [x] New test: rapid subsequent stdout is throttled (only 1 call within interval, verified via Mox expect with count=1)
- [x] All 201 existing tests pass
- [x] Compiles with `--warnings-as-errors`
- [x] Formatted with `mix format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)