### PR TITLE
tidy up coordinator and agent manager event structure

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -413,18 +413,7 @@ defmodule Shire.Agent.AgentManager do
             acc
 
           {:ok, %{"type" => "processing", "payload" => %{"active" => active}}} ->
-            Phoenix.PubSub.broadcast(
-              Shire.PubSub,
-              "project:#{acc.project_id}:agents:lobby",
-              {:agent_busy, acc.agent_id, active}
-            )
-
-            Phoenix.PubSub.broadcast(
-              Shire.PubSub,
-              "project:#{acc.project_id}:agent:#{acc.agent_id}",
-              {:agent_busy, acc.agent_id, active}
-            )
-
+            broadcast(acc, {:agent_busy, acc.agent_id, active})
             acc
 
           {:ok, event} ->
@@ -497,12 +486,6 @@ defmodule Shire.Agent.AgentManager do
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
       "project:#{state.project_id}:agent:#{state.agent_id}",
-      {:status, status}
-    )
-
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "project:#{state.project_id}:agents:lobby",
       {:agent_status, state.agent_id, status}
     )
 

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -50,6 +50,11 @@ defmodule Shire.Agent.Coordinator do
     GenServer.call(via(project_id), {:restart_agent, agent_id}, 60_000)
   end
 
+  @doc "Subscribe the coordinator to an agent's PubSub topic (for status relay)."
+  def watch_agent(project_id, agent_id) do
+    GenServer.cast(via(project_id), {:watch_agent, agent_id})
+  end
+
   def send_message(project_id, agent_id, text) do
     AgentManager.send_message(project_id, agent_id, text, :user)
   end
@@ -91,7 +96,6 @@ defmodule Shire.Agent.Coordinator do
   def init(opts) do
     project_id = Keyword.fetch!(opts, :project_id)
 
-    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
     Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:vm")
 
     state = %{
@@ -243,13 +247,14 @@ defmodule Shire.Agent.Coordinator do
         :ok
     end
 
-    # Clean up monitor
+    # Clean up monitor and subscription
     {ref, monitors} =
       Enum.find_value(state.monitors, {nil, state.monitors}, fn {ref, id} ->
         if id == agent_id, do: {ref, Map.delete(state.monitors, ref)}
       end)
 
     if ref, do: Process.demonitor(ref, [:flush])
+    Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{state.project_id}:agent:#{agent_id}")
 
     # Delete agent (Multi: rm folder + delete DB record)
     case Agents.get_agent(agent_id) do
@@ -370,12 +375,6 @@ defmodule Shire.Agent.Coordinator do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{state.project_id}:agent:#{agent_id}",
-        {:status, :crashed}
-      )
-
-      Phoenix.PubSub.broadcast(
-        Shire.PubSub,
         "project:#{state.project_id}:agents:lobby",
         {:agent_status, agent_id, :crashed}
       )
@@ -389,7 +388,25 @@ defmodule Shire.Agent.Coordinator do
   @impl true
   def handle_info({:agent_status, agent_id, status}, state) do
     statuses = Map.put(state.statuses, agent_id, status)
+
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{state.project_id}:agents:lobby",
+      {:agent_status, agent_id, status}
+    )
+
     {:noreply, %{state | statuses: statuses}}
+  end
+
+  @impl true
+  def handle_info({:agent_busy, agent_id, active}, state) do
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{state.project_id}:agents:lobby",
+      {:agent_busy, agent_id, active}
+    )
+
+    {:noreply, state}
   end
 
   @impl true
@@ -428,6 +445,12 @@ defmodule Shire.Agent.Coordinator do
 
   @impl true
   def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:watch_agent, agent_id}, state) do
+    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{state.project_id}:agent:#{agent_id}")
     {:noreply, state}
   end
 
@@ -501,6 +524,7 @@ defmodule Shire.Agent.Coordinator do
       {:ok, pid} ->
         ref = Process.monitor(pid)
         monitors = Map.put(monitors, ref, agent_id)
+        Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
         Logger.info("Started agent #{agent_name} (#{agent_id}) in project #{project_id}")
         {:ok, pid, monitors}
 

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -259,27 +259,7 @@ defmodule ShireWeb.AgentLive.Index do
       {:noreply, put_flash(socket, :error, "Agent is not running.")}
   end
 
-  # PubSub handlers (agent-specific topic)
-
-  @impl true
-  def handle_info({:status, status}, socket) do
-    agent_id = socket.assigns.selected_agent_id
-
-    if agent_id do
-      statuses = Map.put(socket.assigns.agent_statuses, agent_id, status)
-
-      selected_agent =
-        if socket.assigns.selected_agent do
-          Map.put(socket.assigns.selected_agent, :status, status)
-        else
-          socket.assigns.selected_agent
-        end
-
-      {:noreply, assign(socket, agent_statuses: statuses, selected_agent: selected_agent)}
-    else
-      {:noreply, socket}
-    end
-  end
+  # PubSub handlers
 
   @impl true
   def handle_info({:agent_event, agent_id, event}, socket) do

--- a/lib/shire_web/live/agent_live/show.ex
+++ b/lib/shire_web/live/agent_live/show.ex
@@ -124,7 +124,7 @@ defmodule ShireWeb.AgentLive.Show do
   end
 
   @impl true
