### PR TITLE
docs: update CLAUDE.md and README to reflect latest project state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,13 @@
 - **Frontend:** LiveReact (React components inside Phoenix LiveView) + shadcn/ui (Radix + Tailwind v4)
 - **Build:** Vite (not esbuild), Bun (not npm/node)
 - **CSS:** Tailwind v4 with `@theme inline` + oklch CSS variables (shadcn default)
-- **VM:** Sprite VM (Firecracker), managed via `VirtualMachineSprite` GenServer
+- **VM:** Pluggable VM backend via `VirtualMachine` behaviour — `VirtualMachineSprite` (Firecracker) for production, `VirtualMachineLocal` (local filesystem + Erlang ports) for development. Selected via `SHIRE_VM_TYPE` env var.
 - **Agent runtime:** Bun + multi-harness adapter pattern (Pi SDK, Claude Code CLI)
 - **Agent deployment:** Recipe-based (YAML recipes on the VM filesystem, no DB schema)
-- **Inter-agent comms:** File-based inbox/outbox directories + host-side outbox polling + peer discovery via `peers.json`
-- **Shared drive:** `/drive` on the VM, synced to all agents at `/workspace/shared/`
+- **Agent catalog:** Static YAML agent templates in `priv/catalog/agents/`, read on demand by `Shire.Catalog`
+- **Scheduled tasks:** Oban-based job processing for recurring/one-time automated agent messaging
+- **Inter-agent comms:** File-based inbox/outbox directories + host-side outbox polling + peer discovery via `peers.yaml`
+- **Shared drive:** `/drive` on the VM (Sprite) or local filesystem (Local), synced to all agents at `{workspace_root}/shared/`
 
 ## Architecture: LiveView + React Split
 
@@ -25,7 +27,7 @@
 - Layout and rendering via shadcn/ui components
 
 **Key patterns:**
-- One page-level React component per LiveView (e.g., `AgentDashboard`, `AgentShow`, `SettingsPage`, `SharedDrive`)
+- One page-level React component per LiveView (e.g., `AgentDashboard`, `AgentShow`, `SettingsPage`, `SharedDrive`, `SchedulesPage`, `ProjectDetailsPage`)
 - React receives `pushEvent` as a prop from LiveReact to send events back to LiveView
 - Use specific event names like `create-agent`, `update-agent` instead of generic `save` (avoids dependency on `live_action`)
 - Shared `AppLayout` component wraps all pages with consistent padding/max-width
@@ -33,13 +35,21 @@
 
 ## Key Concepts
 
-**Projects** — DB-backed (`projects` table, UUID PK). Each project owns one Sprite VM and a set of agents. `ProjectManager` boots all project VMs on startup.
+**Projects** — DB-backed (`projects` table, UUID PK). Each project owns one VM (Sprite or Local) and a set of agents. `ProjectManager` boots all project VMs on startup.
 
 **Supervision tree:**
-- `ProjectManager` → `ProjectInstanceSupervisor` (per project, `one_for_all`) → `[VirtualMachineSprite, Coordinator, DynamicSupervisor]`
+- `ProjectManager` → `ProjectInstanceSupervisor` (per project, `one_for_all`) → `[VM module, Coordinator, DynamicSupervisor]`
+- VM module is selected at runtime via config (`VirtualMachineSprite` or `VirtualMachineLocal`)
 - Registries: `AgentRegistry` (agents by name), `ProjectRegistry` (project supervisors by ID)
 
