### PR TITLE
refactor: extract /workspace into configurable workspace_root

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -8,10 +8,16 @@ defmodule Shire.Agent.AgentManager do
   require Logger
 
   alias Shire.Agents
+  alias Shire.Workspace
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
-  defp comms_prompt(agent_name, agent_id) do
+  defp comms_prompt(agent_name, agent_id, project_id) do
+    peers_path = Workspace.peers_path(project_id)
+    outbox_path = Path.join(Workspace.agent_dir(project_id, agent_id), "outbox/<any-name>.yaml")
+    shared_path = Workspace.shared_dir(project_id)
+    project_doc = Workspace.project_doc_path(project_id)
+
     """
     # Inter-Agent Communication
 
@@ -25,12 +31,12 @@ defmodule Shire.Agent.AgentManager do
     - The user sees YOUR output, not the other agents' — always produce the complete response
 
     ## Discovering Peers
-    Read `/workspace/peers.yaml` to see available agents and their descriptions.
+    Read `#{peers_path}` to see available agents and their descriptions.
 
     ## Sending Messages
     To message another agent, write a YAML file to your **outbox**:
 
-    **Path:** `/workspace/agents/#{agent_id}/outbox/<any-name>.yaml`
+    **Path:** `#{outbox_path}`
 
     **Format:**
     ```yaml
@@ -57,16 +63,16 @@ defmodule Shire.Agent.AgentManager do
     - `documents/` — Store internal documents, notes, or references worth keeping
 
     ## Shared Drive
-    All agents can read and write files in `/workspace/shared/`. Use this for sharing documents,
+    All agents can read and write files in `#{shared_path}/`. Use this for sharing documents,
     data, or artifacts that multiple agents need access to.
 
     ## Project Document
-    Before starting any task, read `/workspace/PROJECT.md` for project context, goals, and conventions.
+    Before starting any task, read `#{project_doc}` for project context, goals, and conventions.
     After completing a task, review the document and update it if your work changes any project-level
     context (e.g., new conventions, completed milestones, architectural decisions).
 
     ## Guidelines
-    - Read `/workspace/peers.yaml` before messaging to confirm the target agent exists
+    - Read `#{peers_path}` before messaging to confirm the target agent exists
     - Be specific about what you need from the other agent
     - Don't send messages unnecessarily — only when collaboration genuinely helps
     """
@@ -161,14 +167,15 @@ defmodule Shire.Agent.AgentManager do
 
   @impl true
   def handle_continue(:spawn_runner, state) do
-    agent_dir = "/workspace/agents/#{state.agent_id}"
+    agent_dir = Workspace.agent_dir(state.project_id, state.agent_id)
+    runner_path = Path.join(Workspace.runner_dir(state.project_id), "agent-runner.ts")
     kill_existing_runner(state.project_id, state.agent_id)
     env = load_env_vars(state.project_id)
 
     case @vm.spawn_command(
            state.project_id,
            "bun",
-           ["run", "/workspace/.runner/agent-runner.ts", "--agent-dir", agent_dir],
+           ["run", runner_path, "--agent-dir", agent_dir],
            env: env,
            dir: agent_dir
          ) do
@@ -194,9 +201,9 @@ defmodule Shire.Agent.AgentManager do
       "payload" => %{"text" => text}
     }
 
-    inbox_dir = "/workspace/agents/#{state.agent_id}/inbox"
+    inbox_dir = Path.join(Workspace.agent_dir(state.project_id, state.agent_id), "inbox")
     filename = "#{envelope["ts"]}-#{random_suffix()}.yaml"
-    inbox_path = "#{inbox_dir}/#{filename}"
+    inbox_path = Path.join(inbox_dir, filename)
 
     # Write directly to inbox without creating a DB message.
     # The caller (ScheduleWorker / run-now handler) is responsible for
@@ -220,9 +227,9 @@ defmodule Shire.Agent.AgentManager do
       "payload" => %{"text" => text}
     }
 
-    inbox_dir = "/workspace/agents/#{state.agent_id}/inbox"
+    inbox_dir = Path.join(Workspace.agent_dir(state.project_id, state.agent_id), "inbox")
     filename = "#{envelope["ts"]}-#{random_suffix()}.yaml"