-  def handle_info({:status, status}, socket) do
+  def handle_info({:agent_status, _agent_id, status}, socket) do
     agent = Map.put(socket.assigns.agent, :status, status)
 
     {:noreply,

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -545,7 +545,7 @@ defmodule Shire.Agent.AgentManagerTest do
       assert state.command == nil
       assert state.command_ref == nil
 
-      assert_receive {:status, :idle}, 1_000
+      assert_receive {:agent_status, _, :idle}, 1_000
     end
 
     test "transitions to idle when runner errors", ctx do
@@ -590,7 +590,7 @@ defmodule Shire.Agent.AgentManagerTest do
 
       assert :ok = AgentManager.restart(ctx.project_id, ctx.agent_id)
 
-      assert_receive {:status, :bootstrapping}, 1_000
+      assert_receive {:agent_status, _, :bootstrapping}, 1_000
     end
   end
 
@@ -674,7 +674,7 @@ defmodule Shire.Agent.AgentManagerTest do
       )
 
       assert :ok = AgentManager.auto_restart(ctx.project_id, ctx.agent_id)
-      assert_receive {:status, :bootstrapping}, 1_000
+      assert_receive {:agent_status, _, :bootstrapping}, 1_000
     end
 
     test "returns {:error, :max_retries} after too many consecutive failures", ctx do

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -48,7 +48,7 @@ defmodule Shire.Agent.CoordinatorTest do
   defp broadcast_status(project_id, agent_id, status) do
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
-      "project:#{project_id}:agents:lobby",
+      "project:#{project_id}:agent:#{agent_id}",
       {:agent_status, agent_id, status}
     )
 
@@ -59,11 +59,18 @@ defmodule Shire.Agent.CoordinatorTest do
   defp start_agent_manager(project_id, agent_id, opts \\ []) do
     supervisor_id = Keyword.get(opts, :id, agent_id)
 
-    start_supervised(
-      {AgentManager,
-       project_id: project_id, agent_id: agent_id, agent_name: "test-agent", skip_sprite: true},
-      id: supervisor_id
-    )
+    result =
+      start_supervised(
+        {AgentManager,
+         project_id: project_id, agent_id: agent_id, agent_name: "test-agent", skip_sprite: true},
+        id: supervisor_id
+      )
+
+    # Ensure the Coordinator subscribes to this agent's topic for status relay
+    Coordinator.watch_agent(project_id, agent_id)
+    Process.sleep(10)
+
+    result
   end
 
   defp create_db_agent(project_id, name \\ "coord-test-agent") do
@@ -160,8 +167,12 @@ defmodule Shire.Agent.CoordinatorTest do
   end
 
   describe "status updates via PubSub" do
-    test "coordinator updates internal state from lobby broadcasts", %{project_id: project_id} do
+    test "coordinator updates internal state from agent topic broadcasts", %{
+      project_id: project_id
+    } do
       agent = create_db_agent(project_id)
+      Coordinator.watch_agent(project_id, agent.id)
+      Process.sleep(10)
       broadcast_status(project_id, agent.id, :active)
       assert :active == Coordinator.agent_status(project_id, agent.id)
     end
@@ -366,7 +377,7 @@ defmodule Shire.Agent.CoordinatorTest do
       )
 
       # Should receive bootstrapping status (restart triggers bootstrap)
-      assert_receive {:status, :bootstrapping}, 1_000
+      assert_receive {:agent_status, _, :bootstrapping}, 1_000
     end
 
     test "does not restart non-idle agents when VM wakes up", %{project_id: project_id} do
@@ -390,7 +401,7 @@ defmodule Shire.Agent.CoordinatorTest do
       )
 
       # Should NOT receive any restart-related status change
-      refute_receive {:status, :bootstrapping}, 300
+      refute_receive {:agent_status, _, :bootstrapping}, 300
     end
   end
 

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -326,7 +326,7 @@ defmodule ShireWeb.AgentLiveTest do
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
         "project:#{project_id}:agent:#{agent.id}",
-        {:status, :active}
+        {:agent_status, agent.id, :active}
       )
 
       html = render(view)
@@ -344,7 +344,7 @@ defmodule ShireWeb.AgentLiveTest do
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
         "project:#{project_id}:agent:#{agent.id}",
-        {:status, :idle}
+        {:agent_status, agent.id, :idle}
       )
 
       html = render(view)


### PR DESCRIPTION
## Summary
- **AgentManager** now only broadcasts on its own agent topic (`project:{id}:agent:{id}`), no longer directly to the lobby topic
- **Coordinator** subscribes to each agent's topic and relays `{:agent_status, ...}` and `{:agent_busy, ...}` to the lobby topic
- Unified status message format from `{:status, status}` to `{:agent_status, agent_id, status}` across all topics
- Consolidated duplicate status handlers in `AgentLive.Index`

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test` — all 303 tests pass
- [x] Verified event flow: AgentManager → agent topic → Coordinator → lobby topic → LiveViews

🤖 Generated with [Claude Code](https://claude.com/claude-code)