### PR TITLE
fix: enable streaming events from Claude Agent SDK

### DIFF
--- a/priv/sprite/harness/claude-code-harness.ts
+++ b/priv/sprite/harness/claude-code-harness.ts
@@ -39,6 +39,7 @@ export class ClaudeCodeHarness implements Harness {
           permissionMode: "bypassPermissions",
           allowDangerouslySkipPermissions: true,
           continue: true,
+          includePartialMessages: true,
         },
       });
       this.activeQuery = q;


### PR DESCRIPTION
## Summary
- Add `includePartialMessages: true` to the Claude Agent SDK `query()` options
- Without this flag, the SDK only emits `assistant` and `result` messages — `stream_event` messages (containing `text_delta`) are suppressed
- This was the reason text appeared all at once instead of streaming incrementally

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun test` — 59 tests, 0 failures
- [ ] Manual: send a message to an agent, verify text streams token-by-token

🤖 Generated with [Claude Code](https://claude.com/claude-code)