### PR TITLE
feat: reflect VM state in project status

### DIFF
--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -30,14 +30,16 @@ interface ProjectDashboardProps {
   pushEvent: (event: string, payload: Record<string, unknown>) => void;
 }
 
-function projectStatusVariant(status: string): "default" | "secondary" | "destructive" {
+function projectStatusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
   switch (status) {
     case "running":
       return "default";
     case "starting":
-      return "secondary";
     case "stopped":
       return "secondary";
+    case "idle":
+      return "outline";
+    case "unreachable":
     case "error":
       return "destructive";
     default:
@@ -99,7 +101,9 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
                     <Badge variant={projectStatusVariant(project.status)}>{project.status}</Badge>
                   </div>
                   <div className="mt-4 flex justify-end gap-2">
-                    {(project.status === "stopped" || project.status === "error") && (
+                    {(project.status === "stopped" ||
+                      project.status === "error" ||
+                      project.status === "unreachable") && (
                       <Button
                         variant="outline"
                         size="sm"

--- a/assets/react-components/types.ts
+++ b/assets/react-components/types.ts
@@ -1,7 +1,7 @@
 export interface Project {
   id: string;
   name: string;
-  status: "running" | "starting" | "stopped" | "error";
+  status: "starting" | "running" | "idle" | "unreachable" | "stopped" | "error";
 }
 
 export type HarnessType = "pi" | "claude_code";

--- a/assets/test/ProjectDashboard.test.tsx
+++ b/assets/test/ProjectDashboard.test.tsx
@@ -36,6 +36,28 @@ describe("ProjectDashboard", () => {
     expect(screen.getByText("error")).toBeInTheDocument();
   });
 
+  it("shows idle and unreachable status badges", () => {
+    const vmProjects: Project[] = [
+      { id: "p9", name: "idle-project", status: "idle" },
+      { id: "p10", name: "unreachable-project", status: "unreachable" },
+    ];
+    render(<ProjectDashboard projects={vmProjects} pushEvent={vi.fn()} />);
+    expect(screen.getByText("idle")).toBeInTheDocument();
+    expect(screen.getByText("unreachable")).toBeInTheDocument();
+  });
+
+  it("shows Restart button for unreachable projects", () => {
+    const unreachableProjects: Project[] = [{ id: "p11", name: "unreachable-proj", status: "unreachable" }];
+    render(<ProjectDashboard projects={unreachableProjects} pushEvent={vi.fn()} />);
+    expect(screen.getByText("Restart")).toBeInTheDocument();
+  });
+
+  it("does not show Restart button for idle projects", () => {
+    const idleProjects: Project[] = [{ id: "p12", name: "idle-proj", status: "idle" }];
+    render(<ProjectDashboard projects={idleProjects} pushEvent={vi.fn()} />);
+    expect(screen.queryByText("Restart")).not.toBeInTheDocument();
+  });
+
   it("opens create dialog when clicking + New Project", async () => {
     render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
     await userEvent.click(screen.getByText("+ New Project"));

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -414,6 +414,13 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_info({:vm_woke_up, _project_id}, state) do
+    # Notify project lobby so dashboard status updates
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, state.project_id}
+    )
+
     idle_agents =
       Enum.filter(state.statuses, fn {_id, status} -> status == :idle end)
 
@@ -433,6 +440,28 @@ defmodule Shire.Agent.Coordinator do
         end)
       end)
     end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:vm_went_idle, _project_id}, state) do
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, state.project_id}
+    )
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:vm_unreachable, _project_id}, state) do
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, state.project_id}
+    )
 
     {:noreply, state}
   end

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -29,7 +29,12 @@ defmodule Shire.ProjectManager do
       status =
         case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project.id}) do
           [{pid, _}] ->
-            if Process.alive?(pid), do: :running, else: :error
+            if Process.alive?(pid) do
+              # Coordinator is alive — derive status from VM state
+              @vm.vm_status(project.id)
+            else
+              :error
+            end
 
           [] ->
             :stopped

--- a/lib/shire/virtual_machine.ex
+++ b/lib/shire/virtual_machine.ex
@@ -24,6 +24,11 @@ defmodule Shire.VirtualMachine do
   @callback write_stdin(Sprites.Command.t(), binary()) :: :ok | {:error, term()}
   @callback resize(Sprites.Command.t(), integer(), integer()) :: :ok | {:error, term()}
 
