### PR TITLE
fix: Pi harness — append system prompt, simplify auth, use abort()

### DIFF
--- a/priv/sprite/harness/pi-harness.test.ts
+++ b/priv/sprite/harness/pi-harness.test.ts
@@ -29,6 +29,7 @@ function createMockSession() {
         subscriber({ type: "agent_end" } as AgentSessionEvent);
       }
     }),
+    abort: mock(async () => {}),
     fireEvent: (event: AgentSessionEvent) => {
       if (subscriber) subscriber(event);
     },
@@ -158,16 +159,12 @@ describe("PiHarness", () => {
     expect(events).toHaveLength(0);
   });
 
-  test("interrupt() resets session", async () => {
+  test("interrupt() calls abort on the session", async () => {
     const harness = new PiHarness();
-    let sessionCount = 0;
-    harness._setSessionFactory(async () => {
-      sessionCount++;
-      return createMockSession();
-    });
+    const mockSession = createMockSession();
+    harness._setSessionFactory(async () => mockSession);
     await harness.start(baseConfig);
-    expect(sessionCount).toBe(1);
     await harness.interrupt();
-    expect(sessionCount).toBe(2);
+    expect(mockSession.abort).toHaveBeenCalledTimes(1);
   });
 });

--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -4,6 +4,7 @@ import type { Harness, HarnessConfig, EventCallback } from "./types";
 export type SessionLike = {
   subscribe: (cb: AgentSessionEventListener) => void;
   prompt: (text: string) => Promise<void>;
+  abort: () => Promise<void>;
 };
 
 type SessionFactory = (config: HarnessConfig) => Promise<SessionLike>;
@@ -41,9 +42,8 @@ export class PiHarness implements Harness {
   }
 
   async interrupt(): Promise<void> {
-    if (!this.config) return;
-    this.session = await this.createSession(this.config);
-    this.subscribeToSession(this.session);
+    if (!this.session) return;
+    await this.session.abort();
   }
 
   async stop(): Promise<void> {
@@ -73,10 +73,7 @@ export class PiHarness implements Harness {
     } = await import("@mariozechner/pi-coding-agent");
     const { getModel } = await import("@mariozechner/pi-ai");
 
-    const authStorage = AuthStorage.create();
-    if (process.env.ANTHROPIC_API_KEY) {
-      authStorage.setRuntimeApiKey("anthropic", process.env.ANTHROPIC_API_KEY);
-    }
+    const authStorage = AuthStorage.inMemory();
     const modelRegistry = new ModelRegistry(authStorage);
     const [provider, modelName] = config.model.split("/");
     const model = getModel(provider, modelName);
@@ -89,7 +86,10 @@ export class PiHarness implements Harness {
     const loader = new DefaultResourceLoader({
       cwd: config.cwd,
       settingsManager,
-      systemPromptOverride: () => config.systemPrompt,
+      systemPromptOverride: (base) => {
+        const parts = [base, config.systemPrompt].filter(Boolean);
+        return parts.length > 0 ? parts.join("\n\n") : undefined;
+      },
     });
     await loader.reload();
 


### PR DESCRIPTION
## Summary
- **systemPromptOverride**: Changed from replacing to appending — recipe `system_prompt` is now concatenated with the base prompt from `AGENTS.md`, preserving comms instructions (peer discovery, outbox format, shared drive)
- **Auth**: Simplified from `AuthStorage.create()` + manual `setRuntimeApiKey` to `AuthStorage.inMemory()` — Pi SDK reads env vars (`ANTHROPIC_API_KEY`, etc.) automatically at priority #4
- **Interrupt**: Uses `session.abort()` instead of recreating the entire session

## Test plan
- [x] All 59 tests pass (`bun test`)
- [x] ESLint clean
- [x] Prettier clean
- [ ] Manual test with Pi harness agent to verify system prompt includes both AGENTS.md and recipe prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)