### PR TITLE
Harden frontend accessibility and resilience

### DIFF
--- a/assets/react-components/ActivityLog.tsx
+++ b/assets/react-components/ActivityLog.tsx
@@ -66,12 +66,14 @@ export default function ActivityLog({ messages, hasMore, pushEvent }: ActivityLo
             </div>
             <p className="text-sm whitespace-pre-wrap">{displayText}</p>
             {isLong && (
-              <button
+              <Button
+                variant="link"
+                size="sm"
+                className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
                 onClick={() => toggleExpand(msg.id)}
-                className="text-xs text-muted-foreground hover:text-foreground"
               >
                 {isExpanded ? "Show less" : "Show more"}
-              </button>
+              </Button>
             )}
           </div>
         );

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -77,23 +77,25 @@ export default function AgentSidebar({
 
       <div className="flex-1 overflow-y-auto py-1">
         {agents.map((agent) => (
-          <div
-            key={agent.id}
-            className={`group flex items-center gap-2 px-3 py-2 mx-1 rounded-md cursor-pointer text-sm ${
-              selectedAgentId === agent.id ? "bg-accent text-accent-foreground" : "hover:bg-muted text-foreground"
-            }`}
-            onClick={() => onSelectAgent(agent.id)}
-          >
-            <span
-              className={`w-2 h-2 rounded-full shrink-0 ${statusDotColor(agent.status)}${agent.status === "active" && agent.busy ? " animate-pulse" : ""}`}
-            />
-            <span className="truncate flex-1">{agent.name}</span>
+          <div key={agent.id} className="group flex items-center mx-1">
+            <button
+              type="button"
+              className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm flex-1 min-w-0 text-left ${
+                selectedAgentId === agent.id ? "bg-accent text-accent-foreground" : "hover:bg-muted text-foreground"
+              }`}
+              onClick={() => onSelectAgent(agent.id)}
+            >
+              <span
+                className={`w-2 h-2 rounded-full shrink-0 ${statusDotColor(agent.status)}${agent.status === "active" && agent.busy ? " animate-pulse" : ""}`}
+              />
+              <span className="truncate">{agent.name}</span>
+            </button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-background text-muted-foreground"
-                  onClick={(e) => e.stopPropagation()}
+                  className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-background text-muted-foreground"
+                  aria-label={`${agent.name} actions`}
                 >
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                     <circle cx="8" cy="3" r="1.5" />

--- a/assets/react-components/SchedulesPage.tsx
+++ b/assets/react-components/SchedulesPage.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
 import AppLayout from "./components/AppLayout";
 import { Button } from "./components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "./components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "./components/ui/dialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -349,17 +356,17 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      <Button variant="ghost" size="sm" onClick={() => handleRunNow(task)} title="Run now">
+                      <Button variant="ghost" size="sm" onClick={() => handleRunNow(task)} aria-label="Run now">
                         <Play className="h-4 w-4" />
                       </Button>
-                      <Button variant="ghost" size="sm" onClick={() => openEdit(task)} title="Edit">
+                      <Button variant="ghost" size="sm" onClick={() => openEdit(task)} aria-label="Edit">
                         <Pencil className="h-4 w-4" />
                       </Button>
                       <Button
                         variant="ghost"
                         size="sm"
                         onClick={() => setDeleteId(task.id)}
-                        title="Delete"
+                        aria-label="Delete"
                         className="text-destructive hover:text-destructive"
                       >
                         <Trash2 className="h-4 w-4" />
@@ -378,6 +385,11 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>{editingId ? "Edit Schedule" : "New Schedule"}</DialogTitle>
+            <DialogDescription>
+              {editingId
+                ? "Modify the schedule settings below."
+                : "Configure a scheduled message to be sent to an agent automatically."}
+            </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4 py-2">

--- a/assets/react-components/SettingsPage.tsx
+++ b/assets/react-components/SettingsPage.tsx
@@ -240,13 +240,13 @@ export default function SettingsPage({
                         variant="ghost"
                         size="sm"
                         onClick={() => pushEvent("run-script", { name: draft.originalName })}
-                        title="Run script"
+                        aria-label="Run script"
                       >
                         <Play className="h-4 w-4" />
                       </Button>
                       <AlertDialog>
                         <AlertDialogTrigger asChild>
-                          <Button variant="ghost" size="sm" title="Delete script">
+                          <Button variant="ghost" size="sm" aria-label="Delete script">
                             <Trash2 className="h-4 w-4" />
                           </Button>
                         </AlertDialogTrigger>

--- a/assets/react-components/SharedDrive.tsx
+++ b/assets/react-components/SharedDrive.tsx
@@ -92,9 +92,17 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
     setDeleteTarget(null);
   };
 
+  const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50 MB
+
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    if (file.size > MAX_UPLOAD_SIZE) {
+      alert(`File is too large (${formatSize(file.size)}). Maximum upload size is ${formatSize(MAX_UPLOAD_SIZE)}.`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
 
     const reader = new FileReader();
     reader.onload = () => {
@@ -155,13 +163,14 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
                   <TableRow key={file.path}>
                     <TableCell>
                       {file.type === "directory" ? (
-                        <button
-                          className="flex items-center gap-2 hover:underline text-left"
+                        <Button
+                          variant="link"
+                          className="flex items-center gap-2 text-foreground h-auto p-0"
                           onClick={() => navigate("/" + file.path)}
                         >
                           <span className="text-muted-foreground">📁</span>
                           {file.name}
-                        </button>
+                        </Button>
                       ) : (
                         <div className="flex items-center gap-2">
                           <span className="text-muted-foreground">📄</span>

--- a/assets/react-components/Terminal.tsx
+++ b/assets/react-components/Terminal.tsx
@@ -115,6 +115,16 @@ export default function Terminal({ pushEvent }: TerminalProps) {
   const fitAddonRef = React.useRef<FitAddon | null>(null);
   const [exited, setExited] = React.useState(false);
 
+  // Stable refs so the mount-only effect doesn't need these in its deps
+  const pushEventRef = React.useRef(pushEvent);
+  const handleEventRef = React.useRef(handleEvent);
+  const removeHandleEventRef = React.useRef(removeHandleEvent);
+  React.useEffect(() => {
+    pushEventRef.current = pushEvent;
+    handleEventRef.current = handleEvent;
+    removeHandleEventRef.current = removeHandleEvent;
+  });
+
   React.useEffect(() => {
     if (!containerRef.current) return;
 
@@ -142,18 +152,18 @@ export default function Terminal({ pushEvent }: TerminalProps) {
     // Send keystrokes to server with local echo prediction
     const dataDisposable = term.onData((data) => {
       predictor.predict(data);
-      pushEvent("terminal-input", { data });
+      pushEventRef.current("terminal-input", { data });
     });
 
     // Receive output from server — route through predictor
-    const outputRef = handleEvent("terminal-output", (payload: Record<string, unknown>) => {
+    const outputRef = handleEventRef.current("terminal-output", (payload: Record<string, unknown>) => {
       const data = payload.data as string;
       const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
       predictor.handleOutput(bytes);
     });
 
     // Handle terminal exit
-    const exitRef = handleEvent("terminal-exit", (payload: Record<string, unknown>) => {
+    const exitRef = handleEventRef.current("terminal-exit", (payload: Record<string, unknown>) => {
       const code = payload.code as number;
       term.writeln(`\r\n\x1b[31m[Session ended with code ${code}]\x1b[0m`);
       setExited(true);
@@ -166,27 +176,27 @@ export default function Terminal({ pushEvent }: TerminalProps) {
       resizeTimeout = setTimeout(() => {
         fitAddon.fit();
         const { rows, cols } = term;
-        pushEvent("terminal-resize", { rows, cols });
+        pushEventRef.current("terminal-resize", { rows, cols });
       }, 150);
     });
     observer.observe(containerRef.current);
 
     // Connect to server
-    pushEvent("connect-terminal", {});
+    pushEventRef.current("connect-terminal", {});
 
     return () => {
       clearTimeout(resizeTimeout);
       observer.disconnect();
       predictor.dispose();
       dataDisposable.dispose();
-      removeHandleEvent(outputRef);
-      removeHandleEvent(exitRef);
-      pushEvent("disconnect-terminal", {});
+      removeHandleEventRef.current(outputRef);
+      removeHandleEventRef.current(exitRef);
+      pushEventRef.current("disconnect-terminal", {});
       term.dispose();
       termRef.current = null;
       fitAddonRef.current = null;
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleReconnect = () => {
     setExited(false);

--- a/assets/test/SchedulesPage.test.tsx
+++ b/assets/test/SchedulesPage.test.tsx
@@ -110,7 +110,7 @@ describe("SchedulesPage", () => {
     render(<SchedulesPage {...defaultProps} tasks={sampleTasks} pushEvent={pushEvent} />);
 
     // Edit pre-fills the form including agent_id (avoids Radix Select jsdom limitation)
-    const editButtons = screen.getAllByTitle("Edit");
+    const editButtons = screen.getAllByRole("button", { name: "Edit" });
     await user.click(editButtons[0]);
 
     // Modify the label
@@ -132,7 +132,7 @@ describe("SchedulesPage", () => {
 
   it("opens delete confirmation dialog", async () => {
     render(<SchedulesPage {...defaultProps} tasks={sampleTasks} />);
-    const deleteButtons = screen.getAllByTitle("Delete");
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
     await userEvent.click(deleteButtons[0]);
 
     expect(screen.getByText("Delete Schedule")).toBeInTheDocument();
@@ -145,7 +145,7 @@ describe("SchedulesPage", () => {
     const pushEvent = vi.fn();
     render(<SchedulesPage {...defaultProps} tasks={sampleTasks} pushEvent={pushEvent} />);
 
-    const deleteButtons = screen.getAllByTitle("Delete");
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
     await userEvent.click(deleteButtons[0]);
 
     const alertDialog = screen.getByRole("alertdialog");
@@ -160,7 +160,7 @@ describe("SchedulesPage", () => {
   it("cancels delete confirmation dialog", async () => {
     render(<SchedulesPage {...defaultProps} tasks={sampleTasks} />);
 
-    const deleteButtons = screen.getAllByTitle("Delete");
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
     await userEvent.click(deleteButtons[0]);
     expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 
@@ -188,7 +188,7 @@ describe("SchedulesPage", () => {
     const pushEvent = vi.fn();
     render(<SchedulesPage {...defaultProps} tasks={sampleTasks} pushEvent={pushEvent} />);
 
-    const runButtons = screen.getAllByTitle("Run now");
+    const runButtons = screen.getAllByRole("button", { name: "Run now" });
     await userEvent.click(runButtons[0]);
     expect(pushEvent).toHaveBeenCalledWith("run-now", { id: "t1" });
   });
@@ -196,7 +196,7 @@ describe("SchedulesPage", () => {
   it("opens edit dialog with pre-filled form", async () => {
     render(<SchedulesPage {...defaultProps} tasks={sampleTasks} />);
 
-    const editButtons = screen.getAllByTitle("Edit");
+    const editButtons = screen.getAllByRole("button", { name: "Edit" });
     await userEvent.click(editButtons[0]);
 
     expect(screen.getByRole("heading", { name: "Edit Schedule" })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Convert sidebar agent list items from non-interactive `<div onClick>` to proper `<button>` elements for keyboard accessibility (WCAG 2.1.1)
- Add `aria-label` to all icon-only buttons across AgentSidebar, SchedulesPage, and SettingsPage (WCAG 4.1.2)
- Replace bare `<button>` elements with shadcn `Button` components in ActivityLog and SharedDrive for consistent focus indicators
- Add `DialogDescription` to SchedulesPage create/edit dialog for screen reader support
- Add 50MB client-side file upload size validation in SharedDrive to prevent browser freezes
- Remove `eslint-disable` comment in Terminal.tsx by using refs with `useEffect` sync pattern
- Update SchedulesPage tests to use `getByRole` instead of `getByTitle` to match new `aria-label` attributes

## Test plan

- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors)
- [x] Prettier format check passes
- [x] All 192 Vitest component tests pass
- [x] Elixir compilation passes
- [ ] Manual: verify sidebar agents are keyboard-navigable (Tab + Enter)
- [ ] Manual: verify icon-only buttons are announced by screen reader
- [ ] Manual: verify file upload > 50MB shows alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)