### PR TITLE
Fix coordinator crash loop when VM not ready

### DIFF
--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -97,34 +97,28 @@ defmodule Shire.Agent.Coordinator do
     state = %{
       project_id: project_id,
       monitors: %{},
-      statuses: %{}
+      statuses: %{},
+      deployed: false
     }
 
     {:ok, state, {:continue, :deploy_and_scan}}
   end
 
   @impl true
+  def handle_continue(:deploy_and_scan, %{deployed: true} = state), do: {:noreply, state}
+
   def handle_continue(:deploy_and_scan, state) do
-    write_peers_yaml(state.project_id)
+    case vm().vm_status(state.project_id) do
+      :running ->
+        do_deploy_and_scan(state)
 
-    # Get agents from DB and start managers for those with folders on VM
-    db_agents = Agents.list_agents(state.project_id)
+      status ->
+        Logger.info(
+          "VM not ready (#{status}) for project #{state.project_id}, deferring deploy_and_scan"
+        )
 
-    monitors =
-      Enum.reduce(db_agents, state.monitors, fn agent, acc ->
-        case start_agent_manager(state.project_id, agent.id, agent.name, acc) do
-          {:ok, _pid, updated_monitors} -> updated_monitors
-          {:error, _} -> acc
-        end
-      end)
-
-    Logger.info("Project #{state.project_id}: started #{map_size(monitors)} agents")
-
-    {:noreply, %{state | monitors: monitors}}
-  rescue
-    e ->
-      Logger.error("Deploy and scan failed for #{state.project_id}: #{Exception.message(e)}")
-      {:noreply, state}
+        {:noreply, state}
+    end
   end
 
   @impl true
@@ -409,6 +403,27 @@ defmodule Shire.Agent.Coordinator do
   end
 
   @impl true
+  def handle_info({:vm_ready, _project_id}, %{deployed: true} = state) do
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, state.project_id}
+    )
+
+    {:noreply, state}
+  end
+
+  def handle_info({:vm_ready, _project_id}, state) do
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, state.project_id}
+    )
+
+    do_deploy_and_scan(state)
+  end
+
+  @impl true
   def handle_info({:vm_woke_up, _project_id}, state) do
     # Notify project lobby so dashboard status updates
     Phoenix.PubSub.broadcast(
@@ -470,6 +485,28 @@ defmodule Shire.Agent.Coordinator do
 
   # --- Private ---
 
+  defp do_deploy_and_scan(state) do
+    write_peers_yaml(state.project_id)
+
+    db_agents = Agents.list_agents(state.project_id)
+
+    monitors =
+      Enum.reduce(db_agents, state.monitors, fn agent, acc ->
+        case start_agent_manager(state.project_id, agent.id, agent.name, acc) do
+          {:ok, _pid, updated_monitors} -> updated_monitors
+          {:error, _} -> acc
+        end
+      end)
+
+    Logger.info("Project #{state.project_id}: started #{map_size(monitors)} agents")
+
+    {:noreply, %{state | monitors: monitors, deployed: true}}
+  rescue
+    e ->
+      Logger.error("Deploy and scan failed for #{state.project_id}: #{Exception.message(e)}")
+      {:noreply, state}
+  end
+
   defp read_agent_recipe(project_id, agent_id) do
     path = Path.join(Workspace.agent_dir(project_id, agent_id), "recipe.yaml")
 
@@ -525,8 +562,7 @@ defmodule Shire.Agent.Coordinator do
     end
   end
 
-  @doc false
-  def write_peers_yaml(project_id) do
+  defp write_peers_yaml(project_id) do
     agents = Agents.list_agents(project_id)
 
     peers =
@@ -559,6 +595,10 @@ defmodule Shire.Agent.Coordinator do
         Logger.warning("Failed to write peers.yaml: #{inspect(reason)}")
         {:error, reason}
     end
+  catch
+    :exit, reason ->
+      Logger.warning("Failed to write peers.yaml (VM not available): #{inspect(reason)}")
+      {:error, :vm_not_available}
   end
 
   defp vm, do: Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)

--- a/lib/shire/virtual_machine_local.ex
+++ b/lib/shire/virtual_machine_local.ex
@@ -253,6 +253,12 @@ defmodule Shire.VirtualMachineLocal do
     Logger.info("Local VM ready for project #{project_id} at #{root}")
     update_registry_status(project_id, :running)
 
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{project_id}:vm",
+      {:vm_ready, project_id}
+    )
+
     {:ok, %{project_id: project_id, root: root}}
   end
 

--- a/lib/shire/virtual_machine_sprite.ex
+++ b/lib/shire/virtual_machine_sprite.ex
@@ -192,6 +192,12 @@ defmodule Shire.VirtualMachineSprite do
 
           update_registry_status(project_id, :running)
 
