### PR TITLE
fix coordinator VM readiness race by moving VM event handling to ProjectManager

### DIFF
--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -50,6 +50,16 @@ defmodule Shire.Agent.Coordinator do
     GenServer.call(via(project_id), {:restart_agent, agent_id}, 60_000)
   end
 
+  @doc "Triggers deploy_and_scan if not already deployed. Called by ProjectManager on vm_ready."
+  def deploy_and_scan(project_id) do
+    GenServer.cast(via(project_id), :deploy_and_scan)
+  end
+
+  @doc "Restarts idle agents after VM wake-up. Called by ProjectManager on vm_woke_up."
+  def restart_idle_agents(project_id) do
+    GenServer.cast(via(project_id), :restart_idle_agents)
+  end
+
   @doc "Subscribe the coordinator to an agent's PubSub topic (for status relay)."
   def watch_agent(project_id, agent_id) do
     GenServer.cast(via(project_id), {:watch_agent, agent_id})
@@ -95,8 +105,6 @@ defmodule Shire.Agent.Coordinator do
   @impl true
   def init(opts) do
     project_id = Keyword.fetch!(opts, :project_id)
-
-    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:vm")
 
     state = %{
       project_id: project_id,
@@ -410,16 +418,21 @@ defmodule Shire.Agent.Coordinator do
   end
 
   @impl true
-  def handle_info({:vm_ready, _project_id}, %{deployed: true} = state) do
+  def handle_info(_msg, state) do
     {:noreply, state}
   end
 
-  def handle_info({:vm_ready, _project_id}, state) do
+  @impl true
+  def handle_cast(:deploy_and_scan, %{deployed: true} = state) do
+    {:noreply, state}
+  end
+
+  def handle_cast(:deploy_and_scan, state) do
     do_deploy_and_scan(state)
   end
 
   @impl true
-  def handle_info({:vm_woke_up, _project_id}, state) do
+  def handle_cast(:restart_idle_agents, state) do
     idle_agents =
       Enum.filter(state.statuses, fn {_id, status} -> status == :idle end)
 
@@ -440,11 +453,6 @@ defmodule Shire.Agent.Coordinator do
       end)
     end
 
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info(_msg, state) do
     {:noreply, state}
   end
 

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -248,8 +248,34 @@ defmodule Shire.ProjectManager do
   end
 
   @impl true
+  def handle_info({:vm_ready, project_id}, state) do
+    Shire.Agent.Coordinator.deploy_and_scan(project_id)
+
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, project_id}
+    )
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:vm_woke_up, project_id}, state) do
+    Shire.Agent.Coordinator.restart_idle_agents(project_id)
+
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "projects:lobby",
+      {:project_status_changed, project_id}
+    )
+
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info({event, project_id}, state)
-      when event in [:vm_starting, :vm_ready, :vm_woke_up, :vm_went_idle, :vm_unreachable] do
+      when event in [:vm_starting, :vm_went_idle, :vm_unreachable] do
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
       "projects:lobby",

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -369,12 +369,8 @@ defmodule Shire.Agent.CoordinatorTest do
         "project:#{project_id}:agent:#{agent.id}"
       )
 
-      # Simulate VM waking up
-      Phoenix.PubSub.broadcast(
-        Shire.PubSub,
-        "project:#{project_id}:vm",
-        {:vm_woke_up, project_id}
-      )
+      # Simulate VM waking up — ProjectManager calls restart_idle_agents
+      Coordinator.restart_idle_agents(project_id)
 
       # Should receive bootstrapping status (restart triggers bootstrap)
       assert_receive {:agent_status, _, :bootstrapping}, 1_000
@@ -393,12 +389,8 @@ defmodule Shire.Agent.CoordinatorTest do
         "project:#{project_id}:agent:#{agent.id}"
       )
 
-      # Simulate VM waking up
-      Phoenix.PubSub.broadcast(
-        Shire.PubSub,
-        "project:#{project_id}:vm",
-        {:vm_woke_up, project_id}
-      )
+      # Simulate VM waking up — ProjectManager calls restart_idle_agents
+      Coordinator.restart_idle_agents(project_id)
 
       # Should NOT receive any restart-related status change
       refute_receive {:agent_status, _, :bootstrapping}, 300
@@ -542,7 +534,7 @@ defmodule Shire.Agent.CoordinatorTest do
              )
     end
 
-    test "triggers deploy_and_scan when vm_ready is received" do
+    test "triggers deploy_and_scan when deploy_and_scan/1 is called" do
       Mox.set_mox_global()
 
       stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
@@ -589,17 +581,65 @@ defmodule Shire.Agent.CoordinatorTest do
       # peers.yaml should NOT have been written yet (VM not ready)
       refute_received :peers_yaml_written
 
-      # Now simulate VM becoming ready
+      # Now simulate VM becoming ready — ProjectManager calls deploy_and_scan
       stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
-
-      Phoenix.PubSub.broadcast(
-        Shire.PubSub,
-        "project:#{project_id}:vm",
-        {:vm_ready, project_id}
-      )
+      Coordinator.deploy_and_scan(project_id)
 
       # peers.yaml should now be written
       assert_receive :peers_yaml_written, 1_000
+    end
+
+    test "deploy_and_scan/1 is a no-op when already deployed" do
+      Mox.set_mox_global()
+
+      stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+      stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
+
+      stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+        {:error, :not_available_in_test}
+      end)
+
+      # VM is running from the start
+      stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
+
+      test_pid = self()
+      write_count = :counters.new(1, [:atomics])
+
+      stub(Shire.VirtualMachineMock, :write, fn _project, path, _content ->
+        if String.ends_with?(path, "peers.yaml") do
+          :counters.add(write_count, 1, 1)
+          send(test_pid, :peers_yaml_written)
+        end
+
+        :ok
+      end)
+
+      {:ok, project} = Projects.create_project("test-no-double-deploy")
+      project_id = project.id
+
+      start_supervised!(
+        {DynamicSupervisor,
+         name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
+         strategy: :one_for_one},
+        id: :agent_sup_no_double
+      )
+
+      start_supervised!(
+        {Shire.Agent.Coordinator, project_id: project_id},
+        id: :coordinator_no_double
+      )
+
+      # Wait for initial deploy (VM was running, so handle_continue deploys)
+      assert_receive :peers_yaml_written, 1_000
+
+      # Calling deploy_and_scan again should be a no-op
+      Coordinator.deploy_and_scan(project_id)
+      Process.sleep(50)
+
+      assert :counters.get(write_count, 1) == 1
     end
   end
 


### PR DESCRIPTION
## Summary
- Fix race condition where Coordinator misses `vm_ready`/`vm_woke_up` PubSub events because it subscribes after the VM has already broadcast them
- Move VM event handling from Coordinator to ProjectManager, which subscribes before starting the subtree and never misses events
- Add `Coordinator.deploy_and_scan/1` and `Coordinator.restart_idle_agents/1` public APIs called by ProjectManager

## Test plan
- [x] Existing coordinator tests updated to use new APIs instead of PubSub broadcasts
- [x] Added test: `deploy_and_scan/1` is a no-op when already deployed
- [x] All 304 tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)