+  # --- VM Status (non-blocking, reads from Registry) ---
+
+  @doc "Returns the current VM status for a project (:starting, :running, :idle, :unreachable, :stopped)."
+  @callback vm_status(String.t()) :: :starting | :running | :idle | :unreachable | :stopped
+
   # --- VM Management (module-level, not per-project) ---
 
   @doc "Destroys the underlying VM for a project."

--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -161,10 +161,21 @@ defmodule Shire.VirtualMachineImpl do
 
   # --- GenServer Callbacks ---
 
+  @doc "Returns the VM status for a project by reading directly from Registry (non-blocking)."
+  @impl Shire.VirtualMachine
+  def vm_status(project_id) do
+    case Registry.lookup(Shire.ProjectRegistry, {:vm, project_id}) do
+      [{_pid, status}] -> status
+      [] -> :stopped
+    end
+  end
+
   @impl GenServer
   def init(opts) do
     project_id = Keyword.fetch!(opts, :project_id)
     token = Application.get_env(:shire, :sprites_token)
+
+    update_registry_status(project_id, :starting)
 
     if token do
       vm_name = vm_name(project_id)
@@ -172,9 +183,17 @@ defmodule Shire.VirtualMachineImpl do
       case init_vm(token, vm_name) do
         {:ok, sprite, fs} ->
           Logger.info("VM #{vm_name} ready (project: #{project_id})")
+          update_registry_status(project_id, :running)
 
           {:ok,
-           %{sprite: sprite, fs: fs, project_id: project_id, ping_timer: nil, ping_until: nil}}
+           %{
+             sprite: sprite,
+             fs: fs,
+             project_id: project_id,
+             ping_timer: nil,
+             ping_until: nil,
+             vm_status: :running
+           }}
 
         {:error, reason} ->
           Logger.error("Failed to initialize VM #{vm_name}: #{inspect(reason)}")
@@ -182,7 +201,17 @@ defmodule Shire.VirtualMachineImpl do
       end
     else
       Logger.warning("No SPRITES_TOKEN configured — VM features disabled")
-      {:ok, %{sprite: nil, fs: nil, project_id: project_id, ping_timer: nil, ping_until: nil}}
+      update_registry_status(project_id, :running)
+
+      {:ok,
+       %{
+         sprite: nil,
+         fs: nil,
+         project_id: project_id,
+         ping_timer: nil,
+         ping_until: nil,
+         vm_status: :running
+       }}
     end
   end
 
@@ -360,17 +389,45 @@ defmodule Shire.VirtualMachineImpl do
     now = System.monotonic_time(:millisecond)
 
     if state.ping_until && now < state.ping_until do
+      vm_self = self()
+
       Task.start(fn ->
         try do
           Sprites.cmd(state.sprite, "echo", ["ping"], timeout: 5_000)
         rescue
-          _ -> :ok
+          _ -> send(vm_self, :ping_failed)
         end
       end)
 
       {:noreply, schedule_ping(state)}
     else
-      {:noreply, %{state | ping_timer: nil, ping_until: nil}}
+      update_registry_status(state.project_id, :idle)
+
+      Phoenix.PubSub.broadcast(
+        Shire.PubSub,
+        "project:#{state.project_id}:vm",
+        {:vm_went_idle, state.project_id}
+      )
+
+      {:noreply, %{state | ping_timer: nil, ping_until: nil, vm_status: :idle}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(:ping_failed, state) do
+    if state.vm_status != :unreachable do
+      Logger.warning("VM ping failed for project #{state.project_id}, marking as unreachable")
+      update_registry_status(state.project_id, :unreachable)
+
+      Phoenix.PubSub.broadcast(
+        Shire.PubSub,
+        "project:#{state.project_id}:vm",
+        {:vm_unreachable, state.project_id}
+      )
+
+      {:noreply, %{state | vm_status: :unreachable}}
+    else
+      {:noreply, state}
     end
   end
 
@@ -467,15 +524,34 @@ defmodule Shire.VirtualMachineImpl do
     state = %{state | ping_until: ping_until}
 
     if was_idle do
+      update_registry_status(state.project_id, :running)
+
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
         "project:#{state.project_id}:vm",
         {:vm_woke_up, state.project_id}
       )
 
-      schedule_ping(state)
+      %{schedule_ping(state) | vm_status: :running}
     else
