### PR TITLE
Normalize design system: semantic tokens, consistent patterns

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -62,6 +62,10 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-status-active: var(--status-active);
+  --color-status-starting: var(--status-starting);
+  --color-status-error: var(--status-error);
+  --color-status-idle: var(--status-idle);
 }
 
 :root {
@@ -97,6 +101,12 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --status-active: oklch(0.6 0.2 145);
+  --status-starting: oklch(0.7 0.15 85);
+  --status-error: oklch(0.6 0.2 25);
+  --status-idle: oklch(0.556 0 0);
+  --terminal-bg: oklch(0.16 0 0);
+  --terminal-fg: oklch(0.9 0 0);
 }
 
 .dark {
@@ -131,6 +141,12 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --status-active: oklch(0.65 0.2 150);
+  --status-starting: oklch(0.75 0.15 85);
+  --status-error: oklch(0.65 0.2 25);
+  --status-idle: oklch(0.708 0 0);
+  --terminal-bg: oklch(0.16 0 0);
+  --terminal-fg: oklch(0.9 0 0);
 }
 
 @layer base {

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button } from "./components/ui/button";
+import { Button, buttonVariants } from "./components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,14 +24,14 @@ import { type Agent, type AgentStatus, type Project } from "./types";
 function statusDotColor(status: AgentStatus): string {
   switch (status) {
     case "active":
-      return "bg-green-500";
+      return "bg-status-active";
     case "starting":
     case "bootstrapping":
-      return "bg-yellow-500";
+      return "bg-status-starting";
     case "crashed":
-      return "bg-red-500";
+      return "bg-status-error";
     default:
-      return "bg-gray-400";
+      return "bg-status-idle";
   }
 }
 
@@ -181,10 +181,7 @@ export default function AgentSidebar({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={handleDeleteConfirm}
-            >
+            <AlertDialogAction className={buttonVariants({ variant: "destructive" })} onClick={handleDeleteConfirm}>
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -270,7 +270,7 @@ export default function ChatPanel({
         )}
         {agent.busy && !streamingText && (
           <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
-            <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-status-active animate-pulse" />
             Thinking...
           </div>
         )}

--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button } from "./components/ui/button";
+import { Button, buttonVariants } from "./components/ui/button";
 import { Input } from "./components/ui/input";
 import { Card, CardContent } from "./components/ui/card";
 import { Badge } from "./components/ui/badge";
@@ -180,10 +180,7 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={handleDelete}
-            >
+            <AlertDialogAction className={buttonVariants({ variant: "destructive" })} onClick={handleDelete}>
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/assets/react-components/ProjectDetailsPage.tsx
+++ b/assets/react-components/ProjectDetailsPage.tsx
@@ -40,20 +40,15 @@ export default function ProjectDetailsPage({ project, project_doc, pushEvent }: 
 
   return (
     <AppLayout>
-      <div className="space-y-8">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="gap-1 text-muted-foreground"
-          onClick={() => navigate(`/projects/${project.name}`)}
-        >
-          <ChevronLeft className="h-4 w-4" />
-          Back to dashboard
-        </Button>
-
-        <div>
-          <h1 className="text-2xl font-bold">Project Details</h1>
-          <p className="text-sm text-muted-foreground mt-1">Manage project name and documentation.</p>
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project.name}`)}>
+            <ChevronLeft className="h-5 w-5" />
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold">Project Details</h1>
+            <p className="text-sm text-muted-foreground">Manage project name and documentation.</p>
+          </div>
         </div>
 
         <div className="space-y-2">

--- a/assets/react-components/SchedulesPage.tsx
+++ b/assets/react-components/SchedulesPage.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import AppLayout from "./components/AppLayout";
-import { Button } from "./components/ui/button";
+import { Button, buttonVariants } from "./components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -24,7 +24,7 @@ import { Input } from "./components/ui/input";
 import { Label } from "./components/ui/label";
 import { Textarea } from "./components/ui/textarea";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./components/ui/table";
-import { ArrowLeft, Plus, Play, Pencil, Trash2 } from "lucide-react";
+import { ChevronLeft, Plus, Play, Pencil, Trash2 } from "lucide-react";
 import { navigate } from "./lib/navigate";
 import { type ScheduledTask } from "./types";
 
@@ -300,10 +300,9 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
   return (
     <AppLayout>
       <div className="space-y-6">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => navigate(`/projects/${project.name}`)}>
-            <ArrowLeft className="h-4 w-4 mr-1" />
-            Back
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project.name}`)}>
+            <ChevronLeft className="h-5 w-5" />
           </Button>
           <h1 className="text-2xl font-bold flex-1">Scheduled Tasks</h1>
           <Button onClick={openCreate}>
@@ -613,10 +612,7 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={handleDelete}
-            >
+            <AlertDialogAction className={buttonVariants({ variant: "destructive" })} onClick={handleDelete}>
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/assets/react-components/SettingsPage.tsx
+++ b/assets/react-components/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button } from "./components/ui/button";
+import { Button, buttonVariants } from "./components/ui/button";
 import { Textarea } from "./components/ui/textarea";
 import { Input } from "./components/ui/input";
 import { Label } from "./components/ui/label";
