### PR TITLE
fix: increase wait_for_ready timeout from 10s to 30s

### DIFF
--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -475,7 +475,7 @@ defmodule Shire.VirtualMachineImpl do
   end
 
   defp wait_for_ready(sprite, attempt \\ 1) do
-    Sprites.cmd(sprite, "echo", ["ready"], timeout: 10_000)
+    Sprites.cmd(sprite, "echo", ["ready"], timeout: @default_cmd_timeout)
     :ok
   rescue
     e ->


### PR DESCRIPTION
## Summary
- Increase the per-attempt timeout in `wait_for_ready` from 10s to 30s by using `@default_cmd_timeout`
- Addresses `No space left on device` errors from crun on the Sprites platform causing slower VM responses during init

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test` — 256 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)