### PR TITLE
fix: use Sprites filesystem API instead of shell commands

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -451,7 +451,7 @@ defmodule Shire.Agent.AgentManager do
 
     # Create agent directory structure
     for subdir <- ["inbox", "outbox", "scripts", "documents", ".claude/skills"] do
-      @vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/#{subdir}"], [])
+      @vm.mkdir_p(project_id, "#{agent_dir}/#{subdir}")
     end
 
     # Read recipe to determine harness type
@@ -483,7 +483,7 @@ defmodule Shire.Agent.AgentManager do
   defp read_recipe(project_id, agent_id) do
     path = "/workspace/agents/#{agent_id}/recipe.yaml"
 
-    case @vm.cmd(project_id, "cat", [path], []) do
+    case @vm.read(project_id, path) do
       {:ok, content} ->
         case YamlElixir.read_from_string(content) do
           {:ok, %{} = recipe} -> recipe
@@ -505,11 +505,11 @@ defmodule Shire.Agent.AgentManager do
       end
 
     # Clean stale skills from previous recipe versions
-    @vm.cmd(project_id, "rm", ["-rf", skill_base], [])
+    @vm.rm_rf(project_id, skill_base)
 
     for skill <- skills do
       skill_dir = "#{skill_base}/#{skill["name"]}"
-      @vm.cmd(project_id, "mkdir", ["-p", skill_dir], [])
+      @vm.mkdir_p(project_id, skill_dir)
 
       skill_md = build_skill_md(skill)
       @vm.write(project_id, "#{skill_dir}/SKILL.md", skill_md)
@@ -587,7 +587,7 @@ defmodule Shire.Agent.AgentManager do
   end
 
   defp load_env_vars(project_id) do
-    case @vm.cmd(project_id, "cat", ["/workspace/.env"], []) do
+    case @vm.read(project_id, "/workspace/.env") do
       {:ok, content} ->
         content
         |> String.split("\n", trim: true)

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -466,7 +466,7 @@ defmodule Shire.Agent.Coordinator do
     harness_dir = Path.join(runner_dir, "harness")
 
     if File.dir?(harness_dir) do