-**Recipes** — YAML files defining agents (`name`, `description`, `harness`, `scripts`). Live on the VM at `/workspace/agents/{name}/recipe.yaml` — no DB schema for recipes. Agents themselves are DB-backed with a unique constraint on `(project_id, name)`.
+**VM backends:**
+- `VirtualMachineSprite` — Production backend using Fly.io Sprites (Firecracker VMs). Workspace at `/workspace`.
+- `VirtualMachineLocal` — Development backend using local filesystem (`~/.shire/projects/{project_id}/`) + Erlang ports for process execution.
+- Both implement the `Shire.VirtualMachine` behaviour. `Shire.Workspace` delegates path resolution to the configured backend.
+
+**Recipes** — YAML files defining agents (`name`, `description`, `harness`, `scripts`). Live on the VM at `{workspace_root}/agents/{name}/recipe.yaml` — no DB schema for recipes. Agents themselves are DB-backed with a unique constraint on `(project_id, name)`.
+
+**Catalog** — YAML agent templates in `priv/catalog/agents/` organized by category. Populated by `mix catalog.sync` (gitignored, not checked in). `Shire.Catalog` reads them on demand — no GenServer, no DB schema. Categories defined in `priv/catalog/categories.yaml`.
 
 **Agent lifecycle:**
 - `Coordinator` handles per-project agent CRUD — writes `recipe.yaml` to VM, starts `AgentManager` under `DynamicSupervisor`
@@ -47,12 +57,14 @@
 
 **Inter-agent messaging** — Agents write JSON envelopes to outbox. `AgentManager` polls every 2s (pauses after 15 min idle), routes to target inbox. Messages persisted to DB as `role: "inter_agent"`.
 
+**Scheduled tasks** — Oban-based (`scheduled_tasks` table). Supports one-time and recurring (cron-based) automated messages to agents. `ScheduleWorker` executes jobs; `Shire.Schedules.ensure_jobs_enqueued/0` re-enqueues on app boot.
+
 ## Folder Structure
 
 ```
 lib/shire/
   project_manager.ex              # Boots all project VMs on startup
-  project_instance_supervisor.ex  # Per-project: VirtualMachineSprite + Coordinator + DynamicSupervisor
+  project_instance_supervisor.ex  # Per-project: VM + Coordinator + DynamicSupervisor
   projects.ex                     # Context: Project CRUD
   agents.ex                       # Context: Agent + Message CRUD
   agents/                         # Ecto schemas (agent.ex, message.ex)
@@ -60,27 +72,41 @@ lib/shire/
     agent_manager.ex              # Per-agent GenServer: lifecycle, runner, outbox polling
     coordinator.ex                # Per-project: VM bootstrap, agent CRUD, message routing
     terminal_session.ex           # Interactive TTY on the VM
+  catalog.ex                      # Reads agent templates from priv/catalog/
+  schedules.ex                    # Context: Scheduled task CRUD
+  schedules/
+    scheduled_task.ex             # Ecto schema for scheduled tasks
   virtual_machine.ex              # Behaviour (cmd, read, write, spawn_command, etc.)
-  virtual_machine_sprite.ex       # GenServer wrapping Sprites SDK
+  virtual_machine_sprite.ex       # GenServer wrapping Sprites SDK (production)
+  virtual_machine_local.ex        # Local filesystem + Erlang ports (development)
+  workspace.ex                    # Workspace path resolution (delegates to VM backend)
   workspace_settings.ex           # Per-project env vars and scripts
+  workers/
+    schedule_worker.ex            # Oban worker for scheduled task execution
 
 lib/shire_web/live/
   project_live/index.ex           # ProjectDashboard (root "/" route)
   agent_live/                     # AgentDashboard, AgentShow, agent_streaming, helpers
+  project_details_live/index.ex   # ProjectDetailsPage (rename, edit PROJECT.md)
   settings_live/index.ex          # SettingsPage
   shared_drive_live/index.ex      # SharedDrive
+  schedule_live/index.ex          # SchedulesPage
 
 assets/react-components/
-  *.tsx                           # One page-level component per LiveView
+  *.tsx                           # One page-level component per LiveView + shared components
   components/ui/                  # shadcn/ui primitives
   components/AppLayout.tsx        # Shared layout wrapper
   lib/navigate.ts                 # LiveView navigation utility
   test/                           # Vitest component tests (one per component)
 
-priv/sprite/                      # Agent runtime, deployed to /workspace/.runner/
+priv/sprite/                      # Agent runtime, deployed to {workspace_root}/.runner/
   agent-runner.ts                 # Daemon: watches inbox, dispatches to harness, emits JSONL
-  bootstrap.sh                    # VM bootstrap (creates /workspace dirs)
+  bootstrap.sh                    # VM bootstrap (creates workspace dirs)
   harness/                        # Adapter pattern: pi-harness.ts, claude-code-harness.ts
+
+priv/catalog/                     # Agent templates (gitignored, populated by `mix catalog.sync`)
+  categories.yaml                 # Category definitions
+  agents/{category}/*.yaml        # Agent recipes by category
 ```
 
 ## Verification Commands