-    inbox_path = "#{inbox_dir}/#{filename}"
+    inbox_path = Path.join(inbox_dir, filename)
 
     case Agents.send_message_with_inbox(
            state.project_id,
@@ -473,11 +480,11 @@ defmodule Shire.Agent.AgentManager do
   end
 
   defp setup_agent_workspace(project_id, agent_id, agent_name) do
-    agent_dir = "/workspace/agents/#{agent_id}"
+    agent_dir = Workspace.agent_dir(project_id, agent_id)
 
     # Create agent directory structure
     for subdir <- ["inbox", "outbox", "scripts", "documents", ".claude/skills"] do
-      @vm.mkdir_p(project_id, "#{agent_dir}/#{subdir}")
+      @vm.mkdir_p(project_id, Path.join(agent_dir, subdir))
     end
 
     # Read recipe to determine harness type
@@ -491,7 +498,11 @@ defmodule Shire.Agent.AgentManager do
         _ -> "AGENTS.md"
       end
 
-    @vm.write(project_id, "#{agent_dir}/#{comms_file}", comms_prompt(agent_name, agent_id))
+    @vm.write(
+      project_id,
+      Path.join(agent_dir, comms_file),
+      comms_prompt(agent_name, agent_id, project_id)
+    )
 
     # Deploy skills from recipe
     deploy_skills(project_id, recipe, agent_dir)
@@ -507,7 +518,7 @@ defmodule Shire.Agent.AgentManager do
   end
 
   defp read_recipe(project_id, agent_id) do
-    path = "/workspace/agents/#{agent_id}/recipe.yaml"
+    path = Path.join(Workspace.agent_dir(project_id, agent_id), "recipe.yaml")
 
     case @vm.read(project_id, path) do
       {:ok, content} ->
@@ -566,10 +577,12 @@ defmodule Shire.Agent.AgentManager do
   end
 
   defp kill_existing_runner(project_id, agent_id) do
+    agent_dir = Workspace.agent_dir(project_id, agent_id)
+
     @vm.cmd(
       project_id,
       "pkill",
-      ["-f", "agent-runner.ts --agent-dir /workspace/agents/#{agent_id}"],
+      ["-f", "agent-runner.ts --agent-dir #{agent_dir}"],
       []
     )
 
@@ -613,7 +626,7 @@ defmodule Shire.Agent.AgentManager do
   end
 
   defp load_env_vars(project_id) do
-    case @vm.read(project_id, "/workspace/.env") do
+    case @vm.read(project_id, Workspace.env_path(project_id)) do
       {:ok, content} ->
         content
         |> String.split("\n", trim: true)

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -9,6 +9,7 @@ defmodule Shire.Agent.Coordinator do
 
   alias Shire.Agents
   alias Shire.Agent.AgentManager
+  alias Shire.Workspace
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
@@ -194,7 +195,7 @@ defmodule Shire.Agent.Coordinator do
                :ok <-
                  @vm.write(
                    state.project_id,
-                   "/workspace/agents/#{agent_id}/recipe.yaml",
+                   Path.join(Workspace.agent_dir(state.project_id, agent_id), "recipe.yaml"),
                    recipe_yaml
                  ) do
             case lookup(state.project_id, agent_id) do
@@ -475,14 +476,15 @@ defmodule Shire.Agent.Coordinator do
   # --- Private ---
 
   defp deploy_runner(project_id) do
-    runner_dir = Application.app_dir(:shire, "priv/sprite")
+    source_dir = Application.app_dir(:shire, "priv/sprite")
+    ws_runner_dir = Workspace.runner_dir(project_id)
 
-    content = File.read!(Path.join(runner_dir, "agent-runner.ts"))
+    content = File.read!(Path.join(source_dir, "agent-runner.ts"))
 
-    with :ok <- @vm.write(project_id, "/workspace/.runner/agent-runner.ts", content),
-         :ok <- deploy_harness(project_id, runner_dir),
+    with :ok <- @vm.write(project_id, Path.join(ws_runner_dir, "agent-runner.ts"), content),
+         :ok <- deploy_harness(project_id, source_dir),
          {:ok, _} <-
-           @vm.cmd(project_id, "bash", ["-c", "cd /workspace/.runner && bun install"],
+           @vm.cmd(project_id, "bash", ["-c", "cd #{ws_runner_dir} && bun install"],
              timeout: 120_000
            ) do
       :ok
@@ -491,15 +493,16 @@ defmodule Shire.Agent.Coordinator do
     end
   end
 
-  defp deploy_harness(project_id, runner_dir) do
-    harness_dir = Path.join(runner_dir, "harness")
+  defp deploy_harness(project_id, source_dir) do
+    harness_dir = Path.join(source_dir, "harness")
+    ws_harness_dir = Path.join(Workspace.runner_dir(project_id), "harness")
 
     if File.dir?(harness_dir) do
-      with :ok <- @vm.mkdir_p(project_id, "/workspace/.runner/harness") do
+      with :ok <- @vm.mkdir_p(project_id, ws_harness_dir) do
         Enum.reduce_while(File.ls!(harness_dir), :ok, fn file, :ok ->
           content = File.read!(Path.join(harness_dir, file))
 
-          case @vm.write(project_id, "/workspace/.runner/harness/#{file}", content) do
+          case @vm.write(project_id, Path.join(ws_harness_dir, file), content) do
             :ok -> {:cont, :ok}
             {:error, reason} -> {:halt, {:error, reason}}
           end
@@ -511,7 +514,7 @@ defmodule Shire.Agent.Coordinator do
   end
 
   defp read_agent_recipe(project_id, agent_id) do
-    path = "/workspace/agents/#{agent_id}/recipe.yaml"
+    path = Path.join(Workspace.agent_dir(project_id, agent_id), "recipe.yaml")
 
     case @vm.read(project_id, path) do
       {:ok, content} ->
@@ -591,7 +594,7 @@ defmodule Shire.Agent.Coordinator do
           end) <> "\n"
       end
 
-    case @vm.write(project_id, "/workspace/peers.yaml", yaml_content) do
+    case @vm.write(project_id, Workspace.peers_path(project_id), yaml_content) do
       :ok ->
         :ok
 

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -4,6 +4,7 @@ defmodule Shire.Agents do
   alias Ecto.Multi
   alias Shire.Repo
   alias Shire.Agents.{Agent, Message}
+  alias Shire.Workspace
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
@@ -17,13 +18,13 @@ defmodule Shire.Agents do
     Multi.new()
     |> Multi.insert(:agent, Agent.changeset(%Agent{}, %{name: name, project_id: project_id}))
     |> Multi.run(:vm_setup, fn _repo, %{agent: agent} ->
-      agent_dir = "/workspace/agents/#{agent.id}"
+      agent_dir = Workspace.agent_dir(project_id, agent.id)
 
-      with :ok <- vm.mkdir_p(project_id, "#{agent_dir}/inbox"),
-           :ok <- vm.mkdir_p(project_id, "#{agent_dir}/outbox"),
-           :ok <- vm.mkdir_p(project_id, "#{agent_dir}/scripts"),
-           :ok <- vm.mkdir_p(project_id, "#{agent_dir}/documents"),
-           :ok <- vm.write(project_id, "#{agent_dir}/recipe.yaml", recipe_yaml) do
+      with :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "inbox")),
+           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "outbox")),
+           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "scripts")),
+           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "documents")),
+           :ok <- vm.write(project_id, Path.join(agent_dir, "recipe.yaml"), recipe_yaml) do
         {:ok, agent.id}
       else
         {:error, reason} -> {:error, reason}
