### PR TITLE
Add VM startup retries and manual restart button

### DIFF
--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -36,6 +36,8 @@ function projectStatusVariant(status: string): "default" | "secondary" | "destru
       return "default";
     case "starting":
       return "secondary";
+    case "stopped":
+      return "secondary";
     case "error":
       return "destructive";
     default:
@@ -49,6 +51,11 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
   const [createOpen, setCreateOpen] = React.useState(false);
   const [projectName, setProjectName] = React.useState("");
   const [deleteProject, setDeleteProject] = React.useState<Project | null>(null);
+  const [restartingId, setRestartingId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setRestartingId(null);
+  }, [projects]);
 
   const nameValid = PROJECT_NAME_REGEX.test(projectName);
 
@@ -91,7 +98,21 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
                     <h3 className="font-semibold text-lg">{project.name}</h3>
                     <Badge variant={projectStatusVariant(project.status)}>{project.status}</Badge>
                   </div>
-                  <div className="mt-4 flex justify-end">
+                  <div className="mt-4 flex justify-end gap-2">
+                    {(project.status === "stopped" || project.status === "error") && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={restartingId === project.id}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setRestartingId(project.id);
+                          pushEvent("restart-project", { id: project.id });
+                        }}
+                      >
+                        {restartingId === project.id ? "Restarting..." : "Restart"}
+                      </Button>
+                    )}
                     <Button
                       variant="ghost"
                       size="sm"

--- a/assets/react-components/types.ts
+++ b/assets/react-components/types.ts
@@ -1,7 +1,7 @@
 export interface Project {
   id: string;
   name: string;
-  status: "running" | "starting" | "error";
+  status: "running" | "starting" | "stopped" | "error";
 }
 
 export type HarnessType = "pi" | "claude_code";

--- a/assets/test/ProjectDashboard.test.tsx
+++ b/assets/test/ProjectDashboard.test.tsx
@@ -87,4 +87,39 @@ describe("ProjectDashboard", () => {
 
     expect(pushEvent).toHaveBeenCalledWith("delete-project", { id: "p1" });
   });
+
+  it("shows Restart button for stopped projects", () => {
+    const stoppedProjects: Project[] = [{ id: "p5", name: "stopped-proj", status: "stopped" }];
+    render(<ProjectDashboard projects={stoppedProjects} pushEvent={vi.fn()} />);
+    expect(screen.getByText("Restart")).toBeInTheDocument();
+  });
+
+  it("shows Restart button for error projects", () => {
+    const errorProjects: Project[] = [{ id: "p6", name: "error-proj", status: "error" }];
+    render(<ProjectDashboard projects={errorProjects} pushEvent={vi.fn()} />);
+    expect(screen.getByText("Restart")).toBeInTheDocument();
+  });
+
+  it("does not show Restart button for running projects", () => {
+    render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
+    expect(screen.queryByText("Restart")).not.toBeInTheDocument();
+  });
+
+  it("calls pushEvent with restart-project when clicking Restart", async () => {
+    const pushEvent = vi.fn();
+    const stoppedProjects: Project[] = [{ id: "p7", name: "restart-me", status: "stopped" }];
+    render(<ProjectDashboard projects={stoppedProjects} pushEvent={pushEvent} />);
+
+    await userEvent.click(screen.getByText("Restart"));
+    expect(pushEvent).toHaveBeenCalledWith("restart-project", { id: "p7" });
+  });
+
+  it("shows Restarting... text while restart is in progress", async () => {
+    const pushEvent = vi.fn();
+    const stoppedProjects: Project[] = [{ id: "p8", name: "restarting-proj", status: "stopped" }];
+    render(<ProjectDashboard projects={stoppedProjects} pushEvent={pushEvent} />);
+
+    await userEvent.click(screen.getByText("Restart"));
+    expect(screen.getByText("Restarting...")).toBeInTheDocument();
+  });
 });

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -33,6 +33,11 @@ defmodule Shire.ProjectManager do
     GenServer.call(__MODULE__, {:destroy_project, project_id}, 60_000)
   end
 
+  @doc "Restarts a stopped or errored project by re-starting its supervision subtree."
+  def restart_project(project_id) when is_binary(project_id) do
+    GenServer.call(__MODULE__, {:restart_project, project_id}, 120_000)
+  end
+
   @doc "Renames a project (DB-only, no VM change needed since VM name uses UUID)."
   def rename_project(project_id, new_name) when is_binary(project_id) and is_binary(new_name) do
     GenServer.call(__MODULE__, {:rename_project, project_id, new_name}, 15_000)
@@ -58,7 +63,7 @@ defmodule Shire.ProjectManager do
 
   @impl true
   def init(_opts) do
