### PR TITLE
fix: guard against nil in list_scripts

### DIFF
--- a/lib/shire/workspace_settings.ex
+++ b/lib/shire/workspace_settings.ex
@@ -29,7 +29,7 @@ defmodule Shire.WorkspaceSettings do
   @doc "Lists script filenames in `/workspace/.scripts/`."
   def list_scripts(project_id) do
     case @vm.ls(project_id, "/workspace/.scripts") do
-      {:ok, entries} ->
+      {:ok, entries} when is_list(entries) ->
         names =
           entries
           |> Enum.map(& &1["name"])
@@ -37,7 +37,7 @@ defmodule Shire.WorkspaceSettings do
 
         {:ok, names}
 
-      {:error, _} ->
+      _ ->
         {:ok, []}
     end
   end

--- a/test/shire/workspace_settings_test.exs
+++ b/test/shire/workspace_settings_test.exs
@@ -58,6 +58,14 @@ defmodule Shire.WorkspaceSettingsTest do
       assert {:ok, []} = WorkspaceSettings.list_scripts(@project)
     end
 
+    test "returns {:ok, []} when ls returns nil entries" do
+      stub(Shire.VirtualMachineMock, :ls, fn @project, "/workspace/.scripts" ->
+        {:ok, nil}
+      end)
+
+      assert {:ok, []} = WorkspaceSettings.list_scripts(@project)
+    end
+
     test "returns {:ok, list} with .sh filenames when scripts exist" do
       stub(Shire.VirtualMachineMock, :ls, fn @project, "/workspace/.scripts" ->
         {:ok,


### PR DESCRIPTION
## Summary
- `Sprites.Filesystem.ls/2` can return `{:ok, nil}` when `/workspace/.scripts` doesn't exist, which crashes `Enum.map` with `Protocol.UndefinedError`
- Added `when is_list(entries)` guard to the pattern match and a catch-all `_` fallback returning `{:ok, []}`
- Added test covering the `{:ok, nil}` case

## Test plan
- [x] New test: `"returns {:ok, []} when ls returns nil entries"` passes
- [x] All 18 workspace_settings tests pass
- [x] Full suite: 256 tests, 1 failure (pre-existing flaky `ProjectLiveTest` ordering issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)