@@ -52,14 +53,14 @@ defmodule Shire.Agents do
     Multi.new()
     |> Multi.delete(:agent, agent)
     |> Multi.run(:rm_folder, fn _repo, _ ->
-      case vm.rm_rf(project_id, "/workspace/agents/#{agent.id}") do
+      agent_dir = Workspace.agent_dir(project_id, agent.id)
+
+      case vm.rm_rf(project_id, agent_dir) do
         :ok ->
           {:ok, :removed}
 
         {:error, reason} ->
-          Logger.warning(
-            "Failed to remove agent directory /workspace/agents/#{agent.id}: #{inspect(reason)}"
-          )
+          Logger.warning("Failed to remove agent directory #{agent_dir}: #{inspect(reason)}")
 
           {:ok, :cleanup_failed}
       end

--- a/lib/shire/virtual_machine.ex
+++ b/lib/shire/virtual_machine.ex
@@ -20,9 +20,14 @@ defmodule Shire.VirtualMachine do
   @callback stat(String.t(), binary()) :: {:ok, map()} | {:error, term()}
   @callback touch_keepalive(String.t()) :: :ok
   @callback spawn_command(String.t(), binary(), [binary()], keyword()) ::
-              {:ok, Sprites.Command.t()} | {:error, term()}
-  @callback write_stdin(Sprites.Command.t(), binary()) :: :ok | {:error, term()}
-  @callback resize(Sprites.Command.t(), integer(), integer()) :: :ok | {:error, term()}
+              {:ok, term()} | {:error, term()}
+  @callback write_stdin(term(), binary()) :: :ok | {:error, term()}
+  @callback resize(term(), integer(), integer()) :: :ok | {:error, term()}
+
+  # --- Workspace Root ---
+
+  @doc "Returns the absolute workspace root path for a project."
+  @callback workspace_root(String.t()) :: String.t()
 
   # --- VM Status (non-blocking, reads from Registry) ---
 

--- a/lib/shire/virtual_machine_impl.ex
+++ b/lib/shire/virtual_machine_impl.ex
@@ -113,7 +113,9 @@ defmodule Shire.VirtualMachineImpl do
   end
 
   @impl Shire.VirtualMachine
-  @spec write_stdin(Sprites.Command.t(), binary()) :: :ok | {:error, term()}
+  def workspace_root(_project_id), do: "/workspace"
+
+  @impl Shire.VirtualMachine
   def write_stdin(command, data) do
     Sprites.write(command, data)
   catch
@@ -123,7 +125,6 @@ defmodule Shire.VirtualMachineImpl do
   end
 
   @impl Shire.VirtualMachine
-  @spec resize(Sprites.Command.t(), integer(), integer()) :: :ok | {:error, term()}
   def resize(command, rows, cols) do
     Sprites.resize(command, rows, cols)
   catch

--- a/lib/shire/workspace.ex
+++ b/lib/shire/workspace.ex
@@ -1,0 +1,19 @@
+defmodule Shire.Workspace do
+  @moduledoc """
+  Centralizes workspace path construction for all backends.
+  Delegates to the configured VM implementation for the workspace root.
+  """
+
+  @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
+
+  def root(project_id), do: @vm.workspace_root(project_id)
+  def agents_dir(project_id), do: Path.join(root(project_id), "agents")
+  def agent_dir(project_id, agent_id), do: Path.join(agents_dir(project_id), "#{agent_id}")
+  def shared_dir(project_id), do: Path.join(root(project_id), "shared")
+  def env_path(project_id), do: Path.join(root(project_id), ".env")
+  def scripts_dir(project_id), do: Path.join(root(project_id), ".scripts")
+  def script_path(project_id, name), do: Path.join(scripts_dir(project_id), name)
+  def runner_dir(project_id), do: Path.join(root(project_id), ".runner")
+  def peers_path(project_id), do: Path.join(root(project_id), "peers.yaml")
+  def project_doc_path(project_id), do: Path.join(root(project_id), "PROJECT.md")
+end

--- a/lib/shire/workspace_settings.ex
+++ b/lib/shire/workspace_settings.ex
@@ -4,21 +4,23 @@ defmodule Shire.WorkspaceSettings do
   All functions take `project_id` as the first parameter.
   """
 
+  alias Shire.Workspace
+
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
 
   # --- Environment ---
 
-  @doc "Reads `/workspace/.env` from the VM and returns it as a string."
+  @doc "Reads `.env` from the workspace and returns it as a string."
   def read_env(project_id) do
-    case @vm.read(project_id, "/workspace/.env") do
+    case @vm.read(project_id, Workspace.env_path(project_id)) do
       {:ok, content} -> {:ok, content}
       {:error, _} -> {:ok, ""}
     end
   end
 
-  @doc "Writes the given string to `/workspace/.env` on the VM."
+  @doc "Writes the given string to `.env` in the workspace."
   def write_env(project_id, content) do
-    case @vm.write(project_id, "/workspace/.env", content) do
+    case @vm.write(project_id, Workspace.env_path(project_id), content) do
       :ok -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -26,9 +28,9 @@ defmodule Shire.WorkspaceSettings do
 
   # --- Scripts ---
 
-  @doc "Lists script filenames in `/workspace/.scripts/`."
+  @doc "Lists script filenames in the workspace `.scripts/` directory."
   def list_scripts(project_id) do
-    case @vm.ls(project_id, "/workspace/.scripts") do
+    case @vm.ls(project_id, Workspace.scripts_dir(project_id)) do
       {:ok, entries} when is_list(entries) ->
         names =
           entries
@@ -42,7 +44,7 @@ defmodule Shire.WorkspaceSettings do
     end
   end
 
-  @doc "Lists all scripts with their content from `/workspace/.scripts/`."
+  @doc "Lists all scripts with their content from the workspace scripts directory."
   def read_all_scripts(project_id) do
     with {:ok, names} <- list_scripts(project_id) do
       scripts =
@@ -60,9 +62,9 @@ defmodule Shire.WorkspaceSettings do
     end
   end
 
-  @doc "Reads a script file from `/workspace/.scripts/{name}`."
+  @doc "Reads a script file from the workspace `.scripts/{name}`."
   def read_script(project_id, name) do
-    path = "/workspace/.scripts/#{name}"
+    path = Workspace.script_path(project_id, name)
 
     case @vm.read(project_id, path) do
       {:ok, content} -> {:ok, content}
@@ -71,9 +73,9 @@ defmodule Shire.WorkspaceSettings do
     end
   end
 
-  @doc "Writes a script file to `/workspace/.scripts/{name}`."
+  @doc "Writes a script file to the workspace `.scripts/{name}`."
   def write_script(project_id, name, content) do
-    path = "/workspace/.scripts/#{name}"
+    path = Workspace.script_path(project_id, name)
 
     with :ok <- @vm.write(project_id, path, content),
          {:ok, _} <- @vm.cmd(project_id, "chmod", ["+x", path], []) do
@@ -83,9 +85,9 @@ defmodule Shire.WorkspaceSettings do
     end
   end
 
-  @doc "Deletes a script file from `/workspace/.scripts/{name}`."
+  @doc "Deletes a script file from the workspace `.scripts/{name}`."
   def delete_script(project_id, name) do
-    path = "/workspace/.scripts/#{name}"
+    path = Workspace.script_path(project_id, name)
 
     case @vm.rm(project_id, path) do
       :ok -> :ok
@@ -94,10 +96,11 @@ defmodule Shire.WorkspaceSettings do
     end
   end
 
-  @doc "Runs a script from `/workspace/.scripts/{name}` and returns output."
+  @doc "Runs a script from the workspace `.scripts/{name}` and returns output."
   def run_script(project_id, name) do
-    path = "/workspace/.scripts/#{name}"
-    script_cmd = "[ -f /workspace/.env ] && set -a && . /workspace/.env && set +a; bash #{path}"
+    path = Workspace.script_path(project_id, name)
+    env_path = Workspace.env_path(project_id)
+    script_cmd = "[ -f #{env_path} ] && set -a && . #{env_path} && set +a; bash #{path}"
 
     case @vm.cmd(project_id, "bash", ["-c", script_cmd], timeout: 120_000) do
       {:ok, output} -> {:ok, output}
@@ -107,17 +110,17 @@ defmodule Shire.WorkspaceSettings do
 
   # --- Project Document ---
 
-  @doc "Reads `/workspace/PROJECT.md` from the VM."
+  @doc "Reads `PROJECT.md` from the workspace."
   def read_project_doc(project_id) do
-    case @vm.read(project_id, "/workspace/PROJECT.md") do
+    case @vm.read(project_id, Workspace.project_doc_path(project_id)) do
       {:ok, content} -> {:ok, content}
       {:error, _} -> {:ok, ""}
     end
   end
 
-  @doc "Writes the given string to `/workspace/PROJECT.md` on the VM."
+  @doc "Writes the given string to `PROJECT.md` in the workspace."
   def write_project_doc(project_id, content) do
-    case @vm.write(project_id, "/workspace/PROJECT.md", content) do
+    case @vm.write(project_id, Workspace.project_doc_path(project_id), content) do
       :ok -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -125,11 +128,12 @@ defmodule Shire.WorkspaceSettings do
 
   # --- Bootstrap ---
 
-  @doc "Runs the bootstrap script to initialize `/workspace` directories on the VM."
+  @doc "Runs the bootstrap script to initialize workspace directories on the VM."
   def bootstrap_workspace(project_id) do
     script = File.read!(Application.app_dir(:shire, "priv/sprite/bootstrap.sh"))
+    root = Workspace.root(project_id)
 
-    case @vm.cmd(project_id, "bash", ["-c", script], timeout: 120_000) do
+    case @vm.cmd(project_id, "bash", ["-c", script, "bash", root], timeout: 120_000) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end

--- a/lib/shire_web/controllers/shared_drive_controller.ex
+++ b/lib/shire_web/controllers/shared_drive_controller.ex
@@ -1,12 +1,13 @@
 defmodule ShireWeb.SharedDriveController do
   use ShireWeb, :controller
 
+  alias Shire.Workspace
+
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
-  @drive_path "/workspace/shared"
 
   def download(conn, %{"project_name" => project_name, "path" => path}) do
     project = Shire.Projects.get_project_by_name!(project_name)
-    vm_path = to_vm_path(path)
+    vm_path = to_vm_path(project.id, path)
 
     case @vm.read(project.id, vm_path) do
       {:ok, content} ->
@@ -26,13 +27,14 @@ defmodule ShireWeb.SharedDriveController do
     end
   end
 
-  defp to_vm_path(path) do
+  defp to_vm_path(project_id, path) do
+    drive_path = Workspace.shared_dir(project_id)
     clean = path |> String.trim_leading("/") |> String.trim_trailing("/")
 
     if clean == "" do
-      @drive_path
+      drive_path
     else
-      "#{@drive_path}/#{clean}"
+      Path.join(drive_path, clean)
     end
   end
 end

--- a/lib/shire_web/live/shared_drive_live/index.ex
+++ b/lib/shire_web/live/shared_drive_live/index.ex
@@ -3,9 +3,9 @@ defmodule ShireWeb.SharedDriveLive.Index do
 
   alias Shire.Projects
   alias Shire.ProjectManager
+  alias Shire.Workspace
 
   @vm Application.compile_env(:shire, :vm, Shire.VirtualMachineImpl)
-  @drive_path "/workspace/shared"
 
   @impl true
   def mount(%{"project_name" => project_name}, _session, socket) do
@@ -44,7 +44,7 @@ defmodule ShireWeb.SharedDriveLive.Index do
     project_id = socket.assigns.project.id
     path = join_path(socket.assigns.current_path, name)
 
-    case @vm.mkdir_p(project_id, to_vm_path(path)) do
+    case @vm.mkdir_p(project_id, to_vm_path(project_id, path)) do
       :ok ->
         {:noreply,
          socket
@@ -59,7 +59,7 @@ defmodule ShireWeb.SharedDriveLive.Index do
   def handle_event("delete-file", %{"path" => path}, socket) do
     project_id = socket.assigns.project.id
 
-    case @vm.rm(project_id, to_vm_path(path)) do
+    case @vm.rm(project_id, to_vm_path(project_id, path)) do
       :ok ->
         {:noreply, assign(socket, :files, list_files(project_id, socket.assigns.current_path))}
 
@@ -71,7 +71,7 @@ defmodule ShireWeb.SharedDriveLive.Index do
   def handle_event("delete-directory", %{"path" => path}, socket) do
     project_id = socket.assigns.project.id
 
-    case @vm.rm_rf(project_id, to_vm_path(path)) do
+    case @vm.rm_rf(project_id, to_vm_path(project_id, path)) do
       :ok ->
         {:noreply, assign(socket, :files, list_files(project_id, socket.assigns.current_path))}
 
@@ -86,7 +86,7 @@ defmodule ShireWeb.SharedDriveLive.Index do
 
     case Base.decode64(content) do
       {:ok, decoded} ->
-        vm_path = to_vm_path(path)
+        vm_path = to_vm_path(project_id, path)
 
         with :ok <- @vm.mkdir_p(project_id, Path.dirname(vm_path)),
              :ok <- @vm.write(project_id, vm_path, decoded) do
@@ -105,7 +105,7 @@ defmodule ShireWeb.SharedDriveLive.Index do
   end
 
   defp list_files(project_id, path) do
-    vm_path = to_vm_path(path)
+    vm_path = to_vm_path(project_id, path)
 
     case @vm.ls(project_id, vm_path) do
       {:ok, entries} when is_list(entries) ->
@@ -135,13 +135,14 @@ defmodule ShireWeb.SharedDriveLive.Index do
     end
   end
 
-  defp to_vm_path(path) do
+  defp to_vm_path(project_id, path) do
+    drive_path = Workspace.shared_dir(project_id)
     clean = path |> String.trim_leading("/") |> String.trim_trailing("/")
 
     if clean == "" do
-      @drive_path
+      drive_path
     else
-      "#{@drive_path}/#{clean}"
+      Path.join(drive_path, clean)
     end
   end
 

--- a/priv/sprite/bootstrap.sh
+++ b/priv/sprite/bootstrap.sh
@@ -1,26 +1,29 @@
 #!/bin/bash
-# bootstrap.sh — Sets up the base directory structure on the shared Sprite VM.
+# bootstrap.sh — Sets up the base directory structure on the workspace.
 # Run once when the VM is first created.
+# Accepts workspace root as $1, defaults to /workspace for Sprite VMs.
 
 set -euo pipefail
 
-mkdir -p /workspace/.runner
-mkdir -p /workspace/.scripts
-mkdir -p /workspace/shared
-mkdir -p /workspace/agents
+WORKSPACE_ROOT="${1:-/workspace}"
+
+mkdir -p "$WORKSPACE_ROOT/.runner"
+mkdir -p "$WORKSPACE_ROOT/.scripts"
+mkdir -p "$WORKSPACE_ROOT/shared"
+mkdir -p "$WORKSPACE_ROOT/agents"
 
 # Source workspace env vars in every interactive/login shell
-cat > /root/.bashrc << 'BASHRC'
-if [ -f /workspace/.env ]; then
+cat > /root/.bashrc << BASHRC
+if [ -f $WORKSPACE_ROOT/.env ]; then
   set -a
-  . /workspace/.env
+  . $WORKSPACE_ROOT/.env
   set +a
 fi
 BASHRC
 
 # Create default PROJECT.md if it doesn't exist
-if [ ! -f /workspace/PROJECT.md ]; then
-  cat > /workspace/PROJECT.md << 'PROJECTMD'
+if [ ! -f "$WORKSPACE_ROOT/PROJECT.md" ]; then
+  cat > "$WORKSPACE_ROOT/PROJECT.md" << 'PROJECTMD'
 # Project
 
 Describe your project here. All agents will check this document for context before starting tasks and update it after completing work.

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -12,6 +12,7 @@ defmodule Shire.Agent.AgentManagerTest do
   setup :set_mox_from_context
 
   setup do
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :touch_keepalive, fn _project_id -> :ok end)
 
     {:ok, project} = Projects.create_project("test-project-#{System.unique_integer([:positive])}")

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -11,6 +11,7 @@ defmodule Shire.Agent.CoordinatorTest do
     Mox.set_mox_global()
 
     # Stub all VM calls with safe defaults before starting the Coordinator
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)

--- a/test/shire/agents_test.exs
+++ b/test/shire/agents_test.exs
@@ -1,12 +1,18 @@
 defmodule Shire.AgentsTest do
   use Shire.DataCase, async: true
 
+  import Mox
+
   alias Shire.Agents
   alias Shire.Projects
 
   @vm Shire.VirtualMachineStub
 
+  setup :set_mox_from_context
+
   setup do
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+
     {:ok, project} = Projects.create_project("test-project")
     {:ok, agent} = Agents.create_agent_with_vm(project.id, "test-agent", "version: 1\n", @vm)
     {:ok, agent2} = Agents.create_agent_with_vm(project.id, "chat-agent", "version: 1\n", @vm)
@@ -165,6 +171,9 @@ defmodule Shire.AgentsTest do
         def write_stdin(_c, _d), do: :ok
         def resize(_c, _r, _cols), do: :ok
 
+        def workspace_root(_p), do: "/workspace"
+        def touch_keepalive(_p), do: :ok
+        def vm_status(_p), do: :running
         def destroy_vm(_p), do: :ok
       end
 

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -8,6 +8,7 @@ defmodule Shire.ProjectManagerTest do
   setup do
     Mox.set_mox_global()
 
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)

--- a/test/shire/schedules_test.exs
+++ b/test/shire/schedules_test.exs
@@ -2,6 +2,8 @@ defmodule Shire.SchedulesTest do
   use Shire.DataCase, async: true
   use Oban.Testing, repo: Shire.Repo
 
+  import Mox
+
   alias Shire.Schedules
   alias Shire.Schedules.ScheduledTask
   alias Shire.Agents
@@ -9,7 +11,11 @@ defmodule Shire.SchedulesTest do
 
   @vm Shire.VirtualMachineStub
 
+  setup :set_mox_from_context
+
   setup do
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+
     {:ok, project} = Projects.create_project("schedule-project")
     {:ok, agent} = Agents.create_agent_with_vm(project.id, "sched-agent", "version: 1\n", @vm)
 

--- a/test/shire/workspace_settings_test.exs
+++ b/test/shire/workspace_settings_test.exs
@@ -9,6 +9,7 @@ defmodule Shire.WorkspaceSettingsTest do
 
   setup do
     Mox.set_mox_global()
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     :ok
   end
 

--- a/test/shire/workspace_test.exs
+++ b/test/shire/workspace_test.exs
@@ -1,0 +1,75 @@
+defmodule Shire.WorkspaceTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Shire.Workspace
+
+  @project_id "test-project-id"
+
+  setup do
+    Mox.set_mox_global()
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+    :ok
+  end
+
+  describe "root/1" do
+    test "returns workspace root for project" do
+      assert Workspace.root(@project_id) == "/workspace"
+    end
+  end
+
+  describe "agents_dir/1" do
+    test "returns agents directory under workspace root" do
+      assert Workspace.agents_dir(@project_id) == "/workspace/agents"
+    end
+  end
+
+  describe "agent_dir/2" do
+    test "returns agent directory under agents dir" do
+      assert Workspace.agent_dir(@project_id, "agent-123") == "/workspace/agents/agent-123"
+    end
+  end
+
+  describe "shared_dir/1" do
+    test "returns shared directory" do
+      assert Workspace.shared_dir(@project_id) == "/workspace/shared"
+    end
+  end
+
+  describe "env_path/1" do
+    test "returns .env path" do
+      assert Workspace.env_path(@project_id) == "/workspace/.env"
+    end
+  end
+
+  describe "scripts_dir/1" do
+    test "returns .scripts directory" do
+      assert Workspace.scripts_dir(@project_id) == "/workspace/.scripts"
+    end
+  end
+
+  describe "script_path/2" do
+    test "returns path to a named script" do
+      assert Workspace.script_path(@project_id, "setup.sh") == "/workspace/.scripts/setup.sh"
+    end
+  end
+
+  describe "runner_dir/1" do
+    test "returns .runner directory" do
+      assert Workspace.runner_dir(@project_id) == "/workspace/.runner"
+    end
+  end
+
+  describe "peers_path/1" do
+    test "returns peers.yaml path" do
+      assert Workspace.peers_path(@project_id) == "/workspace/peers.yaml"
+    end
+  end
+
+  describe "project_doc_path/1" do
+    test "returns PROJECT.md path" do
+      assert Workspace.project_doc_path(@project_id) == "/workspace/PROJECT.md"
+    end
+  end
+end

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -7,6 +7,7 @@ defmodule ShireWeb.AgentLiveTest do
   setup do
     Mox.set_mox_global()
 
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)

--- a/test/shire_web/live/project_details_live_test.exs
+++ b/test/shire_web/live/project_details_live_test.exs
@@ -7,6 +7,7 @@ defmodule ShireWeb.ProjectDetailsLiveTest do
   setup do
     Mox.set_mox_global()
 
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)

--- a/test/shire_web/live/project_live_test.exs
+++ b/test/shire_web/live/project_live_test.exs
@@ -7,6 +7,7 @@ defmodule ShireWeb.ProjectLiveTest do
   setup do
     Mox.set_mox_global()
 
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)

--- a/test/shire_web/live/settings_live_test.exs
+++ b/test/shire_web/live/settings_live_test.exs
@@ -9,6 +9,7 @@ defmodule ShireWeb.SettingsLiveTest do
   setup do
     Mox.set_mox_global()
 
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)

--- a/test/support/vm_stub.ex
+++ b/test/support/vm_stub.ex
@@ -46,6 +46,9 @@ defmodule Shire.VirtualMachineStub do
   def resize(_command, _rows, _cols), do: :ok
 
   @impl true
+  def workspace_root(_project_id), do: "/workspace"
+
+  @impl true
   def vm_status(_project_id), do: :running
 
   @impl true


### PR DESCRIPTION
## Summary

- Add `workspace_root/1` callback to the `Shire.VirtualMachine` behaviour so each backend can define its own workspace root path
- Create new `Shire.Workspace` module centralizing all workspace path construction (agents_dir, shared_dir, env_path, scripts_dir, runner_dir, peers_path, etc.)
- Replace ~30 hardcoded `"/workspace"` references across `agents.ex`, `workspace_settings.ex`, `agent_manager.ex`, `coordinator.ex`, `shared_drive_controller.ex`, `shared_drive_live/index.ex`
- Parameterize `priv/sprite/bootstrap.sh` to accept workspace root as `$1` (defaults to `/workspace`)
- Loosen `Sprites.Command.t()` to `term()` in the VM behaviour for future backend flexibility

This is a refactor-only change — Sprites keeps `/workspace` as before. Lays groundwork for local/Docker/EC2 backends that will use different root paths (e.g. `~/.shire/projects/{project_id}/`).

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix test` — 266 tests, 0 failures
- [x] `bunx tsc --noEmit` (assets/) — clean
- [x] `bun run lint` (assets/) — clean
- [x] `bun run format:check` (assets/) — clean
- [x] `bun run test` (assets/) — 177 tests passed
- [x] `bun run lint` (priv/sprite/) — clean
- [x] `bun run format:check` (priv/sprite/) — clean
- [x] New `Shire.Workspace` test module with 10 tests covering all path helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)