### PR TITLE
fix VM GenServer not starting on server restart

### DIFF
--- a/lib/shire/project_instance_supervisor.ex
+++ b/lib/shire/project_instance_supervisor.ex
@@ -14,6 +14,7 @@ defmodule Shire.ProjectInstanceSupervisor do
   @impl true
   def init(project_id) do
     vm_module = Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)
+    Code.ensure_loaded(vm_module)
 
     vm_children =
       if function_exported?(vm_module, :child_spec, 1) do

--- a/lib/shire/project_manager.ex
+++ b/lib/shire/project_manager.ex
@@ -249,6 +249,7 @@ defmodule Shire.ProjectManager do
 
   @impl true
   def handle_info({:vm_ready, project_id}, state) do
+    Logger.info("VM ready for project #{project_id}, deploying and scanning")
     Shire.Agent.Coordinator.deploy_and_scan(project_id)
 
     Phoenix.PubSub.broadcast(

--- a/lib/shire/virtual_machine_sprite.ex
+++ b/lib/shire/virtual_machine_sprite.ex
@@ -178,6 +178,8 @@ defmodule Shire.VirtualMachineSprite do
 
     update_registry_status(project_id, :starting)
 
+    Logger.info("VM starting (project: #{project_id})")
+
     Phoenix.PubSub.broadcast(
       Shire.PubSub,
       "project:#{project_id}:vm",


### PR DESCRIPTION
## Summary
- `function_exported?/3` returns false when the VM module hasn't been loaded into the BEAM yet, causing the VM child to be skipped from the supervision tree on server restart
- Add `Code.ensure_loaded/1` before the check so the module is always available
- Also includes logging additions for VM startup and deploy_and_scan

## Test plan
- [x] Verified locally: VM GenServer now starts on server restart
- [x] All 304 tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)