### PR TITLE
feat: stream text deltas via push_event for faster chat rendering

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useLiveReact } from "live_react";
 import { Badge } from "./components/ui/badge";
 import { Button } from "./components/ui/button";
 import { Textarea } from "./components/ui/textarea";
@@ -125,13 +126,34 @@ export default function ChatPanel({
   loadingMore = false,
   pushEvent,
 }: ChatPanelProps) {
+  const { handleEvent, removeHandleEvent } = useLiveReact();
   const [input, setInput] = React.useState("");
+  const [streamingText, setStreamingText] = React.useState("");
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
   const prevMessagesLengthRef = React.useRef(0);
   const prevScrollHeightRef = React.useRef(0);
   const initialScrollDone = React.useRef(false);
+
+  // Reset streaming text when switching agents
+  React.useEffect(() => {
+    setStreamingText("");
+  }, [agent.id]);
+
+  // Listen for streaming text deltas and flush events from LiveView
+  React.useEffect(() => {
+    const deltaRef = handleEvent("text_delta", (payload: Record<string, unknown>) => {
+      setStreamingText((prev) => prev + (payload.delta as string));
+    });
+    const flushRef = handleEvent("streaming_flush", () => {
+      setStreamingText("");
+    });
+    return () => {
+      removeHandleEvent(deltaRef);
+      removeHandleEvent(flushRef);
+    };
+  }, [handleEvent, removeHandleEvent]);
 
   // Auto-scroll to bottom on initial load and new messages
   React.useEffect(() => {
@@ -157,6 +179,13 @@ export default function ChatPanel({
 
     prevMessagesLengthRef.current = messages.length;
   }, [messages]);
+
+  // Auto-scroll during streaming (instant to avoid animation queue buildup)
+  React.useEffect(() => {
+    if (streamingText && initialScrollDone.current) {
+      messagesEndRef.current?.scrollIntoView();
+    }
+  }, [streamingText]);
 
   // Scroll to bottom when busy state changes (thinking indicator appears/disappears)
   React.useEffect(() => {
@@ -195,7 +224,7 @@ export default function ChatPanel({
     }
   };
 
-  const hasMessages = messages.length > 0;
+  const hasMessages = messages.length > 0 || streamingText.length > 0;
 
   return (
     <div className="flex flex-col h-full">
@@ -229,7 +258,14 @@ export default function ChatPanel({
             </div>
           ),
         )}
-        {agent.busy && (
+        {streamingText && (
+          <div className="flex justify-start">
+            <div className="px-3 py-1.5 rounded-lg text-sm w-fit max-w-[80%] bg-muted">
+              <Markdown>{streamingText}</Markdown>
+            </div>
+          </div>
+        )}
+        {agent.busy && !streamingText && (
           <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
             <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
             Thinking...

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
+import { useLiveReact } from "live_react";
 import ChatPanel, { type Message } from "../react-components/ChatPanel";
 import { type Agent } from "../react-components/types";
 
@@ -127,13 +128,38 @@ describe("ChatPanel", () => {
     expect(screen.getByText("Loading older messages...")).toBeInTheDocument();
   });
 
-  it("renders streaming messages", () => {
-    const streamingMessages: Message[] = [
-      ...messages,
-      { role: "agent_streaming", text: "thinking...", ts: "2026-03-17T00:00:02Z" },
-    ];
-    render(<ChatPanel agent={activeAgent} messages={streamingMessages} pushEvent={vi.fn()} />);
-    expect(screen.getByText("thinking...")).toBeInTheDocument();
+  it("renders streaming text from push_event deltas", () => {
+    const handlers: Record<string, (payload: Record<string, unknown>) => void> = {};
+    vi.mocked(useLiveReact).mockReturnValue({
+      handleEvent: vi.fn((event: string, callback: (payload: Record<string, unknown>) => void) => {
+        handlers[event] = callback;
+        return `ref-${event}`;
+      }),
+      removeHandleEvent: vi.fn(),
+      pushEvent: vi.fn(),
+      pushEventTo: vi.fn(),
+      upload: vi.fn(),
+      uploadTo: vi.fn(),
+    });
+
+    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={vi.fn()} />);
+
+    // Simulate text_delta events
+    act(() => {
+      handlers["text_delta"]({ delta: "Hello " });
+    });
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+
+    act(() => {
+      handlers["text_delta"]({ delta: "world!" });
+    });
+    expect(screen.getByText("Hello world!")).toBeInTheDocument();
+
+    // Simulate flush — streaming text should clear
+    act(() => {
+      handlers["streaming_flush"]({});
+    });
+    expect(screen.queryByText("Hello world!")).not.toBeInTheDocument();
   });
 
   it("renders inter-agent message collapsed by default", () => {
@@ -217,10 +243,34 @@ describe("ChatPanel", () => {
     expect(screen.queryByText("Your outbox message was invalid")).not.toBeInTheDocument();
   });
 
-  it("shows thinking indicator when agent is busy", () => {
+  it("shows thinking indicator when agent is busy and not streaming", () => {
     const busyAgent = { ...activeAgent, busy: true };
     render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);
     expect(screen.getByText("Thinking...")).toBeInTheDocument();
+  });
+
+  it("hides thinking indicator when agent is busy but streaming", () => {
+    const handlers: Record<string, (payload: Record<string, unknown>) => void> = {};
+    vi.mocked(useLiveReact).mockReturnValue({
+      handleEvent: vi.fn((event: string, callback: (payload: Record<string, unknown>) => void) => {
+        handlers[event] = callback;
+        return `ref-${event}`;
+      }),
+      removeHandleEvent: vi.fn(),
+      pushEvent: vi.fn(),
+      pushEventTo: vi.fn(),
+      upload: vi.fn(),
+      uploadTo: vi.fn(),
+    });
+
+    const busyAgent = { ...activeAgent, busy: true };
+    render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);
+
+    act(() => {
+      handlers["text_delta"]({ delta: "streaming..." });
+    });
+    expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
+    expect(screen.getByText("streaming...")).toBeInTheDocument();
   });
 
   it("does not show thinking indicator when agent is not busy", () => {

--- a/assets/test/setup.ts
+++ b/assets/test/setup.ts
@@ -14,12 +14,12 @@ global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
 // Mock useLiveReact globally — individual tests can override via vi.mocked()
 vi.mock("live_react", () => ({
-  useLiveReact: () => ({
+  useLiveReact: vi.fn(() => ({
     handleEvent: vi.fn().mockReturnValue("ref-id"),
     removeHandleEvent: vi.fn(),
     pushEvent: vi.fn(),
     pushEventTo: vi.fn(),
     upload: vi.fn(),
     uploadTo: vi.fn(),
-  }),
+  })),
 }));

--- a/lib/shire_web/live/agent_live/agent_streaming.ex
+++ b/lib/shire_web/live/agent_live/agent_streaming.ex
@@ -3,41 +3,46 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
   Shared agent event streaming logic for AgentLive views.
   Processes real-time agent events and updates socket assigns for display.
   Message persistence is handled by AgentManager — this module is display-only.
+
+  Text deltas are sent via push_event to the client for lightweight streaming,
+  avoiding full messages list re-serialization on every token.
   """
 
   @doc """
   Processes an agent event and returns an updated socket.
   Expects the socket to have :messages and :streaming_text assigns.
+
+  Text deltas are pushed directly to the client via push_event ("text_delta").
+  All other events update the messages assign and push a "streaming_flush"
+  event when streaming text was pending, so the client clears its local buffer.
   """
+  def process_agent_event(socket, %{"type" => "text_delta", "payload" => %{"delta" => delta}}) do
+    socket
+    |> Phoenix.LiveView.push_event("text_delta", %{delta: delta})
+    |> Phoenix.Component.assign(streaming_text: (socket.assigns.streaming_text || "") <> delta)
+  end
+
   def process_agent_event(socket, event) do
-    # Strip ephemeral streaming entry from previous render
-    messages = Enum.reject(socket.assigns.messages, &(&1[:role] == "agent_streaming"))
+    messages = socket.assigns.messages
     streaming_text = socket.assigns.streaming_text
 
     {messages, streaming_text} = handle_event(messages, streaming_text, event)
 
-    display_messages =
-      if streaming_text do
-        messages ++
-          [
-            %{
-              role: "agent_streaming",
-              text: streaming_text,
-              ts: DateTime.utc_now() |> to_string()
-            }
-          ]
-      else
-        messages
-      end
-
-    Phoenix.Component.assign(socket, messages: display_messages, streaming_text: streaming_text)
+    socket
+    |> maybe_push_flush(socket.assigns.streaming_text, streaming_text)
+    |> Phoenix.Component.assign(messages: messages, streaming_text: streaming_text)
   end
 
-  defp handle_event(messages, streaming_text, event) do
-    case event do
-      %{"type" => "text_delta", "payload" => %{"delta" => delta}} ->
-        {messages, (streaming_text || "") <> delta}
+  # Push a flush event when streaming_text transitions from non-nil to nil
+  defp maybe_push_flush(socket, old_streaming, new_streaming)
+       when old_streaming != nil and new_streaming == nil do
+    Phoenix.LiveView.push_event(socket, "streaming_flush", %{})
+  end
 
+  defp maybe_push_flush(socket, _old, _new), do: socket
+
+  defp handle_event(messages, _streaming_text, event) do
+    case event do
       %{"type" => "tool_use", "payload" => %{"status" => "started"}, "message" => msg} ->
         # AgentManager already persisted and flushed streaming text
         {messages ++ [msg], nil}
@@ -67,7 +72,7 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
         # Check if this came with a new message (no prior tool_use found)
         case evt do
           %{"message" => msg} ->
-            {messages ++ [msg], streaming_text}
+            {messages ++ [msg], nil}
 
           _ ->
             update_tool_use_in_list(
@@ -75,8 +80,7 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
               tool_use_id,
               fn msg ->
                 %{msg | input: input}
-              end,
-              streaming_text
+              end
             )
         end
 
@@ -90,8 +94,7 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
           tool_use_id,
           fn msg ->
             %{msg | output: output, is_error: is_error}
-          end,
-          streaming_text
+          end
         )
 
       %{"type" => "text", "message" => msg} ->
@@ -103,20 +106,20 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
         {messages, nil}
 
       %{"type" => "inter_agent_message", "message" => msg} ->
-        {messages ++ [msg], streaming_text}
+        {messages ++ [msg], nil}
 
       %{"type" => "system_message", "message" => msg} ->
-        {messages ++ [msg], streaming_text}
+        {messages ++ [msg], nil}
 
       %{"type" => "turn_complete"} ->
         {messages, nil}
 
       _ ->
-        {messages, streaming_text}
+        {messages, nil}
     end
   end
 
-  defp update_tool_use_in_list(messages, tool_use_id, update_fn, streaming_text) do
+  defp update_tool_use_in_list(messages, tool_use_id, update_fn) do
     idx =
       Enum.find_index(Enum.reverse(messages), fn msg ->
         msg[:role] == "tool_use" && msg[:tool_use_id] == tool_use_id
@@ -126,9 +129,9 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
       real_idx = length(messages) - 1 - idx
       tool_msg = Enum.at(messages, real_idx)
       updated = update_fn.(tool_msg)
-      {List.replace_at(messages, real_idx, updated), streaming_text}
+      {List.replace_at(messages, real_idx, updated), nil}
     else
-      {messages, streaming_text}
+      {messages, nil}
     end
   end
 end

--- a/test/shire_web/live/agent_streaming_test.exs
+++ b/test/shire_web/live/agent_streaming_test.exs
@@ -14,11 +14,19 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
 
   defp mock_socket(overrides \\ %{}) do
     assigns = socket_assigns(overrides)
-    %Phoenix.LiveView.Socket{assigns: Map.merge(%{__changed__: %{}}, assigns)}
+
+    %Phoenix.LiveView.Socket{
+      assigns: Map.merge(%{__changed__: %{}}, assigns),
+      private: %{live_temp: %{}}
+    }
+  end
+
+  defp pushed_events(socket) do
+    socket.private.live_temp[:push_events] || []
   end
 
   describe "process_agent_event/2 with text_delta" do
-    test "accumulates streaming text" do
+    test "accumulates streaming text in assigns" do
       socket = mock_socket()
       event = %{"type" => "text_delta", "payload" => %{"delta" => "Hello "}}
 
@@ -30,14 +38,20 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
       assert socket.assigns.streaming_text == "Hello world"
     end
 
-    test "adds ephemeral agent_streaming entry" do
+    test "pushes text_delta event to client" do
       socket = mock_socket()
       event = %{"type" => "text_delta", "payload" => %{"delta" => "Hello"}}
 
       socket = AgentStreaming.process_agent_event(socket, event)
-      streaming_msg = List.last(socket.assigns.messages)
-      assert streaming_msg[:role] == "agent_streaming"
-      assert streaming_msg[:text] == "Hello"
+      assert ["text_delta", %{delta: "Hello"}] in pushed_events(socket)
+    end
+
+    test "does not modify messages list" do
+      socket = mock_socket(%{messages: [%{id: 1, role: "user", text: "hi"}]})
+      event = %{"type" => "text_delta", "payload" => %{"delta" => "Hello"}}
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      assert length(socket.assigns.messages) == 1
     end
   end
 
@@ -50,6 +64,24 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
       socket = AgentStreaming.process_agent_event(socket, event)
       assert socket.assigns.streaming_text == nil
       assert List.last(socket.assigns.messages) == msg
+    end
+
+    test "pushes streaming_flush when streaming text was pending" do
+      msg = %{id: 1, role: "agent", text: "Hello world", ts: "2024-01-01T00:00:00Z"}
+      socket = mock_socket(%{streaming_text: "Hello "})
+      event = %{"type" => "text", "payload" => %{"text" => "Hello world"}, "message" => msg}
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      assert ["streaming_flush", %{}] in pushed_events(socket)
+    end
+
+    test "does not push streaming_flush when no streaming text was pending" do
+      msg = %{id: 1, role: "agent", text: "Hello world", ts: "2024-01-01T00:00:00Z"}
+      socket = mock_socket()
+      event = %{"type" => "text", "payload" => %{"text" => "Hello world"}, "message" => msg}
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      refute ["streaming_flush", %{}] in pushed_events(socket)
     end
   end
 
@@ -98,6 +130,19 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
       assert tool_msg[:tool] == "Read"
       assert tool_msg[:tool_use_id] == "tu_123"
     end
+
+    test "pushes streaming_flush when streaming text was pending" do
+      socket = mock_socket(%{streaming_text: "partial"})
+
+      event = %{
+        "type" => "tool_use",
+        "payload" => %{"status" => "started", "tool" => "Read", "tool_use_id" => "tu_123"},
+        "message" => %{id: 2, role: "tool_use", tool: "Read", tool_use_id: "tu_123"}
+      }
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      assert ["streaming_flush", %{}] in pushed_events(socket)
+    end
   end
 
   describe "process_agent_event/2 with tool_result" do
@@ -132,7 +177,7 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
   end
 
   describe "process_agent_event/2 with inter_agent_message" do
-    test "appends inter-agent message and preserves streaming text" do
+    test "appends inter-agent message and clears streaming text" do
       msg = %{
         id: 5,
         role: "inter_agent",
@@ -150,12 +195,10 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
       }
 
       socket = AgentStreaming.process_agent_event(socket, event)
-      # Inter-agent message appended before the ephemeral streaming entry
       inter_agent = Enum.find(socket.assigns.messages, &(&1[:role] == "inter_agent"))
       assert inter_agent[:text] == "hello from other"
       assert inter_agent[:from_agent] == "other-agent"
-      # Streaming text preserved
-      assert socket.assigns.streaming_text == "partial"
+      assert socket.assigns.streaming_text == nil
     end
   end
 
@@ -166,6 +209,14 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
 
       socket = AgentStreaming.process_agent_event(socket, event)
       assert socket.assigns.streaming_text == nil
+    end
+
+    test "pushes streaming_flush when streaming text was pending" do
+      socket = mock_socket(%{streaming_text: "partial text"})
+      event = %{"type" => "turn_complete"}
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      assert ["streaming_flush", %{}] in pushed_events(socket)
     end
   end
 


### PR DESCRIPTION
## Summary
- **AgentStreaming**: text_delta events now use `push_event` to send lightweight delta payloads directly to the client, instead of re-serializing the entire messages array on every token. Other events push a `streaming_flush` event when streaming text is cleared.
- **ChatPanel**: uses `useLiveReact()` hook to listen for `text_delta` and `streaming_flush` events, accumulating streaming text in local React state. Renders a streaming bubble and hides the "Thinking..." indicator while streaming.
- **Tests**: updated both Elixir and Vitest tests to cover push_event behavior, flush semantics, and streaming UI interactions.

## Test plan
- [x] `mix compile --warnings-as-errors` — no warnings
- [x] `mix test` — 212 tests, 0 failures
- [x] `bun run tsc --noEmit` — no type errors
- [x] `bun run lint` — clean
- [x] `bun run test` — 138 tests, 0 failures
- [ ] Manual: open agent chat, send a message, verify text streams token-by-token smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)