@@ -108,6 +134,12 @@ Full precommit (compile + format + test):
 ```bash
 mix precommit
 ```
+
+## Environment
+
+- `SHIRE_VM_TYPE` — selects VM backend: `sprites` (default, Firecracker) or `local` (local filesystem for dev)
+- `SPRITES_TOKEN` — required when using the Sprite backend
+- `ANTHROPIC_API_KEY` — passed to agents using the Pi SDK harness
 
 ## Guidelines
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ Shire is an open platform for deploying, orchestrating, and collaborating with A
 
 ## ✨ Why Shire?
 
-Most agent platforms treat agents as stateless API calls. Shire gives every agent a **home** — a persistent workspace with its own filesystem, tools, and mailbox, all running on a Sprite VM. Agents don't just run. They *live* here.
+Most agent platforms treat agents as stateless API calls. Shire gives every agent a **home** — a persistent workspace with its own filesystem, tools, and mailbox. Agents don't just run. They *live* here.
 
-- 📁 **Multi-project architecture** — Organize agents into projects, each with its own dedicated Sprite VM, shared drive, and settings. Spin up as many isolated environments as you need.
-- 🏠 **Persistent workspaces** — Each agent gets its own workspace directory with inbox/outbox, scripts, and documents — all backed by a Firecracker VM with a 100GB NVMe volume.
+- 📁 **Multi-project architecture** — Organize agents into projects, each with its own dedicated VM, shared drive, and settings. Spin up as many isolated environments as you need.
+- 🏠 **Persistent workspaces** — Each agent gets its own workspace directory with inbox/outbox, scripts, and documents — backed by a Firecracker VM in production or local filesystem in development.
 - 🔌 **Multi-harness architecture** — Bring your own runtime. Shire supports multiple agent harnesses (Pi SDK, Claude Code CLI) through a unified adapter pattern.
 - 📜 **Recipe-based deployment** — Define agents as simple YAML recipes with setup scripts that run idempotently. No Dockerfiles, no complex configs.
+- 📚 **Agent catalog** — Browse and deploy agents from a built-in catalog of pre-built templates organized by category (design, marketing, engineering, and more).
 - 💬 **Inter-agent communication** — Agents discover peers and exchange messages through a file-based mailbox system with automatic delivery.
+- ⏰ **Scheduled tasks** — Automate agent work with one-time or recurring scheduled messages — hourly, daily, weekly, monthly, or custom intervals.
 - 📂 **Shared drive** — A communal filesystem synced across all agents within a project for collaborative work.
 - 📊 **Real-time dashboard** — Monitor, chat with, and manage all your agents from a live web UI with streaming updates.
 - 🖥️ **Interactive terminal** — Drop into the VM with a full xterm.js terminal, right from your browser.
@@ -27,10 +29,12 @@ Most agent platforms treat agents as stateless API calls. Shire gives every agen
 │                (Phoenix LiveView + React UI)                │
 ├─────────────────────────────────────────────────────────────┤
 │  ProjectDashboard (/)                                       │
-│  ├── AgentDashboard (/projects/:id)                         │
+│  ├── AgentDashboard (/projects/:name)                       │
 │  │   ├── Agent Sidebar  │  Chat/Stream Panel                │
-│  ├── Settings (/projects/:id/settings)                      │
-│  └── Shared Drive (/projects/:id/shared)                    │
+│  ├── Project Details (/projects/:name/details)              │
+│  ├── Settings (/projects/:name/settings)                    │
+│  ├── Schedules (/projects/:name/schedules)                  │
+│  └── Shared Drive (/projects/:name/shared)                  │
 └────────────────────────────┬────────────────────────────────┘
                              │
                              ▼
