### PR TITLE
Move bootstrap and runner deployment into VM init

### DIFF
--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -105,17 +105,6 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_continue(:deploy_and_scan, state) do
-    case Shire.WorkspaceSettings.bootstrap_workspace(state.project_id) do
-      :ok -> :ok
-      {:error, reason} -> Logger.error("Bootstrap failed: #{inspect(reason)}")
-    end
-
-    case deploy_runner(state.project_id) do
-      :ok -> :ok
-      {:error, reason} -> Logger.error("Runner deployment failed: #{inspect(reason)}")
-    end
-
-    # Write peers.yaml before starting any agents
     write_peers_yaml(state.project_id)
 
     # Get agents from DB and start managers for those with folders on VM
@@ -480,44 +469,6 @@ defmodule Shire.Agent.Coordinator do
   end
 
   # --- Private ---
-
-  defp deploy_runner(project_id) do
-    source_dir = Application.app_dir(:shire, "priv/sprite")
-    ws_runner_dir = Workspace.runner_dir(project_id)
-
-    content = File.read!(Path.join(source_dir, "agent-runner.ts"))
-
-    with :ok <- vm().write(project_id, Path.join(ws_runner_dir, "agent-runner.ts"), content),
-         :ok <- deploy_harness(project_id, source_dir),
-         {:ok, _} <-
-           vm().cmd(project_id, "bash", ["-c", "cd #{ws_runner_dir} && bun install"],
-             timeout: 120_000
-           ) do
-      :ok
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp deploy_harness(project_id, source_dir) do
-    harness_dir = Path.join(source_dir, "harness")
-    ws_harness_dir = Path.join(Workspace.runner_dir(project_id), "harness")
-
-    if File.dir?(harness_dir) do
-      with :ok <- vm().mkdir_p(project_id, ws_harness_dir) do
-        Enum.reduce_while(File.ls!(harness_dir), :ok, fn file, :ok ->
-          content = File.read!(Path.join(harness_dir, file))
-
-          case vm().write(project_id, Path.join(ws_harness_dir, file), content) do
-            :ok -> {:cont, :ok}
-            {:error, reason} -> {:halt, {:error, reason}}
-          end
-        end)
-      end
-    else
-      :ok
-    end
-  end
 
   defp read_agent_recipe(project_id, agent_id) do
     path = Path.join(Workspace.agent_dir(project_id, agent_id), "recipe.yaml")

--- a/lib/shire/virtual_machine/setup.ex
+++ b/lib/shire/virtual_machine/setup.ex
@@ -1,0 +1,96 @@
+defmodule Shire.VirtualMachine.Setup do
+  @moduledoc """
+  Shared VM setup logic: deploys runner files and runs bootstrap.sh.
+
+  Called from VM init callbacks (before the GenServer is registered),
+  so all operations go through closure-based `ops` rather than the
+  GenServer API.
+
+  ## ops map
+
+      %{
+        write: fn path, content -> :ok | {:error, reason} end,
+        mkdir_p: fn path -> :ok | {:error, reason} end,
+        cmd: fn command, args, opts -> {:ok, output} | {:error, reason} end,
+        runner_dir: String.t(),
+        workspace_root: String.t()
+      }
+  """
+
+  require Logger
+
+  @top_level_files ["agent-runner.ts", "package.json", "bun.lock"]
+
+  @doc "Deploys runner files and runs bootstrap.sh."
+  def run(ops) do
+    with :ok <- deploy_runner_files(ops),
+         :ok <- run_bootstrap(ops) do
+      :ok
+    end
+  end
+
+  @doc "Deploys agent-runner.ts, package.json, bun.lock, and harness files to the runner dir."
+  def deploy_runner_files(ops) do
+    source_dir = Application.app_dir(:shire, "priv/sprite")
+    runner_dir = ops.runner_dir
+
+    with :ok <- ops.mkdir_p.(runner_dir),
+         :ok <- deploy_files(ops, source_dir, runner_dir, @top_level_files),
+         :ok <- deploy_harness_files(ops, source_dir, runner_dir) do
+      :ok
+    end
+  end
+
+  @doc "Reads bootstrap.sh from priv and executes it on the VM."
+  def run_bootstrap(ops) do
+    case File.read(Application.app_dir(:shire, "priv/sprite/bootstrap.sh")) do
+      {:ok, script} ->
+        case ops.cmd.("bash", ["-c", script, "bash", ops.workspace_root], timeout: 300_000) do
+          {:ok, _output} -> :ok
+          {:error, _reason} = error -> error
+        end
+
+      {:error, reason} ->
+        {:error, {:read_bootstrap, reason}}
+    end
+  end
+
+  defp deploy_files(ops, source_dir, target_dir, files) do
+    Enum.reduce_while(files, :ok, fn file, :ok ->
+      case File.read(Path.join(source_dir, file)) do
+        {:ok, content} ->
+          case ops.write.(Path.join(target_dir, file), content) do
+            :ok -> {:cont, :ok}
+            {:error, _} = error -> {:halt, error}
+          end
+
+        {:error, reason} ->
+          {:halt, {:error, {:read_source, file, reason}}}
+      end
+    end)
+  end
+
+  defp deploy_harness_files(ops, source_dir, runner_dir) do
+    harness_source = Path.join(source_dir, "harness")
+    harness_target = Path.join(runner_dir, "harness")
+
+    if File.dir?(harness_source) do
+      case File.ls(harness_source) do
+        {:ok, entries} ->
+          files =
+            Enum.filter(entries, fn f ->
+              String.ends_with?(f, ".ts") and not String.ends_with?(f, ".test.ts")
+            end)
+
+          with :ok <- ops.mkdir_p.(harness_target) do
+            deploy_files(ops, harness_source, harness_target, files)
+          end
+
+        {:error, reason} ->
+          {:error, {:ls_harness, reason}}
+      end
+    else
+      :ok
+    end
+  end
+end

