### PR TITLE
debug: add E2B stream handler logging for process failures

### DIFF
--- a/lib/shire/virtual_machine_e2b/stream_handler.ex
+++ b/lib/shire/virtual_machine_e2b/stream_handler.ex
@@ -105,6 +105,8 @@ defmodule Shire.VirtualMachineE2B.StreamHandler do
   end
 
   defp handle_stream_data(data, caller, ref, current_pid, got_exit) when is_binary(data) do
+    Logger.debug("E2B raw stream: #{inspect(String.slice(data, 0, 500))}")
+
     data
     |> String.split("\n", trim: true)
     |> Enum.reduce({current_pid, got_exit}, fn line, {pid, exited} ->
@@ -121,7 +123,12 @@ defmodule Shire.VirtualMachineE2B.StreamHandler do
           send(caller, {:exit, %{ref: ref}, 1})
           {pid, true}
 
-        _ ->
+        {:ok, other} ->
+          Logger.debug("E2B unhandled JSON: #{inspect(other)}")
+          {pid, exited}
+
+        {:error, _} ->
+          Logger.debug("E2B non-JSON line: #{inspect(line)}")
           {pid, exited}
       end
     end)
@@ -159,5 +166,8 @@ defmodule Shire.VirtualMachineE2B.StreamHandler do
     :exit
   end
 
-  defp handle_event(_event, _caller, _ref), do: :ok
+  defp handle_event(event, _caller, _ref) do
+    Logger.debug("E2B unhandled event: #{inspect(event)}")
+    :ok
+  end
 end


### PR DESCRIPTION
## Summary
- Add debug logging to E2B `StreamHandler` to diagnose why bootstrap and runner deployment fail with `{:exit, 1, ""}` (empty output)
- Logs raw stream data (first 500 chars), unhandled JSON responses, and unrecognized events
- This will reveal whether E2B's response format changed after switching from Connect protocol to plain JSON

## Context
Bootstrap and runner deployment consistently fail with exit code 1 and empty output. Without seeing the actual stream data from E2B, we can't determine if:
- The response format differs from what we pattern-match
- The process genuinely fails (e.g., bash not found on base image)
- Events are being silently dropped by catch-all clauses

🤖 Generated with [Claude Code](https://claude.com/claude-code)