### PR TITLE
fix: catalog agent creation sends missing_name_or_recipe

### DIFF
--- a/assets/react-components/AgentForm.tsx
+++ b/assets/react-components/AgentForm.tsx
@@ -98,12 +98,13 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
 
     if (!SLUG_REGEX.test(finalName)) return;
 
-    const event = agent ? "update-agent" : "create-agent";
+    const isUpdate = Boolean(agent?.id);
+    const event = isUpdate ? "update-agent" : "create-agent";
     const payload: Record<string, unknown> = {
       recipe_yaml: recipeYaml,
     };
-    if (agent) {
-      payload.id = agent.id;
+    if (isUpdate) {
+      payload.id = agent!.id;
     } else {
       payload.name = finalName;
     }

--- a/assets/test/AgentForm.test.tsx
+++ b/assets/test/AgentForm.test.tsx
@@ -184,6 +184,42 @@ describe("AgentForm", () => {
     expect(localPushEvent).toHaveBeenCalledWith("create-agent", expect.objectContaining({ name: "valid-agent" }));
   });
 
+  it("submits create-agent with name when agent has empty id (catalog prefill)", async () => {
+    const localPushEvent = vi.fn();
+    const catalogAgent: Agent = {
+      id: "",
+      name: "frontend-developer",
+      description: "React specialist",
+      status: "idle",
+      harness: "claude_code",
+      model: "claude-sonnet-4-6",
+      system_prompt: "You are a frontend developer.",
+    };
+
+    render(
+      <AgentForm
+        open={true}
+        title="New Agent from Catalog"
+        agent={catalogAgent}
+        pushEvent={localPushEvent}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Save Agent"));
+
+    expect(localPushEvent).toHaveBeenCalledWith(
+      "create-agent",
+      expect.objectContaining({
+        name: "frontend-developer",
+        recipe_yaml: expect.any(String),
+      }),
+    );
+    // Should NOT have id in payload
+    const payload = localPushEvent.mock.calls[0][1];
+    expect(payload).not.toHaveProperty("id");
+  });
+
   it("submits update-agent event with recipe_yaml for existing agent", async () => {
     const agent: Agent = {
       id: "a-existing",


### PR DESCRIPTION
## Summary

- **Bug:** Clicking "Add" in the catalog browser, then saving the pre-filled form, returned `:missing_name_or_recipe` instead of creating the agent
- **Root cause:** `AgentForm` used `agent` truthiness to decide create vs update, but catalog-prefilled agents have `id: ""` (falsy id, truthy object). The form sent `update-agent` with `{ id: "", recipe_yaml }` — no `name` key — causing the coordinator's pattern match to fall through
- **Fix:** Changed discriminator from `agent ?` to `Boolean(agent?.id) ?` so empty-id agents are correctly treated as creates

## Test plan

- [x] New test: catalog-prefilled agent (empty id) sends `create-agent` with `name`, no `id`
- [x] Existing tests pass (156 total)
- [x] TypeScript, ESLint, Prettier all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)