--- a/lib/shire/virtual_machine_local.ex
+++ b/lib/shire/virtual_machine_local.ex
@@ -245,7 +245,10 @@ defmodule Shire.VirtualMachineLocal do
 
     File.mkdir_p!(root)
 
-    bootstrap_workspace(root)
+    case Shire.VirtualMachine.Setup.run(build_setup_ops(root)) do
+      :ok -> :ok
+      {:error, reason} -> Logger.error("Local VM setup failed: #{inspect(reason)}")
+    end
 
     Logger.info("Local VM ready for project #{project_id} at #{root}")
     update_registry_status(project_id, :running)
@@ -326,20 +329,40 @@ defmodule Shire.VirtualMachineLocal do
     end
   end
 
-  defp bootstrap_workspace(root) do
-    for dir <- [".runner", ".scripts", "shared", "agents"] do
-      File.mkdir_p!(Path.join(root, dir))
-    end
+  defp build_setup_ops(root) do
+    %{
+      write: fn path, content ->
+        File.mkdir_p!(Path.dirname(path))
 
-    project_md = Path.join(root, "PROJECT.md")
+        case File.write(path, content) do
+          :ok -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+      end,
+      mkdir_p: fn path ->
+        case File.mkdir_p(path) do
+          :ok -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+      end,
+      cmd: fn command, args, opts ->
+        timeout = Keyword.get(opts, :timeout, 30_000)
+        cmd_path = System.find_executable(command) || command
 
-    unless File.exists?(project_md) do
-      File.write!(project_md, """
-      # Project
+        task =
+          Task.async(fn ->
+            System.cmd(cmd_path, args, stderr_to_stdout: true, cd: root)
+          end)
 
-      Describe your project here. All agents will check this document for context before starting tasks and update it after completing work.
-      """)
-    end
+        case Task.yield(task, timeout) || Task.shutdown(task) do
+          {:ok, {output, 0}} -> {:ok, output}
+          {:ok, {output, code}} -> {:error, {:exit, code, output}}
+          nil -> {:error, :timeout}
+        end
+      end,
+      runner_dir: Path.join(root, ".runner"),
+      workspace_root: root
+    }
   end
 
   defp shell_escape(arg) do

--- a/lib/shire/virtual_machine_sprite.ex
+++ b/lib/shire/virtual_machine_sprite.ex
@@ -184,6 +184,12 @@ defmodule Shire.VirtualMachineSprite do
       case init_vm(token, vm_name) do
         {:ok, sprite, fs} ->
           Logger.info("VM #{vm_name} ready (project: #{project_id})")