-    {:ok, %{projects: %{}, refs: %{}}, {:continue, :discover}}
+    {:ok, %{projects: %{}}, {:continue, :discover}}
   end
 
   @impl true
@@ -178,6 +183,40 @@ defmodule Shire.ProjectManager do
   end
 
   @impl true
+  def handle_call({:restart_project, project_id}, _from, state) do
+    case Projects.get_project_by_id(project_id) do
+      nil ->
+        {:reply, {:error, :not_found}, state}
+
+      %Project{} ->
+        pid = Map.get(state.projects, project_id)
+
+        if pid && Process.alive?(pid) do
+          {:reply, {:error, :already_running}, state}
+        else
+          projects = Map.delete(state.projects, project_id)
+
+          case start_project_subtree(project_id) do
+            {:ok, new_pid} ->
+              Process.monitor(new_pid)
+              projects = Map.put(projects, project_id, new_pid)
+
+              Phoenix.PubSub.broadcast(
+                Shire.PubSub,
+                "projects:lobby",
+                {:project_restarted, project_id}
+              )
+
+              {:reply, :ok, %{state | projects: projects}}
+
+            {:error, reason} ->
+              {:reply, {:error, reason}, %{state | projects: projects}}
+          end
+        end
+    end
+  end
+
+  @impl true
   def handle_call({:rename_project, project_id, new_name}, _from, state) do
     case Projects.get_project_by_id(project_id) do
       %Project{} = project ->
@@ -204,16 +243,14 @@ defmodule Shire.ProjectManager do
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     case Enum.find(state.projects, fn {_id, p} -> p == pid end) do
       {project_id, _pid} ->
-        Logger.warning(
-          "Project #{project_id} supervisor went down, removing from tracked projects"
-        )
+        Logger.warning("Project #{project_id} supervisor went down, marking as stopped")
 
         projects = Map.delete(state.projects, project_id)
 
         Phoenix.PubSub.broadcast(
           Shire.PubSub,
           "projects:lobby",
-          {:project_destroyed, project_id}
+          {:project_status_changed, project_id}
         )
 
         {:noreply, %{state | projects: projects}}

--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -13,8 +13,9 @@ defmodule Shire.VirtualMachineImpl do
   @behaviour Shire.VirtualMachine
 
   @default_cmd_timeout 30_000
-  @ready_retries 6
-  @ready_backoff 5_000
+  @ready_retries 10
+  @ready_backoff 2_000
+  @max_backoff 30_000
   @ping_interval 2_000
   @keepalive_duration :timer.minutes(30)
 
@@ -409,15 +410,24 @@ defmodule Shire.VirtualMachineImpl do
   rescue
     e ->
       if attempt < @ready_retries do
+        delay = backoff_delay(attempt)
+
         Logger.info(
-          "VM not ready (attempt #{attempt}/#{@ready_retries}), retrying in #{@ready_backoff}ms..."
+          "VM not ready (attempt #{attempt}/#{@ready_retries}), retrying in #{delay}ms..."
         )
 
-        Process.sleep(@ready_backoff)
+        Process.sleep(delay)
         wait_for_ready(sprite, attempt + 1)
       else
         raise e
       end
+  end
+
+  @doc false
+  def backoff_delay(attempt) do
+    base = min(@ready_backoff * Integer.pow(2, attempt - 1), @max_backoff)
+    jitter = trunc(base * 0.2 * (:rand.uniform() * 2 - 1))
+    base + jitter
   end
 
   @doc false

--- a/lib/shire_web/live/project_live/index.ex
+++ b/lib/shire_web/live/project_live/index.ex
@@ -58,13 +58,33 @@ defmodule ShireWeb.ProjectLive.Index do
   end
 
   @impl true