-      with {:ok, _} <- @vm.cmd(project_id, "mkdir", ["-p", "/workspace/.runner/harness"], []) do
+      with :ok <- @vm.mkdir_p(project_id, "/workspace/.runner/harness") do
         Enum.reduce_while(File.ls!(harness_dir), :ok, fn file, :ok ->
           content = File.read!(Path.join(harness_dir, file))
 
@@ -484,31 +484,21 @@ defmodule Shire.Agent.Coordinator do
   defp read_agent_recipe(project_id, agent_id) do
     path = "/workspace/agents/#{agent_id}/recipe.yaml"
 
-    case @vm.cmd(
-           project_id,
-           "bash",
-           ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"],
-           []
-         ) do
-      {:ok, output} ->
-        if String.trim(output) == "__NOT_FOUND__" do
-          %{}
-        else
-          case YamlElixir.read_from_string(output) do
-            {:ok, recipe} ->
-              recipe
+    case @vm.read(project_id, path) do
+      {:ok, content} ->
+        case YamlElixir.read_from_string(content) do
+          {:ok, recipe} ->
+            recipe
 
-            {:error, reason} ->
-              Logger.warning(
-                "Failed to parse recipe YAML for agent #{agent_id}: #{inspect(reason)}"
-              )
+          {:error, reason} ->
+            Logger.warning(
+              "Failed to parse recipe YAML for agent #{agent_id}: #{inspect(reason)}"
+            )
 
-              %{}
-          end
+            %{}
         end
 
-      {:error, reason} ->
-        Logger.warning("Failed to read recipe for agent #{agent_id}: #{inspect(reason)}")
+      {:error, _} ->
         %{}
     end
   end

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -19,10 +19,10 @@ defmodule Shire.Agents do
     |> Multi.run(:vm_setup, fn _repo, %{agent: agent} ->
       agent_dir = "/workspace/agents/#{agent.id}"
 
-      with {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/inbox"], []),
-           {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/outbox"], []),
-           {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/scripts"], []),
-           {:ok, _} <- vm.cmd(project_id, "mkdir", ["-p", "#{agent_dir}/documents"], []),
+      with :ok <- vm.mkdir_p(project_id, "#{agent_dir}/inbox"),
+           :ok <- vm.mkdir_p(project_id, "#{agent_dir}/outbox"),
+           :ok <- vm.mkdir_p(project_id, "#{agent_dir}/scripts"),
+           :ok <- vm.mkdir_p(project_id, "#{agent_dir}/documents"),
            :ok <- vm.write(project_id, "#{agent_dir}/recipe.yaml", recipe_yaml) do
         {:ok, agent.id}
       else
@@ -52,8 +52,8 @@ defmodule Shire.Agents do
     Multi.new()
     |> Multi.delete(:agent, agent)
     |> Multi.run(:rm_folder, fn _repo, _ ->
-      case vm.cmd(project_id, "rm", ["-rf", "/workspace/agents/#{agent.id}"], []) do
-        {:ok, _} ->
+      case vm.rm_rf(project_id, "/workspace/agents/#{agent.id}") do
+        :ok ->
           {:ok, :removed}
 
         {:error, reason} ->

--- a/lib/shire/workspace_settings.ex
+++ b/lib/shire/workspace_settings.ex
@@ -10,13 +10,8 @@ defmodule Shire.WorkspaceSettings do
 
   @doc "Reads `/workspace/.env` from the VM and returns it as a string."
   def read_env(project_id) do
-    case @vm.cmd(
-           project_id,
-           "bash",
-           ["-c", "test -f /workspace/.env && cat /workspace/.env || echo ''"],
-           []
-         ) do
-      {:ok, output} -> {:ok, output}
+    case @vm.read(project_id, "/workspace/.env") do
+      {:ok, content} -> {:ok, content}
       {:error, _} -> {:ok, ""}
     end
   end
@@ -33,16 +28,11 @@ defmodule Shire.WorkspaceSettings do
 
   @doc "Lists script filenames in `/workspace/.scripts/`."
   def list_scripts(project_id) do
-    case @vm.cmd(
-           project_id,
-           "bash",
-           ["-c", "test -d /workspace/.scripts && ls /workspace/.scripts || echo ''"],
-           []
-         ) do
-      {:ok, output} ->
+    case @vm.ls(project_id, "/workspace/.scripts") do
+      {:ok, entries} ->
         names =
-          output
-          |> String.split("\n", trim: true)
+          entries
+          |> Enum.map(& &1["name"])
           |> Enum.filter(&String.ends_with?(&1, ".sh"))
 
         {:ok, names}
@@ -74,21 +64,10 @@ defmodule Shire.WorkspaceSettings do
   def read_script(project_id, name) do
     path = "/workspace/.scripts/#{name}"
 
-    case @vm.cmd(
-           project_id,
-           "bash",
-           ["-c", "test -f #{path} && cat #{path} || echo '__NOT_FOUND__'"],
-           []
-         ) do
-      {:ok, output} ->
-        if String.trim(output) == "__NOT_FOUND__" do
-          {:error, :not_found}
-        else
-          {:ok, output}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+    case @vm.read(project_id, path) do
+      {:ok, content} -> {:ok, content}
+      {:error, :enoent} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -107,8 +86,12 @@ defmodule Shire.WorkspaceSettings do
   @doc "Deletes a script file from `/workspace/.scripts/{name}`."
   def delete_script(project_id, name) do
     path = "/workspace/.scripts/#{name}"
-    @vm.cmd(project_id, "rm", ["-f", path], [])
-    :ok
+
+    case @vm.rm(project_id, path) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc "Runs a script from `/workspace/.scripts/{name}` and returns output."

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -536,6 +536,9 @@ defmodule Shire.Agent.AgentManagerTest do
       Mox.set_mox_global()
       stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+      stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
 
       {:ok, pid} = start_manager(ctx)
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
@@ -624,6 +627,9 @@ defmodule Shire.Agent.AgentManagerTest do
       Mox.set_mox_global()
       stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+      stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
 
       {:ok, pid} = start_manager(ctx)
       Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)
@@ -652,9 +658,12 @@ defmodule Shire.Agent.AgentManagerTest do
     test "skips workspace setup on auto_restart (fast path)", ctx do
       Mox.set_mox_global()
       stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
 
-      # write should NOT be called — fast path skips setup_agent_workspace
+      # write/mkdir_p/rm_rf should NOT be called — fast path skips setup_agent_workspace
       Mox.expect(Shire.VirtualMachineMock, :write, 0, fn _project, _path, _content -> :ok end)
+      Mox.expect(Shire.VirtualMachineMock, :mkdir_p, 0, fn _project, _path -> :ok end)
+      Mox.expect(Shire.VirtualMachineMock, :rm_rf, 0, fn _project, _path -> :ok end)
 
       stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
         {:ok, %{ref: make_ref()}}

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -13,6 +13,9 @@ defmodule Shire.Agent.CoordinatorTest do
     # Stub all VM calls with safe defaults before starting the Coordinator
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}
@@ -260,7 +263,7 @@ defmodule Shire.Agent.CoordinatorTest do
 
       agent = create_db_agent(project_id, "my-agent")
 
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path ->
         {:ok, recipe_yaml}
       end)
 
@@ -394,7 +397,7 @@ defmodule Shire.Agent.CoordinatorTest do
     } do
       unique_name = "coord-create-test-#{System.unique_integer([:positive])}"
 
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       result =
@@ -410,7 +413,7 @@ defmodule Shire.Agent.CoordinatorTest do
     test "returns {:error, :already_exists} for duplicate names", %{project_id: project_id} do
       unique_name = "coord-dup-test-#{System.unique_integer([:positive])}"
 
-      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       recipe = "version: 1\nname: #{unique_name}\n"

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -10,6 +10,9 @@ defmodule Shire.ProjectManagerTest do
 
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}

--- a/test/shire/workspace_settings_test.exs
+++ b/test/shire/workspace_settings_test.exs
@@ -14,7 +14,7 @@ defmodule Shire.WorkspaceSettingsTest do
 
   describe "read_env/1" do
     test "returns {:ok, string} with VM content" do
-      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts ->
+      stub(Shire.VirtualMachineMock, :read, fn @project, "/workspace/.env" ->
         {:ok, "MY_VAR=hello\n"}
       end)
 
@@ -23,8 +23,8 @@ defmodule Shire.WorkspaceSettingsTest do
     end
 
     test "returns {:ok, empty string} when .env does not exist" do
-      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts ->
-        {:ok, ""}
+      stub(Shire.VirtualMachineMock, :read, fn @project, "/workspace/.env" ->
+        {:error, :enoent}
       end)
 
       assert {:ok, ""} = WorkspaceSettings.read_env(@project)
@@ -51,14 +51,21 @@ defmodule Shire.WorkspaceSettingsTest do
 
   describe "list_scripts/1" do
     test "returns {:ok, []} when no scripts exist" do
-      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :ls, fn @project, "/workspace/.scripts" ->
+        {:error, :enoent}
+      end)
 
       assert {:ok, []} = WorkspaceSettings.list_scripts(@project)
     end
 
     test "returns {:ok, list} with .sh filenames when scripts exist" do