@@ -259,7 +259,10 @@ export default function SettingsPage({
                           </AlertDialogHeader>
                           <AlertDialogFooter>
                             <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => pushEvent("delete-script", { name: draft.originalName })}>
+                            <AlertDialogAction
+                              className={buttonVariants({ variant: "destructive" })}
+                              onClick={() => pushEvent("delete-script", { name: draft.originalName })}
+                            >
                               Delete
                             </AlertDialogAction>
                           </AlertDialogFooter>

--- a/assets/react-components/SharedDrive.tsx
+++ b/assets/react-components/SharedDrive.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button } from "./components/ui/button";
+import { Button, buttonVariants } from "./components/ui/button";
 import { Input } from "./components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./components/ui/table";
 import {
@@ -21,6 +21,8 @@ import {
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
 import AppLayout from "./components/AppLayout";
+import { ChevronLeft } from "lucide-react";
+import { navigate as navigateTo } from "./lib/navigate";
 
 export interface SharedDriveFile {
   name: string;
@@ -126,7 +128,12 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
   return (
     <AppLayout>
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold">Shared Drive</h1>
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigateTo(`/projects/${project.name}`)}>
+            <ChevronLeft className="h-5 w-5" />
+          </Button>
+          <h1 className="text-2xl font-bold">Shared Drive</h1>
+        </div>
         {/* Toolbar */}
         <div className="flex items-center justify-between">
           <Breadcrumbs path={current_path} onNavigate={navigate} />
@@ -252,7 +259,12 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={() => deleteTarget && handleDelete(deleteTarget)}>Delete</AlertDialogAction>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={() => deleteTarget && handleDelete(deleteTarget)}
+            >
+              Delete
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/assets/react-components/Terminal.tsx
+++ b/assets/react-components/Terminal.tsx
@@ -133,8 +133,8 @@ export default function Terminal({ pushEvent }: TerminalProps) {
       fontSize: 14,
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       theme: {
-        background: "#1a1a1a",
-        foreground: "#e5e5e5",
+        background: getComputedStyle(document.documentElement).getPropertyValue("--terminal-bg").trim() || "#1a1a1a",
+        foreground: getComputedStyle(document.documentElement).getPropertyValue("--terminal-fg").trim() || "#e5e5e5",
       },
     });
 
@@ -208,11 +208,11 @@ export default function Terminal({ pushEvent }: TerminalProps) {
     <div className="relative">
       <div
         ref={containerRef}
-        className="w-full rounded-lg overflow-hidden p-3"
-        style={{ height: "480px", backgroundColor: "#1a1a1a" }}
+        className="w-full rounded-lg overflow-hidden p-3 bg-[var(--terminal-bg)]"
+        style={{ height: "480px" }}
       />
       {exited && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/50 rounded-lg">
+        <div className="absolute inset-0 flex items-center justify-center bg-background/50 rounded-lg">
           <Button onClick={handleReconnect}>Reconnect</Button>
         </div>
       )}

--- a/assets/test/AgentSidebar.test.tsx
+++ b/assets/test/AgentSidebar.test.tsx
@@ -84,9 +84,9 @@ describe("AgentSidebar", () => {
     const { container } = render(<AgentSidebar {...defaultProps} agents={agents} />);
 
     const dots = container.querySelectorAll(".rounded-full");
-    expect(dots[0]).toHaveClass("bg-green-500"); // active
-    expect(dots[1]).toHaveClass("bg-gray-400"); // created
-    expect(dots[2]).toHaveClass("bg-gray-400"); // idle
+    expect(dots[0]).toHaveClass("bg-status-active"); // active
+    expect(dots[1]).toHaveClass("bg-status-idle"); // created
+    expect(dots[2]).toHaveClass("bg-status-idle"); // idle
   });
 
   it("pulses the status dot when agent is active and busy", () => {

--- a/assets/test/ProjectDetailsPage.test.tsx
+++ b/assets/test/ProjectDetailsPage.test.tsx
@@ -15,9 +15,9 @@ describe("ProjectDetailsPage", () => {
     expect(screen.getByRole("heading", { name: "Project Details" })).toBeInTheDocument();
   });
 
-  it("renders back link", () => {
+  it("renders back button", () => {
     render(<ProjectDetailsPage {...defaultProps} />);
-    expect(screen.getByText("Back to dashboard")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
   });
 
   it("shows project name in input", () => {


### PR DESCRIPTION
## Summary

- Add semantic CSS variables for status colors (`--status-active`, `--status-starting`, `--status-error`, `--status-idle`) with proper light/dark theme values, registered in `@theme inline` for first-class Tailwind utility support
- Add `--terminal-bg` / `--terminal-fg` CSS variables so Terminal reads theme colors instead of hard-coded hex
- Replace all hard-coded Tailwind color classes (`bg-green-500`, `bg-yellow-500`, `bg-red-500`, `bg-gray-400`) with semantic tokens (`bg-status-active`, etc.) in AgentSidebar and ChatPanel
- Standardize back navigation across all sub-pages to consistent `ChevronLeft` icon button with `aria-label="Back"` (was: 3 different patterns — icon-only, text+icon, different icons)
- Standardize destructive `AlertDialogAction` styling to `buttonVariants({ variant: "destructive" })` across all 5 components (was: some inline classes, some unstyled)
- Add missing back button to SharedDrive page

## Test plan

- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] Prettier: all formatted
- [x] Vitest: 192/192 tests passing
- [x] Elixir: compiles clean
- [ ] Manual: verify status dots render correct colors in sidebar
- [ ] Manual: verify terminal background matches theme
- [ ] Manual: verify all sub-pages have consistent back button
- [ ] Manual: verify all delete confirmations show red button

🤖 Generated with [Claude Code](https://claude.com/claude-code)