### PR TITLE
Add predictive local echo to terminal

### DIFF
--- a/assets/react-components/Terminal.tsx
+++ b/assets/react-components/Terminal.tsx
@@ -8,6 +8,106 @@ interface TerminalProps {
   pushEvent: (event: string, payload: Record<string, unknown>) => void;
 }
 
+function isPrintable(data: string): boolean {
+  if (data.length !== 1) return false;
+  const code = data.charCodeAt(0);
+  return code >= 0x20 && code <= 0x7e;
+}
+
+/**
+ * Predictive local echo for reducing perceived keystroke latency.
+ * Displays typed printable characters immediately in dim style,
+ * then confirms or rolls back when the server responds.
+ */
+export class LocalEchoPredictor {
+  private pending = "";
+  private term: XTerm;
+  private resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(term: XTerm) {
+    this.term = term;
+  }
+
+  predict(data: string): void {
+    if (!isPrintable(data)) {
+      this.clearPredictions();
+      return;
+    }
+
+    this.term.write(`\x1b[2m${data}\x1b[22m`);
+    this.pending += data;
+    this.scheduleReset();
+  }
+
+  handleOutput(data: Uint8Array): void {
+    if (this.pending.length === 0) {
+      this.term.write(data);
+      return;
+    }
+
+    const text = new TextDecoder().decode(data);
+    let matched = 0;
+
+    for (let i = 0; i < text.length && matched < this.pending.length; i++) {
+      if (text[i] === this.pending[matched]) {
+        matched++;
+      } else {
+        break;
+      }
+    }
+
+    if (matched > 0) {
+      // Move cursor back over all dim predicted chars, write full server output,
+      // then re-draw any remaining unconfirmed predictions
+      const totalDim = this.pending.length;
+      this.term.write(`\x1b[${totalDim}D`);
+      this.pending = this.pending.slice(matched);
+      this.term.write(data);
+
+      if (this.pending.length > 0) {
+        this.term.write(`\x1b[2m${this.pending}\x1b[22m`);
+        this.scheduleReset();
+      } else {
+        this.cancelReset();
+      }
+    } else {
+      // Mismatch — erase all dim predictions and write server output
+      this.clearPredictions();
+      this.term.write(data);
+    }
+  }
+
+  clearPredictions(): void {
+    if (this.pending.length > 0) {
+      this.term.write(`\x1b[${this.pending.length}D\x1b[0K`);
+      this.pending = "";
+    }
+    this.cancelReset();
+  }
+
+  get pendingCount(): number {
+    return this.pending.length;
+  }
+
+  dispose(): void {
+    this.cancelReset();
+  }
+
+  private scheduleReset(): void {
+    this.cancelReset();
+    this.resetTimer = setTimeout(() => {
+      this.clearPredictions();
+    }, 1000);
+  }
+
+  private cancelReset(): void {
+    if (this.resetTimer !== null) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+    }
+  }
+}
+
 export default function Terminal({ pushEvent }: TerminalProps) {
   const { handleEvent, removeHandleEvent } = useLiveReact();
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -37,16 +137,19 @@ export default function Terminal({ pushEvent }: TerminalProps) {
     termRef.current = term;
     fitAddonRef.current = fitAddon;
 
-    // Send keystrokes to server
+    const predictor = new LocalEchoPredictor(term);
+
+    // Send keystrokes to server with local echo prediction
     const dataDisposable = term.onData((data) => {
+      predictor.predict(data);
       pushEvent("terminal-input", { data });
     });
 
-    // Receive output from server
+    // Receive output from server — route through predictor
     const outputRef = handleEvent("terminal-output", (payload: Record<string, unknown>) => {
       const data = payload.data as string;
       const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
-      term.write(bytes);
+      predictor.handleOutput(bytes);
     });
 
     // Handle terminal exit
@@ -74,6 +177,7 @@ export default function Terminal({ pushEvent }: TerminalProps) {
     return () => {
       clearTimeout(resizeTimeout);
       observer.disconnect();
+      predictor.dispose();
       dataDisposable.dispose();
       removeHandleEvent(outputRef);
       removeHandleEvent(exitRef);

--- a/assets/test/Terminal.test.tsx
+++ b/assets/test/Terminal.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Override the global useLiveReact mock with test-local fns we can inspect
 const mockHandleEvent = vi.fn().mockReturnValue("ref-id");
@@ -50,7 +50,8 @@ vi.mock("@xterm/addon-fit", () => {
   return { FitAddon: MockFitAddon };
 });
 
-import Terminal from "../react-components/Terminal";
+import Terminal, { LocalEchoPredictor } from "../react-components/Terminal";
+import { Terminal as XTerm } from "@xterm/xterm";
 
 describe("Terminal", () => {
   const pushEvent = vi.fn();
@@ -87,8 +88,24 @@ describe("Terminal", () => {
   it("forwards terminal input via pushEvent", () => {
     render(<Terminal pushEvent={pushEvent} />);
     const onDataCallback = mockOnData.mock.calls[0][0];
-    onDataCallback("hello");
-    expect(pushEvent).toHaveBeenCalledWith("terminal-input", { data: "hello" });
+    onDataCallback("a");
+    expect(pushEvent).toHaveBeenCalledWith("terminal-input", { data: "a" });
+  });
+
+  it("writes printable input in dim style for local echo", () => {
+    render(<Terminal pushEvent={pushEvent} />);
+    const onDataCallback = mockOnData.mock.calls[0][0];
+    onDataCallback("a");
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[2ma\x1b[22m");
+  });
+
+  it("does not predict control characters", () => {
+    render(<Terminal pushEvent={pushEvent} />);
+    const onDataCallback = mockOnData.mock.calls[0][0];
+    mockWrite.mockClear();
+    onDataCallback("\x03"); // Ctrl+C
+    // Should not write dim prediction (only pushEvent)
+    expect(mockWrite).not.toHaveBeenCalledWith(expect.stringContaining("\x1b[2m"));
   });
 
   it("shows reconnect button on terminal exit", () => {
@@ -109,5 +126,125 @@ describe("Terminal", () => {
     await userEvent.click(screen.getByText("Reconnect"));
     const connectCalls = pushEvent.mock.calls.filter((call: unknown[]) => call[0] === "connect-terminal");
     expect(connectCalls).toHaveLength(2);
+  });
+});
+
+describe("LocalEchoPredictor", () => {
+  let term: XTerm;
+  let predictor: LocalEchoPredictor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    term = new XTerm();
+    predictor = new LocalEchoPredictor(term);
+  });
+
+  afterEach(() => {
+    predictor.dispose();
+    vi.useRealTimers();
+  });
+
+  it("writes printable characters in dim style", () => {
+    predictor.predict("a");
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[2ma\x1b[22m");
+    expect(predictor.pendingCount).toBe(1);
+  });
+
+  it("does not predict non-printable characters", () => {
+    predictor.predict("\r"); // Enter
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(predictor.pendingCount).toBe(0);
+  });
+
+  it("does not predict multi-char data (escape sequences)", () => {
+    predictor.predict("\x1b[A"); // Arrow up
+    expect(predictor.pendingCount).toBe(0);
+  });
+
+  it("clears predictions when non-printable input arrives", () => {
+    predictor.predict("a");
+    predictor.predict("b");
+    mockWrite.mockClear();
+
+    predictor.predict("\t"); // Tab
+    // Should erase 2 dim chars: move back 2 + clear to EOL
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[2D\x1b[0K");
+    expect(predictor.pendingCount).toBe(0);
+  });
+
+  it("confirms predictions on matching server output", () => {
+    predictor.predict("a");
+    mockWrite.mockClear();
+
+    const output = new TextEncoder().encode("a");
+    predictor.handleOutput(output);
+
+    // Should move cursor back over dim char, then write server output
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[1D");
+    expect(mockWrite).toHaveBeenCalledWith(output);
+    expect(predictor.pendingCount).toBe(0);
+  });
+
+  it("confirms partial predictions and re-draws remaining", () => {
+    predictor.predict("a");
+    predictor.predict("b");
+    predictor.predict("c");
+    mockWrite.mockClear();
+
+    const output = new TextEncoder().encode("a");
+    predictor.handleOutput(output);
+
+    // Move back 3 (total dim), write server "a", re-draw "bc" dim
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[3D");
+    expect(mockWrite).toHaveBeenCalledWith(output);
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[2mbc\x1b[22m");
+    expect(predictor.pendingCount).toBe(2);
+  });
+
+  it("rolls back predictions on mismatched output", () => {
+    predictor.predict("a");
+    mockWrite.mockClear();
+
+    const output = new TextEncoder().encode("xyz");
+    predictor.handleOutput(output);
+
+    // Should clear dim char, then write server output
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[1D\x1b[0K");
+    expect(mockWrite).toHaveBeenCalledWith(output);
+    expect(predictor.pendingCount).toBe(0);
+  });
+
+  it("passes output through when no predictions pending", () => {
+    const output = new TextEncoder().encode("hello");
+    predictor.handleOutput(output);
+    expect(mockWrite).toHaveBeenCalledWith(output);
+  });
+
+  it("resets predictions after 1 second timeout", () => {
+    predictor.predict("a");
+    expect(predictor.pendingCount).toBe(1);
+    mockWrite.mockClear();
+
+    vi.advanceTimersByTime(1000);
+
+    // Should have cleared the dim prediction
+    expect(mockWrite).toHaveBeenCalledWith("\x1b[1D\x1b[0K");
+    expect(predictor.pendingCount).toBe(0);
+  });
+
+  it("resets timeout when new prediction arrives", () => {
+    predictor.predict("a");
+    vi.advanceTimersByTime(800);
+    predictor.predict("b");
+    mockWrite.mockClear();
+
+    // 800ms after second char — should NOT have reset yet
+    vi.advanceTimersByTime(800);
+    expect(predictor.pendingCount).toBe(2);
+
+    // 200ms more — now 1000ms after second char, should reset
+    vi.advanceTimersByTime(200);
+    expect(predictor.pendingCount).toBe(0);
   });
 });

--- a/lib/shire_web/live/settings_live/index.ex
+++ b/lib/shire_web/live/settings_live/index.ex
@@ -176,25 +176,13 @@ defmodule ShireWeb.SettingsLive.Index do
 
   @impl true
   def handle_event("terminal-input", %{"data" => data}, socket) do
-    project_id = socket.assigns.project.id
-
-    case TerminalSession.find(project_id) do
-      {:ok, _pid} -> TerminalSession.write(project_id, data)
-      :error -> :ok
-    end
-
+    TerminalSession.write(socket.assigns.project.id, data)
     {:noreply, socket}
   end
 
   @impl true
   def handle_event("terminal-resize", %{"rows" => rows, "cols" => cols}, socket) do
-    project_id = socket.assigns.project.id
-
-    case TerminalSession.find(project_id) do
-      {:ok, _pid} -> TerminalSession.resize(project_id, rows, cols)
-      :error -> :ok
-    end
-
+    TerminalSession.resize(socket.assigns.project.id, rows, cols)
     {:noreply, socket}
   end
 

--- a/test/shire_web/live/settings_live_test.exs
+++ b/test/shire_web/live/settings_live_test.exs
@@ -73,5 +73,15 @@ defmodule ShireWeb.SettingsLiveTest do
       assert html =~ "Hello from Alice"
       assert html =~ "Alice"
     end
+
+    test "terminal-input does not crash when no session exists", %{
+      conn: conn,
+      project_name: project_name
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/settings")
+      # Send terminal input without connecting first — should not crash
+      render_hook(view, "terminal-input", %{"data" => "hello"})
+      assert render(view) =~ "SettingsPage"
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add `LocalEchoPredictor` class that displays typed characters immediately in dim style before server confirmation, reducing perceived keystroke latency
- When server output arrives, predictions are confirmed (dim → normal) or rolled back (dim chars erased)
- Safety reset clears unconfirmed predictions after 1 second
- Remove redundant `TerminalSession.find()` Registry lookups on every `terminal-input` and `terminal-resize` event

## Test plan
- [x] New unit tests for `LocalEchoPredictor`: prediction, confirmation, partial match, rollback, timeout, control char handling
- [x] Updated integration tests for Terminal component with local echo
- [x] New Elixir test: terminal-input without active session doesn't crash
- [x] All 302 Elixir tests pass, all 192 JS tests pass
- [x] TypeScript, ESLint, Prettier, Elixir format all clean
- [ ] Manual: open Settings → Terminal, type rapidly — characters should appear instantly in dim, then solidify

🤖 Generated with [Claude Code](https://claude.com/claude-code)