### PR TITLE
fix: E2B runtime errors — multipart uploads, cmd arg passing

### DIFF
--- a/lib/shire/virtual_machine_e2b.ex
+++ b/lib/shire/virtual_machine_e2b.ex
@@ -226,14 +226,15 @@ defmodule Shire.VirtualMachineE2B do
     cwd = Keyword.get(opts, :dir, @workspace_root)
     env = build_env(Keyword.get(opts, :env))
 
-    full_cmd = Enum.join([command | args], " ")
-
     result =
       try do
-        run_cmd_sync(state.sandbox_id, state.access_token, full_cmd, cwd, env, timeout)
+        run_cmd_sync(state.sandbox_id, state.access_token, command, args, cwd, env, timeout)
       rescue
         e ->
-          Logger.error("E2B cmd exception: #{full_cmd} — #{Exception.message(e)}")
+          Logger.error(
+            "E2B cmd exception: #{command} #{Enum.join(args, " ")} — #{Exception.message(e)}"
+          )
+
           {:error, e}
       end
 
@@ -319,7 +320,7 @@ defmodule Shire.VirtualMachineE2B do
   def handle_call({:rm_rf, path}, _from, state) do
     result =
       try do
-        run_cmd_sync(state.sandbox_id, state.access_token, "rm -rf #{path}", "/", %{}, 30_000)
+        run_cmd_sync(state.sandbox_id, state.access_token, "rm", ["-rf", path], "/", %{}, 30_000)
         |> case do
           {:ok, _} -> :ok
           {:error, {:exit, _code, _output}} = err -> err
@@ -509,7 +510,7 @@ defmodule Shire.VirtualMachineE2B do
 
   # --- Private: Synchronous Command Execution ---
 
-  defp run_cmd_sync(sandbox_id, access_token, full_cmd, cwd, env, timeout) do
+  defp run_cmd_sync(sandbox_id, access_token, cmd, args, cwd, env, timeout) do
     opts = [
       cwd: cwd,
       envs: env,
@@ -519,7 +520,7 @@ defmodule Shire.VirtualMachineE2B do
     ]
 
     {:ok, %{ref: stream_ref, pid: handler_pid}} =
-      StreamHandler.start_link(sandbox_id, access_token, "/bin/bash", ["-c", full_cmd], opts)
+      StreamHandler.start_link(sandbox_id, access_token, cmd, args, opts)
 
     collect_cmd_output(stream_ref, handler_pid, "", timeout)
   end
@@ -537,7 +538,17 @@ defmodule Shire.VirtualMachineE2B do
     after
       timeout ->
         Process.exit(handler_pid, :kill)
+        flush_ref(ref)
         {:error, :timeout}
+    end
+  end
+
+  defp flush_ref(ref) do
+    receive do
+      {:stdout, %{ref: ^ref}, _} -> flush_ref(ref)
+      {:exit, %{ref: ^ref}, _} -> flush_ref(ref)
+    after
+      0 -> :ok
     end
   end
 

--- a/lib/shire/virtual_machine_e2b/client.ex
+++ b/lib/shire/virtual_machine_e2b/client.ex
@@ -13,8 +13,7 @@ defmodule Shire.VirtualMachineE2B.Client do
   def management_req(api_key) do
     Req.new(
       base_url: @management_base_url,
-      headers: [{"x-api-key", api_key}],
-      json: true
+      headers: [{"x-api-key", api_key}]
     )
   end
 
@@ -131,12 +130,23 @@ defmodule Shire.VirtualMachineE2B.Client do
 
   def write_file(sandbox_id, access_token, path, content) do
     req = sandbox_req(sandbox_id, access_token)
+    boundary = "----E2BUpload" <> Base.encode16(:crypto.strong_rand_bytes(16))
+    filename = path |> Path.basename() |> String.replace(~S["], ~S[\"])
+
+    body =
+      "--#{boundary}\r\n" <>
+        "Content-Disposition: form-data; name=\"file\"; filename=\"#{filename}\"\r\n" <>
+        "Content-Type: application/octet-stream\r\n" <>
+        "\r\n" <>
+        content <>
+        "\r\n" <>
+        "--#{boundary}--\r\n"
 
     case Req.post(req,
            url: "/files",
            params: [path: path],
-           headers: [{"content-type", "application/octet-stream"}],
-           body: content
+           headers: [{"content-type", "multipart/form-data; boundary=#{boundary}"}],
+           body: body
          ) do
       {:ok, %Req.Response{status: status}} when status in [200, 204] ->
         :ok


### PR DESCRIPTION
## Summary
- **write_file**: Use `multipart/form-data` with cryptographically random boundary instead of `application/octet-stream` (E2B `/files` endpoint requires multipart)
- **cmd**: Pass `command` and `args` directly to E2B process API instead of joining into a string and wrapping in `bash -c` (fixes bootstrap script failure from double-wrapping)
- **rm_rf**: Pass args as list `["−rf", path]` instead of interpolated string
- **management_req**: Remove invalid `json: true` Req option (likely caused 400 on `GET /sandboxes`)
- **collect_cmd_output**: Flush ref-tagged messages from mailbox after timeout kill to prevent unbounded mailbox growth

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] All 312 tests pass
- [ ] Manual test: set `SHIRE_VM_TYPE=e2b`, verify sandbox creation, bootstrap, and file writes succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)