### PR TITLE
fix: make ProjectManager non-blocking during VM startup

### DIFF
--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -18,9 +18,25 @@ defmodule Shire.ProjectManager do
 
   # --- Public API ---
 
-  @doc "Lists all projects from the DB, merged with runtime status."
+  @doc """
+  Lists all projects from the DB, merged with runtime status.
+  This bypasses the GenServer to avoid blocking during VM startup.
+  Status is derived from Registry lookups instead of GenServer state.
+  """
   def list_projects do
-    GenServer.call(__MODULE__, :list_projects, 30_000)
+    Projects.list_projects()
+    |> Enum.map(fn project ->
+      status =
+        case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project.id}) do
+          [{pid, _}] ->
+            if Process.alive?(pid), do: :running, else: :error
+
+          [] ->
+            :stopped
+        end
+
+      %{id: project.id, name: project.name, status: status}
+    end)
   end
 
   @doc "Creates a new project: inserts DB record and starts the supervision subtree."
@@ -69,45 +85,24 @@ defmodule Shire.ProjectManager do
   @impl true
   def handle_continue(:discover, state) do
     db_projects = Projects.list_projects()
+    manager = self()
 
-    projects =
-      Enum.reduce(db_projects, state.projects, fn project, acc ->
+    for project <- db_projects do
+      Task.start(fn ->
         case start_project_subtree(project.id) do
           {:ok, pid} ->
-            Process.monitor(pid)
-            Map.put(acc, project.id, pid)
+            send(manager, {:project_started, project.id, pid})
 
           {:error, reason} ->
             Logger.error(
               "Failed to start project #{project.name} (#{project.id}): #{inspect(reason)}"
             )
-
-            acc
         end
       end)
+    end
 
-    Logger.info("Discovered #{map_size(projects)} project(s)")
-    {:noreply, %{state | projects: projects}}
-  end
-
-  @impl true
-  def handle_call(:list_projects, _from, state) do
-    projects =
-      Projects.list_projects()
-      |> Enum.map(fn project ->
-        pid = Map.get(state.projects, project.id)
-
-        status =
-          cond do
-            pid && Process.alive?(pid) -> :running
-            pid -> :error
-            true -> :stopped
-          end
-
-        %{id: project.id, name: project.name, status: status}
-      end)
-
-    {:reply, projects, state}
+    Logger.info("Starting #{length(db_projects)} project(s) asynchronously")
+    {:noreply, state}
   end
 
   @impl true
@@ -237,6 +232,20 @@ defmodule Shire.ProjectManager do
       nil ->
         {:reply, {:error, :not_found}, state}
     end
+  end
+
+  @impl true
+  def handle_info({:project_started, project_id, sup_pid}, state) do
+    Process.monitor(sup_pid)
+    projects = Map.put(state.projects, project_id, sup_pid)
+
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, project_id}
+    )
+
+    {:noreply, %{state | projects: projects}}
   end
 
   @impl true

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -213,6 +213,49 @@ defmodule Shire.ProjectManagerTest do
     end
   end
 
+  describe "list_projects/0 is non-blocking" do
+    test "returns results even when GenServer is processing a slow call" do
+      {:ok, _project} = ProjectManager.create_project("nonblock-proj")
+
+      # Suspend the GenServer to simulate it being busy
+      :sys.suspend(ProjectManager)
+
+      # list_projects should still work because it bypasses the GenServer
+      projects = ProjectManager.list_projects()
+      assert length(projects) == 1
+      assert hd(projects).name == "nonblock-proj"
+      assert hd(projects).status == :running
+
+      :sys.resume(ProjectManager)
+    end
+  end
+
+  describe "async discovery" do
+    test "project_started message registers the project supervisor" do
+      # Create a project directly in the DB without going through ProjectManager
+      {:ok, project} = Shire.Projects.create_project("async-disc")
+
+      # Start the subtree manually and send the message as handle_continue would
+      {:ok, sup_pid} =
+        DynamicSupervisor.start_child(
+          Shire.ProjectSupervisor,
+          {Shire.ProjectInstanceSupervisor, project_id: project.id}
+        )
+
+      Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
+
+      send(ProjectManager, {:project_started, project.id, sup_pid})
+
+      project_id = project.id
+      assert_receive {:project_status_changed, ^project_id}, 1000
+
+      # Verify the project is tracked in GenServer state
+      state = :sys.get_state(ProjectManager)
+      assert Map.has_key?(state.projects, project.id)
+      assert state.projects[project.id] == sup_pid
+    end
+  end
+
   # Terminates the project supervisor cleanly and waits for registry cleanup
   defp kill_project_supervisor(project_id) do
     projects_state = :sys.get_state(ProjectManager)


### PR DESCRIPTION
## Summary
- `list_projects` now bypasses the GenServer entirely — reads from DB + checks status via Registry lookups (same pattern as existing `lookup_coordinator`/`lookup_vm`)
- `handle_continue(:discover)` spawns async tasks per project instead of blocking sequentially — GenServer is immediately available after init
- New `handle_info({:project_started, ...})` registers supervisor PIDs as VMs come online and broadcasts PubSub updates so the UI refreshes

## Problem
During startup, `ProjectManager` sequentially started every project's VM (with retry/backoff up to 30s each). While busy, all `GenServer.call`s queued up and timed out — including `list_projects` called by every LiveView mount — making the entire web UI unresponsive.

## Test plan
- [x] New test: `list_projects` works even with GenServer suspended (proves non-blocking)
- [x] New test: `project_started` message correctly registers supervisor PID
- [x] All 217 existing tests pass
- [ ] Manual: deploy and verify UI loads instantly, projects transition from stopped → running as VMs boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)