### PR TITLE
fix: switch E2B RPC from Connect protocol to plain JSON

### DIFF
--- a/lib/shire/virtual_machine_e2b/client.ex
+++ b/lib/shire/virtual_machine_e2b/client.ex
@@ -160,17 +160,17 @@ defmodule Shire.VirtualMachineE2B.Client do
   end
 
   def mkdir_p(sandbox_id, access_token, path) do
-    connect_post(sandbox_id, access_token, "/filesystem.Filesystem/MakeDir", %{"path" => path})
+    json_post(sandbox_id, access_token, "/filesystem.Filesystem/MakeDir", %{"path" => path})
     |> normalize_ok_response()
   end
 
   def remove(sandbox_id, access_token, path) do
-    connect_post(sandbox_id, access_token, "/filesystem.Filesystem/Remove", %{"path" => path})
+    json_post(sandbox_id, access_token, "/filesystem.Filesystem/Remove", %{"path" => path})
     |> normalize_ok_response()
   end
 
   def list_dir(sandbox_id, access_token, path) do
-    case connect_post(sandbox_id, access_token, "/filesystem.Filesystem/ListDir", %{
+    case json_post(sandbox_id, access_token, "/filesystem.Filesystem/ListDir", %{
            "path" => path,
            "depth" => 1
          }) do
@@ -186,7 +186,7 @@ defmodule Shire.VirtualMachineE2B.Client do
   end
 
   def stat_path(sandbox_id, access_token, path) do
-    connect_post(sandbox_id, access_token, "/filesystem.Filesystem/Stat", %{"path" => path})
+    json_post(sandbox_id, access_token, "/filesystem.Filesystem/Stat", %{"path" => path})
   end
 
   # --- Sandbox Process API ---
@@ -219,7 +219,9 @@ defmodule Shire.VirtualMachineE2B.Client do
     req =
       sandbox_req(sandbox_id, access_token)
       |> Req.merge(
-        headers: connect_headers(),
+        headers: [
+          {"content-type", "application/json"}
+        ],
         url: "/process.Process/Start",
         method: :post,
         body: Jason.encode!(body),
@@ -245,7 +247,7 @@ defmodule Shire.VirtualMachineE2B.Client do
       "input" => input
     }
 
-    connect_post(sandbox_id, access_token, "/process.Process/SendInput", body)
+    json_post(sandbox_id, access_token, "/process.Process/SendInput", body)
     |> normalize_ok_response()
   end
 
@@ -255,30 +257,16 @@ defmodule Shire.VirtualMachineE2B.Client do
       "pty" => %{"size" => %{"cols" => cols, "rows" => rows}}
     }
 
-    connect_post(sandbox_id, access_token, "/process.Process/Update", body)
+    json_post(sandbox_id, access_token, "/process.Process/Update", body)
     |> normalize_ok_response()
   end
 
-  # --- Connect Protocol Helpers ---
+  # --- JSON RPC Helpers ---
 
-  defp connect_headers do
-    [
-      {"connect-protocol-version", "1"},
-      {"content-type", "application/connect+json"}
-    ]
-  end
-
-  defp connect_post(sandbox_id, access_token, path, body) do
+  defp json_post(sandbox_id, access_token, path, body) do
     req = sandbox_req(sandbox_id, access_token)
 
-    case Req.post(req,
-           url: path,
-           headers: connect_headers(),
-           body: Jason.encode!(body)
-         ) do
-      {:ok, %Req.Response{status: 200, body: body}} when is_binary(body) ->
-        Jason.decode(body)
-
+    case Req.post(req, url: path, json: body) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         {:ok, body}
 
@@ -291,7 +279,6 @@ defmodule Shire.VirtualMachineE2B.Client do
   end
 
   defp normalize_ok_response({:ok, _}), do: :ok
-  defp normalize_ok_response(:ok), do: :ok
   defp normalize_ok_response({:error, _} = err), do: err
 
   defp sandbox_base_url(sandbox_id) do


### PR DESCRIPTION
## Summary
- Switch all E2B RPC calls (filesystem + process) from `application/connect+json` to `application/json` via Req's `json` option
- E2B's envd server returns **415 Unsupported Media Type** for `application/connect+json` on filesystem endpoints (`mkdir_p`, `remove`, `list_dir`, `stat`)
- Remove unused `connect_headers/0` and `connect_post/4` helpers
- Remove unreachable `normalize_ok_response(:ok)` clause

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] All 312 tests pass
- [ ] Manual: verify `mkdir_p`, file writes, and process execution work on E2B sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)