### PR TITLE
Enable Pi harness in harness selection

### DIFF
--- a/assets/react-components/AgentForm.tsx
+++ b/assets/react-components/AgentForm.tsx
@@ -228,9 +228,7 @@ export default function AgentForm({ open, title, agent, pushEvent, onClose }: Ag
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="claude_code">Claude Code</SelectItem>
-                    <SelectItem value="pi" disabled>
-                      Pi (Coming soon)
-                    </SelectItem>
+                    <SelectItem value="pi">Pi</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/assets/react-components/types.ts
+++ b/assets/react-components/types.ts
@@ -102,6 +102,6 @@ export const harnessLabel = (harness: HarnessType): string => {
     case "claude_code":
       return "Claude Code";
     case "pi":
-      return "Pi (Coming soon)";
+      return "Pi";
   }
 };

--- a/assets/test/AgentShow.test.tsx
+++ b/assets/test/AgentShow.test.tsx
@@ -170,7 +170,7 @@ describe("AgentShow", () => {
         pushEvent={vi.fn()}
       />,
     );
-    expect(screen.getByText("Pi (Coming soon)")).toBeInTheDocument();
+    expect(screen.getByText("Pi")).toBeInTheDocument();
   });
 
   it("shows Edit button and opens edit form dialog", async () => {


### PR DESCRIPTION
## Summary
- Remove `disabled` prop and "Coming soon" label from the Pi harness option in the agent creation/edit form
- Update `harnessLabel` helper to return "Pi" instead of "Pi (Coming soon)"
- Update test assertion to match the new label

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Prettier passes
- [x] All 180 Vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)