+          Phoenix.PubSub.broadcast(
+            Shire.PubSub,
+            "project:#{project_id}:vm",
+            {:vm_ready, project_id}
+          )
+
           {:ok,
            %{
              sprite: sprite,
@@ -209,6 +215,12 @@ defmodule Shire.VirtualMachineSprite do
     else
       Logger.warning("No SPRITES_TOKEN configured — VM features disabled")
       update_registry_status(project_id, :running)
+
+      Phoenix.PubSub.broadcast(
+        Shire.PubSub,
+        "project:#{project_id}:vm",
+        {:vm_ready, project_id}
+      )
 
       {:ok,
        %{

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -14,6 +14,7 @@ defmodule Shire.Agent.AgentManagerTest do
   setup do
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :touch_keepalive, fn _project_id -> :ok end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
 
     {:ok, project} = Projects.create_project("test-project-#{System.unique_integer([:positive])}")
     {:ok, agent} = Agents.create_agent_with_vm(project.id, "test-agent", "version: 1\n", @vm)

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -22,6 +22,8 @@ defmodule Shire.Agent.CoordinatorTest do
       {:error, :not_available_in_test}
     end)
 
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
+
     # Create a DB-backed project
     {:ok, project} = Projects.create_project("test-project")
     project_id = project.id
@@ -483,6 +485,110 @@ defmodule Shire.Agent.CoordinatorTest do
         })
 
       assert {:error, :invalid_name} = result
+    end
+  end
+
+  describe "vm_ready deploy_and_scan" do
+    test "defers deploy_and_scan when VM is not running" do
+      Mox.set_mox_global()
+
+      stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+      stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
+
+      stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+        {:error, :not_available_in_test}
+      end)
+
+      # VM reports :starting (not ready yet)
+      stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :starting end)
+
+      {:ok, project} = Projects.create_project("test-vm-deferred")
+      project_id = project.id
+
+      start_supervised!(
+        {DynamicSupervisor,
+         name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
+         strategy: :one_for_one},
+        id: :agent_sup_deferred
+      )
+
+      start_supervised!(
+        {Shire.Agent.Coordinator, project_id: project_id},
+        id: :coordinator_deferred
+      )
+
+      Process.sleep(50)
+
+      # Coordinator should still be alive (no crash)
+      assert Process.alive?(
+               GenServer.whereis(
+                 {:via, Registry, {Shire.ProjectRegistry, {:coordinator, project_id}}}
+               )
+             )
+    end
+
+    test "triggers deploy_and_scan when vm_ready is received" do
+      Mox.set_mox_global()
+
+      stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+      stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
+
+      stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+        {:error, :not_available_in_test}
+      end)
+
+      # Start with VM not ready
+      stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :starting end)
+
+      # Track write calls to verify peers.yaml is written after vm_ready
+      test_pid = self()
+
+      stub(Shire.VirtualMachineMock, :write, fn _project, path, _content ->
+        if String.ends_with?(path, "peers.yaml") do
+          send(test_pid, :peers_yaml_written)
+        end
+
+        :ok
+      end)
+
+      {:ok, project} = Projects.create_project("test-vm-ready-trigger")
+      project_id = project.id
+
+      start_supervised!(
+        {DynamicSupervisor,
+         name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
+         strategy: :one_for_one},
+        id: :agent_sup_trigger
+      )
+
+      start_supervised!(
+        {Shire.Agent.Coordinator, project_id: project_id},
+        id: :coordinator_trigger
+      )
+
+      Process.sleep(50)
+
+      # peers.yaml should NOT have been written yet (VM not ready)
+      refute_received :peers_yaml_written
+
+      # Now simulate VM becoming ready
+      stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
+
+      Phoenix.PubSub.broadcast(
+        Shire.PubSub,
+        "project:#{project_id}:vm",
+        {:vm_ready, project_id}
+      )
+
+      # peers.yaml should now be written
+      assert_receive :peers_yaml_written, 1_000
     end
   end
 

--- a/test/shire/schedules_test.exs
+++ b/test/shire/schedules_test.exs
@@ -15,6 +15,7 @@ defmodule Shire.SchedulesTest do
 
   setup do
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
 
     {:ok, project} = Projects.create_project("schedule-project")
     {:ok, agent} = Agents.create_agent_with_vm(project.id, "sched-agent", "version: 1\n", @vm)

--- a/test/shire/workspace_settings_test.exs
+++ b/test/shire/workspace_settings_test.exs
@@ -10,6 +10,7 @@ defmodule Shire.WorkspaceSettingsTest do
   setup do
     Mox.set_mox_global()
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
     :ok
   end
 

--- a/test/shire/workspace_test.exs
+++ b/test/shire/workspace_test.exs
@@ -10,6 +10,7 @@ defmodule Shire.WorkspaceTest do
   setup do
     Mox.set_mox_global()
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
     :ok
   end
 

--- a/test/shire_web/live/project_details_live_test.exs
+++ b/test/shire_web/live/project_details_live_test.exs
@@ -13,6 +13,7 @@ defmodule ShireWeb.ProjectDetailsLiveTest do
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
     stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}

--- a/test/shire_web/live/settings_live_test.exs
+++ b/test/shire_web/live/settings_live_test.exs
@@ -16,6 +16,7 @@ defmodule ShireWeb.SettingsLiveTest do
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
     stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
     stub(Shire.VirtualMachineMock, :ls, fn _project, _path -> {:ok, []} end)
+    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
 
     stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
       {:error, :not_available_in_test}


### PR DESCRIPTION
## Summary
- Fixes crash loop where the Coordinator repeatedly crashes during project creation because the VM process isn't ready yet
- Adds VM readiness mechanism: VM backends broadcast `{:vm_ready, project_id}` after init, Coordinator defers `deploy_and_scan` until VM is running
- Adds `catch :exit` safety net in `write_peers_yaml` for runtime VM failures
- Guards against double `deploy_and_scan` execution with a `deployed` flag in Coordinator state

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] All 303 tests pass (`mix test`)
- [x] New tests: "defers deploy_and_scan when VM is not running" and "triggers deploy_and_scan when vm_ready is received"
- [ ] Manual test: create a new project in the UI, verify no crash loop in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)