### PR TITLE
fix: add visible background to code blocks in message bubbles

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -253,7 +253,9 @@ export default function ChatPanel({
                   msg.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
                 }`}
               >
-                <Markdown className={msg.role === "user" ? "prose-invert" : ""}>{msg.text ?? ""}</Markdown>
+                <Markdown className={msg.role === "user" ? "prose-invert" : ""} inverted={msg.role === "user"}>
+                  {msg.text ?? ""}
+                </Markdown>
               </div>
             </div>
           ),

--- a/assets/react-components/components/Markdown.tsx
+++ b/assets/react-components/components/Markdown.tsx
@@ -5,21 +5,24 @@ import remarkGfm from "remark-gfm";
 interface MarkdownProps {
   children: string;
   className?: string;
+  inverted?: boolean;
 }
 
-export default function Markdown({ children, className }: MarkdownProps) {
+export default function Markdown({ children, className, inverted }: MarkdownProps) {
+  const codeBg = inverted ? "bg-background/20 text-inherit" : "bg-foreground text-background";
+
   return (
     <div className={`prose prose-sm max-w-none dark:prose-invert break-words ${className ?? ""}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          pre: ({ children }) => <pre className="overflow-x-auto rounded bg-muted/50 p-2 text-xs">{children}</pre>,
+          pre: ({ children }) => <pre className={`overflow-x-auto rounded ${codeBg} p-2 text-xs`}>{children}</pre>,
           code: ({ children, className }) => {
             const isBlock = className?.startsWith("language-");
             if (isBlock) {
-              return <code className={`${className} text-xs`}>{children}</code>;
+              return <code className={`${className} text-xs bg-transparent`}>{children}</code>;
             }
-            return <code className="rounded bg-muted/50 px-1 py-0.5 text-xs font-mono">{children}</code>;
+            return <code className={`rounded ${codeBg} px-1 py-0.5 text-xs font-mono`}>{children}</code>;
           },
           a: ({ href, children }) => (
             <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline">

--- a/assets/test/Markdown.test.tsx
+++ b/assets/test/Markdown.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Markdown from "../react-components/components/Markdown";
+
+describe("Markdown", () => {
+  it("renders code blocks with inverted background", () => {
+    const { container } = render(<Markdown>{"```js\nconsole.log('hello');\n```"}</Markdown>);
+    const pre = container.querySelector("pre");
+    expect(pre).toBeInTheDocument();
+    expect(pre?.className).toContain("bg-foreground");
+    expect(pre?.className).toContain("text-background");
+  });
+
+  it("renders block code element with transparent background", () => {
+    const { container } = render(<Markdown>{"```js\nconsole.log('hello');\n```"}</Markdown>);
+    const code = container.querySelector("pre code");
+    expect(code).toBeInTheDocument();
+    expect(code?.className).toContain("bg-transparent");
+  });
+
+  it("renders inline code with inverted background", () => {
+    const { container } = render(<Markdown>{"Use `myVar` here"}</Markdown>);
+    const code = container.querySelector("code");
+    expect(code).toBeInTheDocument();
+    expect(code?.className).toContain("bg-foreground");
+    expect(code?.className).toContain("text-background");
+  });
+
+  it("renders code blocks with subtle background when inverted", () => {
+    const { container } = render(<Markdown inverted>{"```js\nconsole.log('hello');\n```"}</Markdown>);
+    const pre = container.querySelector("pre");
+    expect(pre).toBeInTheDocument();
+    expect(pre?.className).toContain("bg-background/20");
+    expect(pre?.className).not.toContain("bg-foreground");
+  });
+
+  it("renders inline code with subtle background when inverted", () => {
+    const { container } = render(<Markdown inverted>{"Use `myVar` here"}</Markdown>);
+    const code = container.querySelector("code");
+    expect(code).toBeInTheDocument();
+    expect(code?.className).toContain("bg-background/20");
+    expect(code?.className).not.toContain("bg-foreground");
+  });
+});


### PR DESCRIPTION
## Summary
- Code blocks in assistant message bubbles used `bg-muted/50` which was lighter than the `bg-muted` bubble itself, providing no visual contrast
- Changed to `bg-foreground text-background` for an inverted look that stands out clearly
- Added `inverted` prop to `Markdown` component so user bubbles (already dark) use a subtle `bg-background/20` instead
- Fixed inner `<code>` in fenced blocks to use `bg-transparent` to inherit from `<pre>`

## Test plan
- [x] New `Markdown.test.tsx` with 5 tests covering code blocks, inline code, and inverted variants
- [x] All 177 tests pass
- [x] TypeScript, ESLint, Prettier all clean
- [ ] Visually verify code blocks in agent chat messages have visible background

🤖 Generated with [Claude Code](https://claude.com/claude-code)