@@ -44,7 +48,7 @@ Most agent platforms treat agents as stateless API calls. Shire gives every agen
 │  Project A                   │  │  Project B                   │
 │  (ProjectInstanceSupervisor) │  │  (ProjectInstanceSupervisor) │
 │  ┌────────────────────────┐  │  │  ┌────────────────────────┐  │
-│  │ VirtualMachineSprite     │  │  │  │ VirtualMachineSprite     │  │
+│  │ VM (Sprite or Local)   │  │  │  │ VM (Sprite or Local)   │  │
 │  │ Coordinator            │  │  │  │ Coordinator            │  │
 │  │ AgentMgr A, B, ...     │  │  │  │ AgentMgr C, D, ...     │  │
 │  │ Terminal Session       │  │  │  │ Terminal Session       │  │
@@ -53,19 +57,19 @@ Most agent platforms treat agents as stateless API calls. Shire gives every agen
                │                                 │
                ▼                                 ▼
 ┌──────────────────────────────┐  ┌──────────────────────────────┐
-│  Sprite VM (A)               │  │  Sprite VM (B)               │
-│  (1 VM per project)          │  │  (1 VM per project)          │
+│  VM (A)                      │  │  VM (B)                      │
+│  Sprite or Local per project │  │  Sprite or Local per project │
 │                              │  │                              │
-│  /workspace/                 │  │  /workspace/                 │
+│  {workspace_root}/             │  │  {workspace_root}/             │
 │  ├── agents/                 │  │  ├── agents/                 │
 │  │   ├── researcher/         │  │  │   └── ...                 │
-│  │   │   ├── recipe.yaml     │  │  ├── shared/ ←── /drive      │
+│  │   │   ├── recipe.yaml     │  │  ├── shared/                 │
 │  │   │   ├── inbox/          │  │  └── .runner/                │
 │  │   │   ├── outbox/         │  └──────────────────────────────┘
 │  │   │   ├── scripts/        │
 │  │   │   └── documents/      │
 │  │   └── coder/              │
