### PR TITLE
fix lobby missing :starting status

### DIFF
--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -393,45 +393,16 @@ defmodule Shire.Agent.Coordinator do
   end
 
   @impl true
-  def handle_info({:agent_busy, _agent_id, _active}, state) do
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info({:agent_created, _id}, state) do
-    {:noreply, state}
-  end
-
-  @impl true
   def handle_info({:vm_ready, _project_id}, %{deployed: true} = state) do
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "projects:lobby",
-      {:project_status_changed, state.project_id}
-    )
-
     {:noreply, state}
   end
 
   def handle_info({:vm_ready, _project_id}, state) do
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "projects:lobby",
-      {:project_status_changed, state.project_id}
-    )
-
     do_deploy_and_scan(state)
   end
 
   @impl true
   def handle_info({:vm_woke_up, _project_id}, state) do
-    # Notify project lobby so dashboard status updates
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "projects:lobby",
-      {:project_status_changed, state.project_id}
-    )
-
     idle_agents =
       Enum.filter(state.statuses, fn {_id, status} -> status == :idle end)
 
@@ -456,30 +427,7 @@ defmodule Shire.Agent.Coordinator do
   end
 
   @impl true
-  def handle_info({:vm_went_idle, _project_id}, state) do
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "projects:lobby",
-      {:project_status_changed, state.project_id}
-    )
-
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info({:vm_unreachable, _project_id}, state) do
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "projects:lobby",
-      {:project_status_changed, state.project_id}
-    )
-
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info(msg, state) do
-    Logger.debug("Coordinator unexpected message: #{inspect(msg)}")
+  def handle_info(_msg, state) do
     {:noreply, state}
   end
 

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -24,19 +24,7 @@ defmodule Shire.ProjectManager do
   def list_projects do
     Projects.list_projects()
     |> Enum.map(fn project ->
-      status =
-        case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project.id}) do
-          [{pid, _}] ->
-            if Process.alive?(pid) do
-              # Coordinator is alive — derive status from VM state
-              vm().vm_status(project.id)
-            else
-              :error
-            end
-
-          [] ->
-            :stopped
-        end
+      status = vm().vm_status(project.id)
 
       %{id: project.id, name: project.name, status: status}
     end)
@@ -91,6 +79,8 @@ defmodule Shire.ProjectManager do
     manager = self()
 
     for project <- db_projects do
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project.id}:vm")
+
       Task.start(fn ->
         case start_project_subtree(project.id) do
           {:ok, pid} ->
@@ -119,6 +109,8 @@ defmodule Shire.ProjectManager do
       else
         case Projects.create_project(name) do
           {:ok, project} ->
+            Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project.id}:vm")
+
             case start_project_subtree(project.id) do
               {:ok, pid} ->
                 Process.monitor(pid)
@@ -154,6 +146,7 @@ defmodule Shire.ProjectManager do
       {pid, projects} ->
         # Stop the supervision subtree first
         DynamicSupervisor.terminate_child(Shire.ProjectSupervisor, pid)
+        Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:vm")
 
         # Destroy the underlying VM
         case vm().destroy_vm(project_id) do
@@ -193,6 +186,8 @@ defmodule Shire.ProjectManager do
           {:reply, {:error, :already_running}, state}
         else
           projects = Map.delete(state.projects, project_id)
+          Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:vm")
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:vm")
 
           case start_project_subtree(project_id) do
             {:ok, new_pid} ->
@@ -240,6 +235,7 @@ defmodule Shire.ProjectManager do
   @impl true
   def handle_info({:project_started, project_id, sup_pid}, state) do
     Process.monitor(sup_pid)
+    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:vm")
     projects = Map.put(state.projects, project_id, sup_pid)
 
     Phoenix.PubSub.broadcast(
@@ -252,11 +248,24 @@ defmodule Shire.ProjectManager do
   end
 
   @impl true
+  def handle_info({event, project_id}, state)
+      when event in [:vm_starting, :vm_ready, :vm_woke_up, :vm_went_idle, :vm_unreachable] do
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, project_id}
+    )
+
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     case Enum.find(state.projects, fn {_id, p} -> p == pid end) do
       {project_id, _pid} ->
         Logger.warning("Project #{project_id} supervisor went down, marking as stopped")
 
+        Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:vm")
         projects = Map.delete(state.projects, project_id)
 
         Phoenix.PubSub.broadcast(

--- a/lib/shire/virtual_machine_local.ex
+++ b/lib/shire/virtual_machine_local.ex
@@ -243,6 +243,12 @@ defmodule Shire.VirtualMachineLocal do
     root = workspace_root(project_id)
     update_registry_status(project_id, :starting)
 
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{project_id}:vm",
+      {:vm_starting, project_id}
+    )
+
     File.mkdir_p!(root)
 
     case Shire.VirtualMachine.Setup.run(build_setup_ops(root)) do

--- a/lib/shire/virtual_machine_sprite.ex
+++ b/lib/shire/virtual_machine_sprite.ex
@@ -178,6 +178,12 @@ defmodule Shire.VirtualMachineSprite do
 
     update_registry_status(project_id, :starting)
 
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{project_id}:vm",
+      {:vm_starting, project_id}
+    )
+
     if token do
       vm_name = vm_name(project_id)
 

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -20,7 +20,13 @@ defmodule Shire.ProjectManagerTest do
     end)
 
     stub(Shire.VirtualMachineMock, :destroy_vm, fn _name -> :ok end)
-    stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
+
+    stub(Shire.VirtualMachineMock, :vm_status, fn project_id ->
+      case Registry.lookup(Shire.ProjectRegistry, {:coordinator, project_id}) do
+        [{pid, _}] -> if Process.alive?(pid), do: :running, else: :stopped
+        [] -> :stopped
+      end
+    end)
 
     start_supervised!(ProjectManager)
 


### PR DESCRIPTION
## Summary
- **VMs now broadcast `{:vm_starting, project_id}`** on the project VM topic when entering `:starting` state, making the status visible to subscribers
- **ProjectManager subscribes to `project:{id}:vm` topics** and relays VM status changes to the lobby, replacing the Coordinator's relay role
- **Simplified `list_projects/0`** to delegate directly to `vm_status()` instead of checking the Coordinator registry
- **Cleaned up Coordinator** — removed lobby re-broadcasts and no-op event handlers (now handled by catch-all)
- **Fixed potential double-subscribe** on restart by unsubscribing before resubscribing

## Test plan
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — 303 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [ ] Manual: restart a stopped project and verify status transitions: stopped → starting → running

🤖 Generated with [Claude Code](https://claude.com/claude-code)