-      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts ->
-        {:ok, "deploy.sh\nsetup.sh\nreadme.txt\n"}
+      stub(Shire.VirtualMachineMock, :ls, fn @project, "/workspace/.scripts" ->
+        {:ok,
+         [
+           %{"name" => "deploy.sh", "isDir" => false},
+           %{"name" => "setup.sh", "isDir" => false},
+           %{"name" => "readme.txt", "isDir" => false}
+         ]}
       end)
 
       assert {:ok, scripts} = WorkspaceSettings.list_scripts(@project)
@@ -70,17 +77,12 @@ defmodule Shire.WorkspaceSettingsTest do
 
   describe "read_all_scripts/1" do
     test "returns scripts with content" do
-      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", ["-c", cmd], _opts ->
-        cond do
-          String.contains?(cmd, "ls /workspace/.scripts") ->
-            {:ok, "setup.sh\n"}
+      stub(Shire.VirtualMachineMock, :ls, fn @project, "/workspace/.scripts" ->
+        {:ok, [%{"name" => "setup.sh", "isDir" => false}]}
+      end)
 
-          String.contains?(cmd, "cat /workspace/.scripts/setup.sh") ->
-            {:ok, "#!/bin/bash\necho hi"}
-
-          true ->
-            {:ok, ""}
-        end
+      stub(Shire.VirtualMachineMock, :read, fn @project, "/workspace/.scripts/setup.sh" ->
+        {:ok, "#!/bin/bash\necho hi"}
       end)
 
       assert {:ok, [%{name: "setup.sh", content: "#!/bin/bash\necho hi"}]} =