-│  ├── shared/ ←── /drive      │
+│  ├── shared/                 │
 │  └── .runner/                │
 └──────────────────────────────┘
 ```
@@ -85,6 +89,8 @@ Shire is built on top of [**Fly.io Sprites**](https://sprites.dev) — lightweig
 
 Shire uses the [Sprites Elixir SDK](https://github.com/superfly/sprites-ex) to manage VM lifecycles, execute commands, sync files, and stream terminal sessions — all from the Phoenix backend.
 
+> 💡 **Local development mode:** Don't have a Sprites account? Set `SHIRE_VM_TYPE=local` to use a local filesystem backend instead. Agent workspaces live at `~/.shire/projects/` and processes run as local Erlang ports.
+
 ## 🧰 Tech Stack
 
 | Layer | Technology |
@@ -93,7 +99,8 @@ Shire uses the [Sprites Elixir SDK](https://github.com/superfly/sprites-ex) to m
 | Frontend | LiveReact (React inside Phoenix LiveView), shadcn/ui, Tailwind v4 |
 | Build | Vite, Bun |
 | Agent Runtime | Bun + TypeScript, multi-harness adapter pattern |
-| VM | [Fly.io Sprites](https://sprites.dev) (Firecracker) |
+| VM | Pluggable: [Fly.io Sprites](https://sprites.dev) (Firecracker) or Local (dev) |
+| Job Processing | [Oban](https://getoban.pro/) (scheduled tasks, recurring jobs) |
 
 ## 🚀 Getting Started
 
@@ -102,7 +109,7 @@ Shire uses the [Sprites Elixir SDK](https://github.com/superfly/sprites-ex) to m
 - Elixir 1.17+
 - PostgreSQL
 - [Bun](https://bun.sh)
-- A [Sprites](https://sprites.dev) account (for the `SPRITES_TOKEN`)
+- A [Sprites](https://sprites.dev) account (for the `SPRITES_TOKEN`) — optional if using the local VM backend
 
 ### Environment Variables
 
@@ -112,11 +119,11 @@ Create a `.env` file in the project root. It's automatically loaded in dev/test 
 
 | Variable | Description |
 |----------|-------------|
-| `SPRITES_TOKEN` | Sprites SDK authentication token from [sprites.dev](https://sprites.dev) |
+| `SPRITES_TOKEN` | Sprites SDK authentication token from [sprites.dev](https://sprites.dev) (not needed with local VM backend) |
 | `DATABASE_URL` | PostgreSQL connection string (production only — dev uses local defaults) |
 | `SECRET_KEY_BASE` | Phoenix cookie/session secret. Generate with: `mix phx.gen.secret` |
 
-> 💡 In development, only `SPRITES_TOKEN` is needed — everything else has sensible defaults.
+> 💡 In development with local VM backend (`SHIRE_VM_TYPE=local`), no external tokens are needed. With Sprite VMs, only `SPRITES_TOKEN` is required.
 
 **Optional:**
 
@@ -128,6 +135,7 @@ Create a `.env` file in the project root. It's automatically loaded in dev/test 
 | `ECTO_IPV6` | — | Set to `true` to enable IPv6 for database connections |
 | `DNS_CLUSTER_QUERY` | — | DNS query for distributed Erlang node discovery |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key, passed to agents using the Pi SDK harness |
+| `SHIRE_VM_TYPE` | `sprites` | VM backend: `sprites` (Firecracker) or `local` (local filesystem for dev) |
 
 ### Setup
 
@@ -159,7 +167,7 @@ cd assets && bun run test          # Frontend tests
 
 ### 1. Create a Project
 
-Projects are the top-level unit in Shire. Each project gets its own dedicated Sprite VM with isolated storage and networking. Create one from the dashboard at `/`. 📁
+Projects are the top-level unit in Shire. Each project gets its own dedicated VM (Sprite or Local) with isolated storage and networking. Create one from the dashboard at `/`. 📁
 
 ### 2. Define a Recipe
 
@@ -179,13 +187,17 @@ scripts:
 
 ### 3. Deploy
 
-Navigate into your project, hit "Create Agent", paste your recipe, and Shire handles the rest — bootstrapping the workspace, executing setup scripts idempotently, and spawning the agent runner. ⚡
+Navigate into your project, hit "Create Agent", paste your recipe or pick one from the built-in catalog, and Shire handles the rest — bootstrapping the workspace, executing setup scripts idempotently, and spawning the agent runner. ⚡
 
 ### 4. Collaborate
 
-Agents within a project discover each other through `peers.json` and communicate via the file-based mailbox system. Drop files in the shared drive for all agents in the project to access. Chat with any agent directly from the dashboard. 🤝
+Agents within a project discover each other through `peers.yaml` and communicate via the file-based mailbox system. Drop files in the shared drive for all agents in the project to access. Chat with any agent directly from the dashboard. 🤝
 
-### 5. Sleep & Resume
+### 5. Automate
+
+Set up scheduled tasks to send messages to agents on a recurring basis — hourly, daily, weekly, or custom intervals. Great for periodic reports, health checks, or automated workflows. ⏰
+
+### 6. Sleep & Resume
 
 When agents go idle, the VM auto-sleeps — preserving installed packages, workspaces, and all state. When you need them again, everything wakes up instantly right where it left off. No rebuilding, no lost context. 💤
 


### PR DESCRIPTION
## Summary

- Document `VirtualMachineLocal` backend and `SHIRE_VM_TYPE` env var for local development
- Add scheduled tasks (Oban), agent catalog, and new pages (Schedules, Project Details) to both files
- Update folder structure in CLAUDE.md with new modules (`catalog.ex`, `schedules.ex`, `workspace.ex`, `virtual_machine_local.ex`, `schedule_worker.ex`)
- Fix `peers.json` → `peers.yaml` references in both files
- Update README architecture diagram to be VM-backend-agnostic (`{workspace_root}/`)
- Add new environment variables section to CLAUDE.md

## Test plan

- [x] Documentation-only changes — no code modified
- [x] Cross-referenced all documented paths and modules against actual codebase
- [x] Verified peers.yaml is the correct filename (not peers.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)