### PR TITLE
fix: deduplicate streaming text DB persistence

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -714,12 +714,19 @@ defmodule Shire.Agent.AgentManager do
   end
 
   defp persist_and_broadcast(state, %{"type" => "text", "payload" => %{"text" => text}} = event) do
-    had_streaming = state.streaming_text != nil and state.streaming_text != ""
+    streaming_text_before = state.streaming_text
+    had_streaming = streaming_text_before != nil and streaming_text_before != ""
     state = flush_and_broadcast_streaming(state)
 
     # If we just flushed streaming text, skip persisting the result text
     # to avoid duplicate messages (streaming deltas already captured the content)
     if had_streaming do
+      if text != streaming_text_before do
+        Logger.warning(
+          "Text event content differs from accumulated streaming text for #{state.agent_name}"
+        )
+      end
+
       state
     else
       case Agents.create_message(%{

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -714,23 +714,30 @@ defmodule Shire.Agent.AgentManager do
   end
 
   defp persist_and_broadcast(state, %{"type" => "text", "payload" => %{"text" => text}} = event) do
+    had_streaming = state.streaming_text != nil and state.streaming_text != ""
     state = flush_and_broadcast_streaming(state)
 
-    case Agents.create_message(%{
-           project_id: state.project_id,
-           agent_id: state.agent_id,
-           role: "agent",
-           content: %{"text" => text}
-         }) do
-      {:ok, msg} ->
-        enriched = put_in(event, ["message"], serialize_message(msg))
-        broadcast(state, {:agent_event, state.agent_id, enriched})
+    # If we just flushed streaming text, skip persisting the result text
+    # to avoid duplicate messages (streaming deltas already captured the content)
+    if had_streaming do
+      state
+    else
+      case Agents.create_message(%{
+             project_id: state.project_id,
+             agent_id: state.agent_id,
+             role: "agent",
+             content: %{"text" => text}
+           }) do
+        {:ok, msg} ->
+          enriched = put_in(event, ["message"], serialize_message(msg))
+          broadcast(state, {:agent_event, state.agent_id, enriched})
 
-      {:error, _} ->
-        broadcast(state, {:agent_event, state.agent_id, event})
+        {:error, _} ->
+          broadcast(state, {:agent_event, state.agent_id, event})
+      end
+
+      state
     end
-
-    state
   end
 
   defp persist_and_broadcast(state, %{"type" => "turn_complete"} = event) do

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -237,6 +237,55 @@ defmodule Shire.Agent.AgentManagerTest do
       assert_receive {:agent_event, _, %{"type" => "turn_complete"}}, 1_000
     end
 
+    test "skips duplicate DB message when streaming text is flushed by text event",
+         %{pid: pid, ref: ref} = ctx do
+      # Send streaming deltas first
+      delta1 = Jason.encode!(%{"type" => "text_delta", "payload" => %{"delta" => "Hello "}})
+      delta2 = Jason.encode!(%{"type" => "text_delta", "payload" => %{"delta" => "world"}})
+      send(pid, {:stdout, %{ref: ref}, delta1 <> "\n" <> delta2 <> "\n"})
+
+      assert_receive {:agent_event, _, %{"type" => "text_delta"}}, 1_000
+      assert_receive {:agent_event, _, %{"type" => "text_delta"}}, 1_000
+
+      # Now send the final text event (same content as accumulated streaming)
+      text_event =
+        Jason.encode!(%{"type" => "text", "payload" => %{"text" => "Hello world"}})
+
+      send(pid, {:stdout, %{ref: ref}, text_event <> "\n"})
+
+      # Should receive the flushed streaming text as a persisted message
+      assert_receive {:agent_event, _, %{"type" => "text", "message" => msg}}, 1_000
+      assert msg[:text] == "Hello world"
+      assert msg[:id]
+
+      # Should NOT receive a second text event (the duplicate)
+      refute_receive {:agent_event, _, %{"type" => "text"}}, 300
+
+      # Verify only one DB message was created (the flushed streaming text)
+      {messages, _} = Agents.list_messages_for_agent(ctx.project_id, ctx.agent_id)
+      agent_msgs = Enum.filter(messages, &(&1.role == "agent"))
+      assert length(agent_msgs) == 1
+      assert hd(agent_msgs).content["text"] == "Hello world"
+    end
+
+    test "persists text event normally when no streaming text was accumulated",
+         %{pid: pid, ref: ref} = ctx do
+      # Send text event without any prior streaming deltas
+      text_event =
+        Jason.encode!(%{"type" => "text", "payload" => %{"text" => "Direct message"}})
+
+      send(pid, {:stdout, %{ref: ref}, text_event <> "\n"})
+
+      assert_receive {:agent_event, _, %{"type" => "text", "message" => msg}}, 1_000
+      assert msg[:text] == "Direct message"
+      assert msg[:id]
+
+      {messages, _} = Agents.list_messages_for_agent(ctx.project_id, ctx.agent_id)
+      agent_msgs = Enum.filter(messages, &(&1.role == "agent"))
+      assert length(agent_msgs) == 1
+      assert hd(agent_msgs).content["text"] == "Direct message"
+    end
+
     test "broadcasts include agent_id in 3-tuple", ctx do
       %{pid: pid, ref: ref} = ctx
       line = Jason.encode!(%{"type" => "text", "payload" => %{"text" => "test"}})

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -286,6 +286,34 @@ defmodule Shire.Agent.AgentManagerTest do
       assert hd(agent_msgs).content["text"] == "Direct message"
     end
 
+    test "handles interleaved streaming and non-streaming text events correctly",
+         %{pid: pid, ref: ref} = ctx do
+      # First turn: streaming deltas then text event (should deduplicate)
+      delta = Jason.encode!(%{"type" => "text_delta", "payload" => %{"delta" => "streamed"}})
+      send(pid, {:stdout, %{ref: ref}, delta <> "\n"})
+      assert_receive {:agent_event, _, %{"type" => "text_delta"}}, 1_000
+
+      text1 = Jason.encode!(%{"type" => "text", "payload" => %{"text" => "streamed"}})
+      send(pid, {:stdout, %{ref: ref}, text1 <> "\n"})
+      assert_receive {:agent_event, _, %{"type" => "text", "message" => msg1}}, 1_000
+      assert msg1[:text] == "streamed"
+      refute_receive {:agent_event, _, %{"type" => "text"}}, 200
+
+      # Second turn: text event without streaming (should persist normally)
+      text2 = Jason.encode!(%{"type" => "text", "payload" => %{"text" => "direct"}})
+      send(pid, {:stdout, %{ref: ref}, text2 <> "\n"})
+      assert_receive {:agent_event, _, %{"type" => "text", "message" => msg2}}, 1_000
+      assert msg2[:text] == "direct"
+      assert msg2[:id]
+
+      # Verify exactly 2 DB messages total
+      {messages, _} = Agents.list_messages_for_agent(ctx.project_id, ctx.agent_id)
+      agent_msgs = Enum.filter(messages, &(&1.role == "agent"))
+      assert length(agent_msgs) == 2
+      texts = Enum.map(agent_msgs, & &1.content["text"]) |> Enum.sort()
+      assert texts == ["direct", "streamed"]
+    end
+
     test "broadcasts include agent_id in 3-tuple", ctx do
       %{pid: pid, ref: ref} = ctx
       line = Jason.encode!(%{"type" => "text", "payload" => %{"text" => "test"}})


### PR DESCRIPTION
## Summary
- When streaming text deltas were accumulated and then a final \`text\` event arrived, both \`flush_and_broadcast_streaming\` and the text event handler would persist the same content to the DB, creating duplicate messages
- Now checks if streaming text was present before flushing, and skips the second \`create_message\` call when streaming content was already persisted
- Added tests verifying: (1) only one DB message is created when streaming text precedes a text event, (2) text events without prior streaming still persist normally

## Test plan
- [x] New test: streaming deltas + text event creates only one DB message
- [x] New test: text event without streaming still persists normally
- [x] All 214 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)