### PR TITLE
fix: make agent interrupt work during active processing

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useLiveReact } from "live_react";
+import { Square } from "lucide-react";
 import { Badge } from "./components/ui/badge";
 import { Button } from "./components/ui/button";
 import { Textarea } from "./components/ui/textarea";
@@ -296,7 +297,18 @@ export default function ChatPanel({
                 }
               }}
             />
-            <Button onClick={handleSend}>Send</Button>
+            {agent.busy ? (
+              <Button
+                variant="destructive"
+                size="icon"
+                onClick={() => pushEvent("interrupt-agent", {})}
+                aria-label="Stop"
+              >
+                <Square className="h-4 w-4 fill-current" />
+              </Button>
+            ) : (
+              <Button onClick={handleSend}>Send</Button>
+            )}
           </div>
         </div>
       ) : agent.status === "idle" ? (

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -243,6 +243,27 @@ describe("ChatPanel", () => {
     expect(screen.queryByText("Your outbox message was invalid")).not.toBeInTheDocument();
   });
 
+  it("shows stop button when agent is busy", () => {
+    const busyAgent = { ...activeAgent, busy: true };
+    render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);
+    expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    expect(screen.queryByText("Send")).not.toBeInTheDocument();
+  });
+
+  it("sends interrupt-agent event when stop button is clicked", async () => {
+    const busyAgent = { ...activeAgent, busy: true };
+    const pushEvent = vi.fn();
+    render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={pushEvent} />);
+    await userEvent.click(screen.getByLabelText("Stop"));
+    expect(pushEvent).toHaveBeenCalledWith("interrupt-agent", {});
+  });
+
+  it("shows send button when agent is not busy", () => {
+    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={vi.fn()} />);
+    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+  });
+
   it("shows thinking indicator when agent is busy and not streaming", () => {
     const busyAgent = { ...activeAgent, busy: true };
     render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -106,6 +106,10 @@ defmodule Shire.Agent.AgentManager do
     GenServer.call(via(project_id, agent_id), {:send_message, text, from}, 60_000)
   end
 
+  def interrupt(project_id, agent_id) do
+    GenServer.call(via(project_id, agent_id), :interrupt, 15_000)
+  end
+
   @spec get_state(atom() | pid() | {atom(), any()} | {:via, atom(), any()}) :: any()
   def get_state(server) do
     GenServer.call(server, :get_state, 60_000)
@@ -247,6 +251,34 @@ defmodule Shire.Agent.AgentManager do
 
   @impl true
   def handle_call({:send_message, _text, _from}, _from_pid, state) do
+    {:reply, {:error, :not_active}, state}
+  end
+
+  @impl true
+  def handle_call(:interrupt, _from, %{status: :active} = state) do
+    envelope = %{
+      "ts" => System.system_time(:millisecond),
+      "type" => "interrupt",
+      "from" => "user",
+      "payload" => %{}
+    }
+
+    inbox_dir = Path.join(Workspace.agent_dir(state.project_id, state.agent_id), "inbox")
+    filename = "#{envelope["ts"]}-#{random_suffix()}.yaml"
+    inbox_path = Path.join(inbox_dir, filename)
+
+    case vm().write(state.project_id, inbox_path, Ymlr.document!(envelope)) do
+      :ok ->
+        {:reply, :ok, state}
+
+      {:error, reason} ->
+        Logger.warning("Failed to write interrupt: #{inspect(reason)}")
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:interrupt, _from, state) do
     {:reply, {:error, :not_active}, state}
   end
 

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -54,6 +54,10 @@ defmodule Shire.Agent.Coordinator do
     AgentManager.send_message(project_id, agent_id, text, :user)
   end
 
+  def interrupt_agent(project_id, agent_id) do
+    AgentManager.interrupt(project_id, agent_id)
+  end
+
   @doc "Look up a running agent's pid by ID within a project."
   def lookup(project_id, agent_id) do
     case Registry.lookup(Shire.AgentRegistry, {project_id, agent_id}) do

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -238,6 +238,27 @@ defmodule ShireWeb.AgentLive.Index do
     {:noreply, socket}
   end
 
+  @impl true
+  def handle_event("interrupt-agent", _params, socket) do
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.selected_agent_id
+
+    if agent_id do
+      case Coordinator.interrupt_agent(project_id, agent_id) do
+        :ok ->
+          {:noreply, socket}
+
+        {:error, reason} ->
+          {:noreply, put_flash(socket, :error, "Failed to interrupt: #{inspect(reason)}")}
+      end
+    else
+      {:noreply, socket}
+    end
+  catch
+    :exit, _ ->
+      {:noreply, put_flash(socket, :error, "Agent is not running.")}
+  end
+
   # PubSub handlers (agent-specific topic)
 
   @impl true

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -10,6 +10,7 @@ import {
   processInbox,
   processOutbox,
   writeSystemMessage,
+  tryHandleInterrupt,
   type MessageEnvelope,
 } from "./agent-runner";
 import type { Harness } from "./harness";
@@ -649,5 +650,60 @@ describe("writeSystemMessage()", () => {
     expect(envelope.from).toBe("system");
     expect(typeof envelope.ts).toBe("number");
     expect((envelope.payload as Record<string, unknown>).text).toBe("Something went wrong.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tryHandleInterrupt()
+// ---------------------------------------------------------------------------
+
+describe("tryHandleInterrupt()", () => {
+  const TEST_INTERRUPT_INBOX = "/tmp/test-interrupt-inbox";
+
+  beforeEach(() => {
+    rmSync(TEST_INTERRUPT_INBOX, { recursive: true, force: true });
+    mkdirSync(TEST_INTERRUPT_INBOX, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_INTERRUPT_INBOX, { recursive: true, force: true });
+  });
+
+  test("calls harness.interrupt() and returns true for interrupt envelope", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({ type: "interrupt", payload: {} });
+    const filename = "001-int.yaml";
+    writeFileSync(`${TEST_INTERRUPT_INBOX}/${filename}`, yaml.dump(envelope));
+
+    const events = await captureEmits(async () => {
+      const result = await tryHandleInterrupt(harness, filename, TEST_INTERRUPT_INBOX);
+      expect(result).toBe(true);
+    });
+
+    expect(harness.interrupt).toHaveBeenCalled();
+    expect(events.map((e) => e.type)).toContain("interrupted");
+    expect(existsSync(`${TEST_INTERRUPT_INBOX}/${filename}`)).toBe(false);
+  });
+
+  test("returns false and leaves file for non-interrupt envelope", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({ type: "user_message", payload: { text: "Hi" } });
+    const filename = "002-msg.yaml";
+    writeFileSync(`${TEST_INTERRUPT_INBOX}/${filename}`, yaml.dump(envelope));
+
+    const result = await tryHandleInterrupt(harness, filename, TEST_INTERRUPT_INBOX);
+
+    expect(result).toBe(false);
+    expect(harness.interrupt).not.toHaveBeenCalled();
+    expect(existsSync(`${TEST_INTERRUPT_INBOX}/${filename}`)).toBe(true);
+  });
+
+  test("returns false without crashing for non-existent file", async () => {
+    const harness = createMockHarness();
+
+    const result = await tryHandleInterrupt(harness, "does-not-exist.yaml", TEST_INTERRUPT_INBOX);
+
+    expect(result).toBe(false);
+    expect(harness.interrupt).not.toHaveBeenCalled();
   });
 });

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -103,6 +103,23 @@ export function agentName(): string {
   return peersIdToName.get(id) || id;
 }
 
+export async function tryHandleInterrupt(harness: Harness, filename: string, inboxDir = INBOX_DIR): Promise<boolean> {
+  try {
+    const path = join(inboxDir, filename);
+    const raw = await readFile(path, "utf-8");
+    const envelope = yaml.load(raw) as MessageEnvelope;
+    if (envelope.type === "interrupt") {
+      await harness.interrupt();
+      emit("interrupted", {});
+      await unlink(path);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export async function processMessage(harness: Harness, envelope: MessageEnvelope): Promise<void> {
   if (envelope.type === "user_message" || envelope.type === "agent_message" || envelope.type === "system_message") {
     const text = envelope.payload.text as string;
@@ -264,7 +281,11 @@ async function main() {
 
   // Watch for new inbox messages
   const inboxWatcher = watch(INBOX_DIR, async (_eventType: string, filename: string | null) => {
-    if ((!filename?.endsWith(".yaml") && !filename?.endsWith(".yml")) || processing) return;
+    if (!filename?.endsWith(".yaml") && !filename?.endsWith(".yml")) return;
+    if (processing) {
+      await tryHandleInterrupt(harness, filename);
+      return;
+    }
     processing = true;
     emit("processing", { active: true });
     try {

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -92,6 +92,38 @@ defmodule Shire.Agent.AgentManagerTest do
     end
   end
 
+  describe "interrupt/2" do
+    test "returns error when agent is not active", ctx do
+      {:ok, pid} = start_manager(ctx)
+
+      assert {:error, :not_active} = GenServer.call(pid, :interrupt)
+    end
+
+    test "writes interrupt envelope to inbox when active", ctx do
+      Mox.set_mox_global()
+      test_pid = self()
+
+      expect(Shire.VirtualMachineMock, :write, fn _project, path, content ->
+        send(test_pid, {:write_called, path, content})
+        :ok
+      end)
+
+      {:ok, pid} = start_manager(ctx)
+
+      ref = make_ref()
+
+      :sys.replace_state(pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      assert :ok = GenServer.call(pid, :interrupt)
+
+      assert_receive {:write_called, path, content}, 1_000
+      assert path =~ "/inbox/"
+      assert content =~ "interrupt"
+    end
+  end
+
   describe "responsiveness" do
     test "get_state responds immediately even during non-idle statuses", ctx do
       {:ok, pid} = start_manager(ctx)

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -233,6 +233,20 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentDashboard"
     end
 
+    # --- interrupt-agent ---
+
+    test "interrupt-agent with no selected agent is a no-op", %{
+      conn: conn,
+      project_name: project_name
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}")
+
+      render_hook(view, "interrupt-agent", %{})
+
+      html = render(view)
+      assert html =~ "AgentDashboard"
+    end
+
     test "agent_event for non-selected agent is ignored", %{
       conn: conn,
       project_id: project_id,


### PR DESCRIPTION
## Summary

- **Fixed broken interrupt delivery**: The inbox file watcher in `agent-runner.ts` was ignoring all new files when `processing === true`, making interrupt messages useless. New `tryHandleInterrupt()` function handles interrupt messages out-of-band during active processing.
- **Added backend interrupt API**: `AgentManager.interrupt/2` writes an interrupt envelope to the agent's inbox, exposed via `Coordinator.interrupt_agent/2` and a new `interrupt-agent` LiveView event handler (with exit guard).
- **Added Stop button**: When an agent is busy, the Send button is replaced with a red Stop button that triggers the interrupt flow.

## Test plan

- [x] `tryHandleInterrupt` unit tests: interrupt envelope handled, non-interrupt left in place, missing file handled gracefully
- [x] ChatPanel tests: Stop button visible when busy, sends `interrupt-agent` event, Send button visible when not busy
- [x] AgentManager tests: interrupt writes envelope when active, returns error when not active
- [x] LiveView test: `interrupt-agent` with no selected agent is a no-op
- [x] All verification passes: `mix compile --warnings-as-errors`, `mix format`, `bun tsc`, `bun lint`, `bun format:check`, `bun test` (180 frontend + 62 runtime tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)