### PR TITLE
fix: register SchedulesPage in LiveReact component index

### DIFF
--- a/assets/react-components/index.ts
+++ b/assets/react-components/index.ts
@@ -3,6 +3,7 @@ import AgentForm from "./AgentForm";
 import AgentShow from "./AgentShow";
 import ProjectDashboard from "./ProjectDashboard";
 import ProjectDetailsPage from "./ProjectDetailsPage";
+import SchedulesPage from "./SchedulesPage";
 import SettingsPage from "./SettingsPage";
 import SharedDrive from "./SharedDrive";
 
@@ -12,6 +13,7 @@ export default {
   AgentShow,
   ProjectDashboard,
   ProjectDetailsPage,
+  SchedulesPage,
   SettingsPage,
   SharedDrive,
 };


### PR DESCRIPTION
## Summary
- The schedules page was rendering blank because `SchedulesPage` was not registered in `assets/react-components/index.ts`
- Added the import and export so LiveReact can find the component when `<.react name="SchedulesPage" />` is called

## Test plan
- [ ] Navigate to `/projects/<name>/schedules` and confirm the page renders correctly
- [ ] Verify creating, editing, toggling, and deleting schedules still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)