### PR TITLE
Add responsive mobile support for chat layout

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -43,6 +43,11 @@ export default function AgentDashboard({
   const [catalogOpen, setCatalogOpen] = React.useState(false);
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
 
+  // Close mobile sidebar when the selected agent changes (e.g. server-driven navigation)
+  React.useEffect(() => {
+    setSidebarOpen(false);
+  }, [selectedAgent?.id]);
+
   React.useEffect(() => {
     if (editAgent) {
       setCurrentAgent(editAgent);

--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -41,6 +41,7 @@ export default function AgentDashboard({
   const [editingAgent, setEditingAgent] = React.useState<Agent | null>(null);
   const [currentAgent, setCurrentAgent] = React.useState<Agent | null>(null);
   const [catalogOpen, setCatalogOpen] = React.useState(false);
+  const [sidebarOpen, setSidebarOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (editAgent) {
@@ -84,6 +85,7 @@ export default function AgentDashboard({
   };
 
   const handleSelectAgent = (id: string) => {
+    setSidebarOpen(false);
     pushEvent("select-agent", { id });
   };
 
@@ -106,21 +108,35 @@ export default function AgentDashboard({
 
   return (
     <div className="flex h-screen bg-background">
-      <AgentSidebar
-        project={project}
-        projects={projects}
-        agents={agents}
-        selectedAgentId={selectedAgent?.id ?? null}
-        onSelectAgent={handleSelectAgent}
-        onNewAgent={handleNew}
-        onDeleteAgent={handleDeleteAgent}
-        onBrowseCatalog={handleBrowseCatalog}
-      />
+      {/* Mobile sidebar overlay */}
+      {sidebarOpen && (
+        <div className="fixed inset-0 z-40 md:hidden" aria-hidden="true" onClick={() => setSidebarOpen(false)}>
+          <div className="absolute inset-0 bg-background/80" />
+        </div>
+      )}
+
+      {/* Sidebar — always visible on md+, slide-in overlay on mobile */}
+      <div
+        className={`fixed inset-y-0 left-0 z-50 w-64 transition-transform duration-200 md:static md:translate-x-0 ${
+          sidebarOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <AgentSidebar
+          project={project}
+          projects={projects}
+          agents={agents}
+          selectedAgentId={selectedAgent?.id ?? null}
+          onSelectAgent={handleSelectAgent}
+          onNewAgent={handleNew}
+          onDeleteAgent={handleDeleteAgent}
+          onBrowseCatalog={handleBrowseCatalog}
+        />
+      </div>
 
       <div className="flex-1 flex flex-col min-w-0">
         {selectedAgent ? (
           <>
-            <ChatHeader agent={selectedAgent} />
+            <ChatHeader agent={selectedAgent} onMenuToggle={() => setSidebarOpen(!sidebarOpen)} />
             <div className="flex-1 min-h-0">
               <ChatPanel
                 agent={selectedAgent}
@@ -132,7 +148,7 @@ export default function AgentDashboard({
             </div>
           </>
         ) : (
-          <WelcomePanel onNewAgent={handleNew} />
+          <WelcomePanel onNewAgent={handleNew} onMenuToggle={() => setSidebarOpen(!sidebarOpen)} />
         )}
       </div>
 

--- a/assets/react-components/ChatHeader.tsx
+++ b/assets/react-components/ChatHeader.tsx
@@ -1,13 +1,21 @@
+import { Menu } from "lucide-react";
 import { Badge } from "./components/ui/badge";
+import { Button } from "./components/ui/button";
 import { type Agent, statusVariant } from "./types";
 
 interface ChatHeaderProps {
   agent: Agent;
+  onMenuToggle?: () => void;
 }
 
-export default function ChatHeader({ agent }: ChatHeaderProps) {
+export default function ChatHeader({ agent, onMenuToggle }: ChatHeaderProps) {
   return (
     <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
+      {onMenuToggle && (
+        <Button variant="ghost" size="icon" className="md:hidden" aria-label="Open menu" onClick={onMenuToggle}>
+          <Menu className="h-5 w-5" />
+        </Button>
+      )}
       <h2 className="text-lg font-semibold">{agent.name}</h2>
       <Badge variant={statusVariant(agent.status)}>{agent.status}</Badge>
     </div>

--- a/assets/react-components/SchedulesPage.tsx
+++ b/assets/react-components/SchedulesPage.tsx
@@ -317,65 +317,67 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
             <p className="text-sm mt-1">Create a schedule to automatically send messages to agents.</p>
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Label</TableHead>
-                <TableHead>Agent</TableHead>
-                <TableHead>Schedule</TableHead>
-                <TableHead>Last Run</TableHead>
-                <TableHead>Enabled</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {tasks.map((task) => (
-                <TableRow key={task.id} className={!task.enabled ? "opacity-50" : ""}>
-                  <TableCell className="font-medium">{task.label}</TableCell>
-                  <TableCell>{task.agent_name}</TableCell>
-                  <TableCell className="text-sm text-muted-foreground">
-                    {task.schedule_type === "recurring" && task.cron_expression
-                      ? describeCron(task.cron_expression)
-                      : task.scheduled_at
-                        ? new Date(task.scheduled_at).toLocaleString()
-                        : "—"}
-                  </TableCell>
-                  <TableCell className="text-sm text-muted-foreground">
-                    {task.last_run_at ? timeAgo(task.last_run_at) : "Never"}
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      variant={task.enabled ? "default" : "outline"}
-                      size="sm"
-                      className="h-7 text-xs"
-                      onClick={() => handleToggle(task)}
-                    >
-                      {task.enabled ? "On" : "Off"}
-                    </Button>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <Button variant="ghost" size="sm" onClick={() => handleRunNow(task)} aria-label="Run now">
-                        <Play className="h-4 w-4" />
-                      </Button>
-                      <Button variant="ghost" size="sm" onClick={() => openEdit(task)} aria-label="Edit">
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setDeleteId(task.id)}
-                        aria-label="Delete"
-                        className="text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </TableCell>
+          <div className="overflow-x-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Label</TableHead>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Schedule</TableHead>
+                  <TableHead>Last Run</TableHead>
+                  <TableHead>Enabled</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {tasks.map((task) => (
+                  <TableRow key={task.id} className={!task.enabled ? "opacity-50" : ""}>
+                    <TableCell className="font-medium">{task.label}</TableCell>
+                    <TableCell>{task.agent_name}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {task.schedule_type === "recurring" && task.cron_expression
+                        ? describeCron(task.cron_expression)
+                        : task.scheduled_at
+                          ? new Date(task.scheduled_at).toLocaleString()
+                          : "—"}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {task.last_run_at ? timeAgo(task.last_run_at) : "Never"}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant={task.enabled ? "default" : "outline"}
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => handleToggle(task)}
+                      >
+                        {task.enabled ? "On" : "Off"}
+                      </Button>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button variant="ghost" size="sm" onClick={() => handleRunNow(task)} aria-label="Run now">
+                          <Play className="h-4 w-4" />
+                        </Button>
+                        <Button variant="ghost" size="sm" onClick={() => openEdit(task)} aria-label="Edit">
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setDeleteId(task.id)}
+                          aria-label="Delete"
+                          className="text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </div>
 
@@ -541,7 +543,7 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
                           type="button"
                           variant={form.days_of_week.includes(i + 1) ? "default" : "outline"}
                           size="sm"
-                          className="h-8 w-10 text-xs"
+                          className="h-10 w-11 text-xs"
                           onClick={() => toggleDay(i + 1)}
                         >
                           {label}

--- a/assets/react-components/WelcomePanel.tsx
+++ b/assets/react-components/WelcomePanel.tsx
@@ -1,15 +1,26 @@
+import { Menu } from "lucide-react";
 import { Button } from "./components/ui/button";
 
 interface WelcomePanelProps {
   onNewAgent: () => void;
+  onMenuToggle?: () => void;
 }
 
-export default function WelcomePanel({ onNewAgent }: WelcomePanelProps) {
+export default function WelcomePanel({ onNewAgent, onMenuToggle }: WelcomePanelProps) {
   return (
-    <div className="flex flex-col items-center justify-center h-full text-center p-8">
-      <h2 className="text-2xl font-bold mb-2">Shire</h2>
-      <p className="text-muted-foreground mb-6">Select an agent from the sidebar to start chatting.</p>
-      <Button onClick={onNewAgent}>+ New Agent</Button>
+    <div className="flex flex-col h-full">
+      {onMenuToggle && (
+        <div className="px-4 py-3 border-b border-border md:hidden">
+          <Button variant="ghost" size="icon" aria-label="Open menu" onClick={onMenuToggle}>
+            <Menu className="h-5 w-5" />
+          </Button>
+        </div>
+      )}
+      <div className="flex flex-col items-center justify-center flex-1 text-center p-8">
+        <h2 className="text-2xl font-bold mb-2">Shire</h2>
+        <p className="text-muted-foreground mb-6">Select an agent from the sidebar to start chatting.</p>
+        <Button onClick={onNewAgent}>+ New Agent</Button>
+      </div>
     </div>
   );
 }

--- a/assets/test/AgentDashboard.test.tsx
+++ b/assets/test/AgentDashboard.test.tsx
@@ -122,6 +122,31 @@ describe("AgentDashboard", () => {
     expect(pushEvent).toHaveBeenCalledWith("get-catalog-agent", { name: "frontend-developer" });
   });
 
+  it("renders menu toggle button in chat header", () => {
+    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={agents[0]} />);
+    expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
+  });
+
+  it("renders menu toggle button in welcome panel", () => {
+    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
+    expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
+  });
+
+  it("shows backdrop when menu toggle is clicked", async () => {
+    const { container } = render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(container.querySelector(".fixed.inset-0.z-40")).toBeInTheDocument();
+  });
+
+  it("closes sidebar backdrop when clicked", async () => {
+    const { container } = render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    const backdrop = container.querySelector(".fixed.inset-0.z-40");
+    expect(backdrop).toBeInTheDocument();
+    await userEvent.click(backdrop!);
+    expect(container.querySelector(".fixed.inset-0.z-40")).not.toBeInTheDocument();
+  });
+
   it("pre-fills agent form when catalogSelectedAgent is provided", () => {
     render(
       <AgentDashboard


### PR DESCRIPTION
## Summary

- **Collapsible sidebar on mobile**: The `AgentDashboard` sidebar is now hidden by default on screens below `md` (768px). A hamburger menu button appears in the `ChatHeader` and `WelcomePanel` to toggle it as a slide-in overlay with a backdrop. On desktop (`md+`), the sidebar remains permanently visible as before.
- **Scrollable schedules table**: The 6-column table in `SchedulesPage` is wrapped in `overflow-x-auto` so it scrolls horizontally on narrow viewports instead of overflowing.
- **Larger touch targets**: Day-of-week picker buttons increased from 32x40px (`h-8 w-10`) to 40x44px (`h-10 w-11`) to meet the 44px minimum touch target guideline.

## Test plan

- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] Prettier: all formatted
- [x] Vitest: 192/192 tests passing
- [x] Elixir: compiles clean
- [ ] Manual: resize browser below 768px — sidebar should hide, hamburger appears
- [ ] Manual: tap hamburger — sidebar slides in, backdrop visible
- [ ] Manual: tap backdrop or select agent — sidebar closes
- [ ] Manual: resize above 768px — sidebar always visible, no hamburger
- [ ] Manual: view SchedulesPage on narrow viewport — table scrolls horizontally
- [ ] Manual: day-of-week buttons should be comfortably tappable on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)