### PR TITLE
docs: add workflow guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,10 @@ mix precommit
 
 ## Guidelines
 
-- **Always use a git worktree for new features and bug fixes** — before creating the worktree, pull latest main (`git pull origin main`) to ensure you're building on the latest codebase
+- **Always use plan mode first** — never start implementation for new features or bug fixes without planning first
+- **Always use a git worktree for any implementation** — before creating the worktree, pull latest main (`git pull origin main`) to ensure you're building on the latest codebase
+- **Always dispatch a code review subagent after implementation and verification** — fix issues found, then verify again. Never submit code without review and verification.
+- **Work always ends in a PR** — never push to main directly or push to a branch without creating a PR
 - Use `bun` for all JS package management and scripts, never `npm` or `node`
 - Use `Req` for HTTP requests, never httpoison/tesla/httpc
 - Use `yaml_elixir` for YAML parsing in Elixir


### PR DESCRIPTION
## Summary
- Add **plan mode first** rule — no implementation without planning
- Broaden worktree rule to cover **any implementation** (not just features/bugs)
- Add **code review subagent** requirement after implementation and verification
- Add **PR-only** rule — never push to main directly

## Test plan
- [x] Verify CLAUDE.md formatting is correct
- [x] Confirm no other files are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)