@@ -88,7 +90,9 @@ defmodule Shire.WorkspaceSettingsTest do
     end
 
     test "returns empty list when no scripts" do
-      stub(Shire.VirtualMachineMock, :cmd, fn @project, "bash", _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :ls, fn @project, "/workspace/.scripts" ->
+        {:error, :enoent}
+      end)
 
       assert {:ok, []} = WorkspaceSettings.read_all_scripts(@project)
     end
@@ -115,11 +119,8 @@ defmodule Shire.WorkspaceSettingsTest do
 
   describe "delete_script/2" do
     test "deletes the script file" do
-      expect(Shire.VirtualMachineMock, :cmd, fn @project,
-                                                "rm",
-                                                ["-f", "/workspace/.scripts/setup.sh"],
-                                                _opts ->
-        {:ok, ""}
+      expect(Shire.VirtualMachineMock, :rm, fn @project, "/workspace/.scripts/setup.sh" ->
+        :ok
       end)
 
       assert :ok = WorkspaceSettings.delete_script(@project, "setup.sh")

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -9,6 +9,9 @@ defmodule ShireWeb.AgentLiveTest do
 
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}

--- a/test/shire_web/live/project_details_live_test.exs
+++ b/test/shire_web/live/project_details_live_test.exs
@@ -10,6 +10,8 @@ defmodule ShireWeb.ProjectDetailsLiveTest do
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}

--- a/test/shire_web/live/project_live_test.exs
+++ b/test/shire_web/live/project_live_test.exs
@@ -9,6 +9,9 @@ defmodule ShireWeb.ProjectLiveTest do
 
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}

--- a/test/shire_web/live/settings_live_test.exs
+++ b/test/shire_web/live/settings_live_test.exs
@@ -11,6 +11,10 @@ defmodule ShireWeb.SettingsLiveTest do
 
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+    stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :ls, fn _project, _path -> {:ok, []} end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}


### PR DESCRIPTION
## Summary
- Replace `cmd("cat")` / `cmd("bash", "test -f && cat")` calls with `@vm.read()` across `agent_manager.ex`, `coordinator.ex`, and `workspace_settings.ex`
- Replace `cmd("mkdir", ["-p", ...])` with `@vm.mkdir_p()` in `agent_manager.ex`, `coordinator.ex`, and `agents.ex`
- Replace `cmd("rm", ["-rf", ...])` / `cmd("rm", ["-f", ...])` with `@vm.rm_rf()` / `@vm.rm()` in `agent_manager.ex`, `agents.ex`, and `workspace_settings.ex`
- Replace `cmd("bash", "ls")` with `@vm.ls()` in `workspace_settings.ex`

## Test plan
- [x] All 217 tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)