-      state
+      # If recovering from unreachable, update status and notify
+      if state.vm_status == :unreachable do
+        update_registry_status(state.project_id, :running)
+
+        Phoenix.PubSub.broadcast(
+          Shire.PubSub,
+          "project:#{state.project_id}:vm",
+          {:vm_woke_up, state.project_id}
+        )
+
+        %{state | vm_status: :running}
+      else
+        state
+      end
     end
+  end
+
+  defp update_registry_status(project_id, status) do
+    Registry.update_value(Shire.ProjectRegistry, {:vm, project_id}, fn _ -> status end)
   end
 end

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -16,6 +16,7 @@ defmodule Shire.ProjectManagerTest do
     end)
 
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
 
     start_supervised!(ProjectManager)
 
@@ -156,12 +157,8 @@ defmodule Shire.ProjectManagerTest do
 
       Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
 
-      # Get the supervisor pid from the ProjectManager state
-      projects_state = :sys.get_state(ProjectManager)
-      sup_pid = Map.get(projects_state.projects, project.id)
-
-      # Kill the supervisor
-      Process.exit(sup_pid, :kill)
+      # Terminate the supervisor cleanly (avoids DynamicSupervisor restart race)
+      kill_project_supervisor(project.id)
 
       project_id = project.id
       assert_receive {:project_status_changed, ^project_id}, 1000
@@ -210,6 +207,36 @@ defmodule Shire.ProjectManagerTest do
 
       project_id = project.id
       assert_receive {:project_restarted, ^project_id}
+    end
+  end
+
+  describe "list_projects/0 reflects VM status" do
+    test "returns :idle status when VM reports idle" do
+      {:ok, project} = ProjectManager.create_project("idle-proj")
+
+      # Override vm_status to return :idle
+      Mox.stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :idle end)
+
+      projects = ProjectManager.list_projects()
+      assert hd(projects).status == :idle
+    end
+
+    test "returns :unreachable status when VM reports unreachable" do
+      {:ok, project} = ProjectManager.create_project("unreach-proj")
+
+      Mox.stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :unreachable end)
+
+      projects = ProjectManager.list_projects()
+      assert hd(projects).status == :unreachable
+    end
+
+    test "returns :starting status when VM reports starting" do
+      {:ok, project} = ProjectManager.create_project("starting-proj")
+
+      Mox.stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :starting end)
+
+      projects = ProjectManager.list_projects()
+      assert hd(projects).status == :starting
     end
   end
 

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -15,6 +15,7 @@ defmodule ShireWeb.AgentLiveTest do
     end)
 
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
 
     start_supervised!(Shire.ProjectManager)
 

--- a/test/shire_web/live/project_live_test.exs
+++ b/test/shire_web/live/project_live_test.exs
@@ -16,6 +16,7 @@ defmodule ShireWeb.ProjectLiveTest do
 
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
     stub(Shire.VirtualMachineMock, :touch_keepalive, fn _project_id -> :ok end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
 
     pid = start_supervised!(Shire.ProjectManager)
     Ecto.Adapters.SQL.Sandbox.allow(Shire.Repo, self(), pid)

--- a/test/support/vm_stub.ex
+++ b/test/support/vm_stub.ex
@@ -46,5 +46,8 @@ defmodule Shire.VirtualMachineStub do
   def resize(_command, _rows, _cols), do: :ok
 
   @impl true
+  def vm_status(_project_id), do: :running
+
+  @impl true
   def destroy_vm(_project_id), do: :ok
 end


### PR DESCRIPTION
## Summary
- Project status now derives from actual VM state instead of just GenServer liveness
- New statuses: `starting` (VM booting), `running` (keepalive active), `idle` (keepalive expired), `unreachable` (ping failures)
- VirtualMachineImpl stores status in Registry metadata for non-blocking reads by `list_projects/0`
- Coordinator forwards VM events (`vm_woke_up`, `vm_went_idle`, `vm_unreachable`) to `projects:lobby` for real-time dashboard updates

## Test plan
- [x] 3 new Elixir tests for idle/unreachable/starting status derivation
- [x] 3 new frontend tests for idle/unreachable badge display and restart button
- [x] Fixed race condition in supervisor monitoring test
- [x] All 220 Elixir tests pass
- [x] All 141 frontend tests pass
- [x] TypeScript, ESLint, Prettier, Elixir format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)