### PR TITLE
fix: make catalog card titles readable

### DIFF
--- a/assets/react-components/CatalogBrowser.tsx
+++ b/assets/react-components/CatalogBrowser.tsx
@@ -112,15 +112,13 @@ export default function CatalogBrowser({ open, onClose, agents, categories, onAd
                 {filteredAgents.map((agent) => (
                   <Card key={agent.name} className="flex flex-col">
                     <CardHeader className="pb-2">
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="flex items-center gap-2 min-w-0">
-                          <span className="text-lg shrink-0">{agent.emoji}</span>
-                          <CardTitle className="text-sm truncate">{agent.display_name}</CardTitle>
-                        </div>
-                        <Badge variant="secondary" className="shrink-0 text-xs">
-                          {agent.category}
-                        </Badge>
+                      <div className="flex items-center gap-2">
+                        <span className="text-lg shrink-0">{agent.emoji}</span>
+                        <CardTitle className="text-sm line-clamp-2">{agent.display_name}</CardTitle>
                       </div>
+                      <Badge variant="secondary" className="text-xs w-fit">
+                        {agent.category}
+                      </Badge>
                     </CardHeader>
                     <CardContent className="flex-1 pb-3">
                       <CardDescription className="text-xs line-clamp-2">{agent.description}</CardDescription>

--- a/assets/test/CatalogBrowser.test.tsx
+++ b/assets/test/CatalogBrowser.test.tsx
@@ -35,6 +35,16 @@ const agents: CatalogAgentSummary[] = [
     harness: "claude_code",
     model: "claude-sonnet-4-6",
   },
+  {
+    name: "senior-infrastructure-platform-engineer",
+    display_name: "Senior Full-Stack Infrastructure & Platform Engineer",
+    description: "Expert in cloud infrastructure and platform engineering",
+    category: "engineering",
+    emoji: "🔧",
+    tags: ["infrastructure", "platform"],
+    harness: "claude_code",
+    model: "claude-sonnet-4-6",
+  },
 ];
 
 const categories: CatalogCategory[] = [
@@ -118,5 +128,12 @@ describe("CatalogBrowser", () => {
   it("displays agent descriptions", () => {
     render(<CatalogBrowser {...defaultProps} />);
     expect(screen.getByText("Expert React/TypeScript developer")).toBeInTheDocument();
+  });
+
+  it("uses line-clamp instead of truncate for agent titles", () => {
+    render(<CatalogBrowser {...defaultProps} />);
+    const title = screen.getByText("Senior Full-Stack Infrastructure & Platform Engineer");
+    expect(title).toHaveClass("line-clamp-2");
+    expect(title).not.toHaveClass("truncate");
   });
 });


### PR DESCRIPTION
## Summary
- Separated title and badge into two rows in catalog agent cards — titles were truncated to unreadable lengths when sharing a row with the badge
- Replaced `truncate` (single-line) with `line-clamp-2` so titles get up to 2 lines before ellipsis
- Added test with a long display name asserting `line-clamp-2` is used instead of `truncate`

## Test plan
- [x] CatalogBrowser tests pass (11/11)
- [x] TypeScript, ESLint, Prettier all pass
- [ ] Visual check: open Agent Catalog dialog and verify titles are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)