-  def handle_info({:project_created, _id}, socket) do
-    projects = ProjectManager.list_projects()
-    {:noreply, assign(socket, :projects, projects)}
+  def handle_event("restart-project", %{"id" => project_id}, socket) do
+    case ProjectManager.restart_project(project_id) do
+      :ok ->
+        projects = ProjectManager.list_projects()
+
+        {:noreply,
+         socket
+         |> assign(:projects, projects)
+         |> put_flash(:info, "Project restarted")}
+
+      {:error, :already_running} ->
+        {:noreply, put_flash(socket, :error, "Project is already running")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Failed to restart: #{inspect(reason)}")}
+    end
   end
 
   @impl true
-  def handle_info({:project_destroyed, _id}, socket) do
+  def handle_info({event, _id}, socket)
+      when event in [
+             :project_created,
+             :project_destroyed,
+             :project_renamed,
+             :project_restarted,
+             :project_status_changed
+           ] do
     projects = ProjectManager.list_projects()
     {:noreply, assign(socket, :projects, projects)}
   end

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -164,12 +164,64 @@ defmodule Shire.ProjectManagerTest do
       Process.exit(sup_pid, :kill)
 
       project_id = project.id
-      assert_receive {:project_destroyed, ^project_id}, 1000
+      assert_receive {:project_status_changed, ^project_id}, 1000
 
       # DB record still exists but status is :stopped (no running supervisor)
       projects = ProjectManager.list_projects()
       assert length(projects) == 1
       assert hd(projects).status == :stopped
     end
+  end
+
+  describe "restart_project/1" do
+    test "restarts a stopped project" do
+      {:ok, project} = ProjectManager.create_project("restart-proj")
+      kill_project_supervisor(project.id)
+
+      # Verify it's stopped
+      projects = ProjectManager.list_projects()
+      assert hd(projects).status == :stopped
+
+      # Restart it
+      assert :ok = ProjectManager.restart_project(project.id)
+
+      # Verify it's running again
+      projects = ProjectManager.list_projects()
+      assert hd(projects).status == :running
+    end
+
+    test "returns {:error, :already_running} for a running project" do
+      {:ok, project} = ProjectManager.create_project("running-proj")
+      assert {:error, :already_running} = ProjectManager.restart_project(project.id)
+    end
+
+    test "returns {:error, :not_found} for non-existent project" do
+      assert {:error, :not_found} =
+               ProjectManager.restart_project("00000000-0000-0000-0000-000000000000")
+    end
+
+    test "broadcasts {:project_restarted, project_id} via PubSub" do
+      {:ok, project} = ProjectManager.create_project("restart-broadcast")
+      kill_project_supervisor(project.id)
+
+      Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
+
+      :ok = ProjectManager.restart_project(project.id)
+
+      project_id = project.id
+      assert_receive {:project_restarted, ^project_id}
+    end
+  end
+
+  # Terminates the project supervisor cleanly and waits for registry cleanup
+  defp kill_project_supervisor(project_id) do
+    projects_state = :sys.get_state(ProjectManager)
+    sup_pid = Map.get(projects_state.projects, project_id)
+
+    # Use terminate_child for clean shutdown (unregisters from Registry)
+    DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, sup_pid)
+
+    # Wait for the DOWN message to be processed by ProjectManager
+    Process.sleep(100)
   end
 end

--- a/test/shire/virtual_machine_test.exs
+++ b/test/shire/virtual_machine_test.exs
@@ -158,6 +158,27 @@ defmodule Shire.VirtualMachineImplTest do
     end
   end
 
+  describe "backoff_delay/1" do
+    test "returns increasing delays with exponential backoff" do
+      delays = Enum.map(1..5, fn attempt -> VM.backoff_delay(attempt) end)
+
+      # Each delay should be roughly double the previous (within jitter range)
+      # Attempt 1: ~2000ms, Attempt 2: ~4000ms, Attempt 3: ~8000ms, etc.
+      for {delay, i} <- Enum.with_index(delays, 1) do
+        base = min(2_000 * Integer.pow(2, i - 1), 30_000)
+        assert delay >= base * 0.8, "Delay #{delay} for attempt #{i} should be >= #{base * 0.8}"
+        assert delay <= base * 1.2, "Delay #{delay} for attempt #{i} should be <= #{base * 1.2}"
+      end
+    end
+
+    test "caps at max backoff" do
+      # Attempt 10 would be 2000 * 2^9 = 1_024_000, but capped at 30_000
+      delay = VM.backoff_delay(10)
+      assert delay >= 30_000 * 0.8
+      assert delay <= 30_000 * 1.2
+    end
+  end
+
   describe "resize/3" do
     test "returns :ok even when process is dead (SDK silently succeeds)" do
       dead_pid = spawn(fn -> :ok end)


### PR DESCRIPTION
## Summary
- **Exponential backoff** on VM startup: retries increased from 6 (fixed 5s) to 10 (2s–30s with jitter), covering ~3 min per init attempt and ~30 min total with supervisor restarts
- **Manual restart button** on ProjectDashboard for stopped/error projects, with `restart_project/1` API in ProjectManager
- **Fixed DOWN handler** to broadcast `:project_status_changed` instead of `:project_destroyed` when a supervisor crashes (project still exists in DB)
- **Cleanup**: removed unused `refs` field from ProjectManager state, added missing `project_renamed` PubSub handler, consolidated repetitive LiveView PubSub handlers

## Test plan
- [x] Backend: 205 tests passing (backoff math, restart happy/sad paths, PubSub broadcasts)
- [x] Frontend: 137 tests passing (restart button visibility, click behavior, loading state)
- [x] `mix compile --warnings-as-errors` clean
- [x] TypeScript, ESLint, Prettier all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)