+
+          case Shire.VirtualMachine.Setup.run(build_setup_ops(sprite, fs)) do
+            :ok -> :ok
+            {:error, reason} -> Logger.error("VM setup failed: #{inspect(reason)}")
+          end
+
           update_registry_status(project_id, :running)
 
           {:ok,
@@ -550,6 +556,43 @@ defmodule Shire.VirtualMachineSprite do
         state
       end
     end
+  end
+
+  defp build_setup_ops(sprite, fs) do
+    ws_root = "/workspace"
+
+    %{
+      write: fn path, content ->
+        try do
+          Sprites.Filesystem.write!(fs, path, content)
+          :ok
+        rescue
+          e -> {:error, e}
+        end
+      end,
+      mkdir_p: fn path ->
+        try do
+          Sprites.Filesystem.mkdir_p!(fs, path)
+          :ok
+        rescue
+          e -> {:error, e}
+        end
+      end,
+      cmd: fn command, args, opts ->
+        timeout = Keyword.get(opts, :timeout, @default_cmd_timeout)
+
+        try do
+          case Sprites.cmd(sprite, command, args, timeout: timeout) do
+            {output, 0} -> {:ok, output}
+            {output, code} -> {:error, {:exit, code, output}}
+          end
+        rescue
+          e -> {:error, e}
+        end
+      end,
+      runner_dir: Path.join(ws_root, ".runner"),
+      workspace_root: ws_root
+    }
   end
 
   defp update_registry_status(project_id, status) do

--- a/lib/shire/workspace_settings.ex
+++ b/lib/shire/workspace_settings.ex
@@ -124,18 +124,5 @@ defmodule Shire.WorkspaceSettings do
     end
   end
 
-  # --- Bootstrap ---
-
-  @doc "Runs the bootstrap script to initialize workspace directories on the VM."
-  def bootstrap_workspace(project_id) do
-    script = File.read!(Application.app_dir(:shire, "priv/sprite/bootstrap.sh"))
-    root = Workspace.root(project_id)
-
-    case vm().cmd(project_id, "bash", ["-c", script, "bash", root], timeout: 300_000) do
-      {:ok, _} -> :ok
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
   defp vm, do: Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)
 end

--- a/priv/sprite/bootstrap.sh
+++ b/priv/sprite/bootstrap.sh
@@ -52,4 +52,10 @@ Describe your project here. All agents will check this document for context befo
 PROJECTMD
 fi
 
+# --- Install runner dependencies ---
+if [ -f "$WORKSPACE_ROOT/.runner/package.json" ]; then
+  echo "Installing runner dependencies..."
+  cd "$WORKSPACE_ROOT/.runner" && bun install
+fi
+
 echo "Bootstrap complete"

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -104,6 +104,7 @@ defmodule Shire.ProjectManagerTest do
   describe "destroy_project/1" do
     test "removes a project from the list" do
       {:ok, project} = ProjectManager.create_project("destroy-me")
+      wait_for_coordinator(project.id)
       assert :ok = ProjectManager.destroy_project(project.id)
       assert ProjectManager.list_projects() == []
     end
@@ -115,6 +116,7 @@ defmodule Shire.ProjectManagerTest do
 
     test "broadcasts {:project_destroyed, project_id} via PubSub" do
       {:ok, project} = ProjectManager.create_project("destroy-broadcast")
+      wait_for_coordinator(project.id)
 
       Phoenix.PubSub.subscribe(Shire.PubSub, "projects:lobby")
 
@@ -288,8 +290,29 @@ defmodule Shire.ProjectManagerTest do
     end
   end
 
+  # Waits for the Coordinator's handle_continue to finish so it doesn't
+  # hold a DB connection when we terminate the subtree.
+  defp wait_for_coordinator(project_id, retries \\ 10) do
+    case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project_id}) do
+      [{pid, _}] ->
+        :sys.get_state(pid, 5_000)
+        :ok
+
+      [] when retries > 0 ->
+        Process.sleep(10)
+        wait_for_coordinator(project_id, retries - 1)
+
+      [] ->
+        :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
   # Terminates the project supervisor cleanly and waits for registry cleanup
   defp kill_project_supervisor(project_id) do
+    wait_for_coordinator(project_id)
+
     projects_state = :sys.get_state(ProjectManager)
     sup_pid = Map.get(projects_state.projects, project_id)
 

--- a/test/shire/virtual_machine/setup_test.exs
+++ b/test/shire/virtual_machine/setup_test.exs
@@ -1,0 +1,97 @@
+defmodule Shire.VirtualMachine.SetupTest do
+  use ExUnit.Case, async: true
+
+  alias Shire.VirtualMachine.Setup
+
+  setup do
+    # Track all calls made through ops closures
+    test_pid = self()
+
+    ops = %{
+      write: fn path, content ->
+        send(test_pid, {:write, path, content})
+        :ok
+      end,
+      mkdir_p: fn path ->
+        send(test_pid, {:mkdir_p, path})
+        :ok
+      end,
+      cmd: fn command, args, opts ->
+        send(test_pid, {:cmd, command, args, opts})
+        {:ok, ""}
+      end,
+      runner_dir: "/workspace/.runner",
+      workspace_root: "/workspace"
+    }
+
+    %{ops: ops}
+  end
+
+  describe "deploy_runner_files/1" do
+    test "deploys agent-runner.ts, package.json, and bun.lock to runner dir", %{ops: ops} do
+      assert :ok = Setup.deploy_runner_files(ops)
+
+      assert_received {:mkdir_p, "/workspace/.runner"}
+      assert_received {:write, "/workspace/.runner/agent-runner.ts", content}
+      assert is_binary(content) and byte_size(content) > 0
+
+      assert_received {:write, "/workspace/.runner/package.json", pkg}
+      assert is_binary(pkg) and byte_size(pkg) > 0
+
+      assert_received {:write, "/workspace/.runner/bun.lock", lock}
+      assert is_binary(lock) and byte_size(lock) > 0
+    end
+
+    test "deploys harness files excluding test files", %{ops: ops} do
+      assert :ok = Setup.deploy_runner_files(ops)
+
+      assert_received {:mkdir_p, "/workspace/.runner/harness"}
+
+      # Should deploy production harness files
+      assert_received {:write, "/workspace/.runner/harness/index.ts", _}
+      assert_received {:write, "/workspace/.runner/harness/types.ts", _}
+      assert_received {:write, "/workspace/.runner/harness/claude-code-harness.ts", _}
+      assert_received {:write, "/workspace/.runner/harness/pi-harness.ts", _}
+
+      # Should NOT deploy test files
+      refute_received {:write, "/workspace/.runner/harness/claude-code-harness.test.ts", _}
+      refute_received {:write, "/workspace/.runner/harness/pi-harness.test.ts", _}
+    end
+  end
+
+  describe "run_bootstrap/1" do
+    test "reads and executes bootstrap.sh with workspace root arg", %{ops: ops} do
+      assert :ok = Setup.run_bootstrap(ops)
+
+      assert_received {:cmd, "bash", ["-c", script, "bash", "/workspace"], opts}
+      assert is_binary(script)
+      assert String.contains?(script, "WORKSPACE_ROOT")
+      assert Keyword.get(opts, :timeout) == 300_000
+    end
+  end
+
+  describe "run/1" do
+    test "deploys runner files then runs bootstrap", %{ops: ops} do
+      assert :ok = Setup.run(ops)
+
+      # Verify runner files were deployed
+      assert_received {:mkdir_p, "/workspace/.runner"}
+      assert_received {:write, "/workspace/.runner/agent-runner.ts", _}
+
+      # Verify bootstrap was run
+      assert_received {:cmd, "bash", ["-c", _, "bash", "/workspace"], _}
+    end
+
+    test "returns error if deploy_runner_files fails", %{ops: ops} do
+      failing_ops = %{ops | mkdir_p: fn _path -> {:error, :eacces} end}
+
+      assert {:error, :eacces} = Setup.run(failing_ops)
+    end
+
+    test "returns error if bootstrap fails", %{ops: ops} do
+      failing_ops = %{ops | cmd: fn _cmd, _args, _opts -> {:error, {:exit, 1, "failed"}} end}
+
+      assert {:error, {:exit, 1, "failed"}} = Setup.run(failing_ops)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Move bootstrap.sh execution and runner file deployment from Coordinator's `handle_continue` into VM `init`, so the `:starting` status accurately reflects full setup time
- Create shared `VirtualMachine.Setup` module with closure-based ops that works during GenServer init (before registration)
- Move runner to top-level `.runner/` dir with `bun install` in `bootstrap.sh` — shared across all agents, no per-agent reinstall
- Also deploys `package.json` and `bun.lock` (previously missing from runner deployment)

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] All 301 tests pass (`mix test`)
- [x] New `VirtualMachine.SetupTest` covers deploy and bootstrap with mock ops
- [x] Fixed race condition in `ProjectManagerTest` with `wait_for_coordinator`
- [ ] Manual: start project with `SHIRE_VM_TYPE=local`, verify `:starting` during bootstrap → `:running` after

🤖 Generated with [Claude Code](https://claude.com/claude-code)