### PR TITLE
Add iOS safe area inset support

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -112,7 +112,7 @@ export default function AgentDashboard({
   };
 
   return (
-    <div className="flex h-screen bg-background">
+    <div className="flex h-dvh bg-background pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]">
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div className="fixed inset-0 z-40 md:hidden" aria-hidden="true" onClick={() => setSidebarOpen(false)}>
@@ -122,7 +122,7 @@ export default function AgentDashboard({
 
       {/* Sidebar — always visible on md+, slide-in overlay on mobile */}
       <div
-        className={`fixed inset-y-0 left-0 z-50 w-64 transition-transform duration-200 md:static md:translate-x-0 ${
+        className={`fixed top-[env(safe-area-inset-top)] bottom-[env(safe-area-inset-bottom)] left-[env(safe-area-inset-left)] z-50 w-64 transition-transform duration-200 md:static md:inset-auto md:translate-x-0 ${
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >

--- a/assets/react-components/components/AppLayout.tsx
+++ b/assets/react-components/components/AppLayout.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <main className="px-4 py-8 sm:px-6 lg:px-8">
+    <main className="pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] sm:pl-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] lg:pl-[max(2rem,env(safe-area-inset-left))] lg:pr-[max(2rem,env(safe-area-inset-right))]">
       <div className="mx-auto max-w-5xl">{children}</div>
     </main>
   );

--- a/assets/test/AgentDashboard.test.tsx
+++ b/assets/test/AgentDashboard.test.tsx
@@ -147,6 +147,20 @@ describe("AgentDashboard", () => {
     expect(container.querySelector(".fixed.inset-0.z-40")).not.toBeInTheDocument();
   });
 
+  it("applies safe area insets to root container", () => {
+    const { container } = render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("safe-area-inset-top");
+    expect(root.className).toContain("safe-area-inset-bottom");
+  });
+
+  it("uses dvh for viewport height", () => {
+    const { container } = render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("h-dvh");
+    expect(root.className).not.toContain("h-screen");
+  });
+
   it("pre-fills agent form when catalogSelectedAgent is provided", () => {
     render(
       <AgentDashboard

--- a/assets/test/AppLayout.test.tsx
+++ b/assets/test/AppLayout.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import AppLayout from "../react-components/components/AppLayout";
+
+describe("AppLayout", () => {
+  it("renders children", () => {
+    render(<AppLayout>Hello World</AppLayout>);
+    expect(screen.getByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("applies safe area insets", () => {
+    const { container } = render(<AppLayout>content</AppLayout>);
+    const main = container.querySelector("main") as HTMLElement;
+    expect(main.className).toContain("safe-area-inset-top");
+    expect(main.className).toContain("safe-area-inset-bottom");
+  });
+});

--- a/lib/shire_web/components/layouts/root.html.heex
+++ b/lib/shire_web/components/layouts/root.html.heex
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <.live_title default="Shire" suffix=" · Phoenix Framework">
       {assigns[:page_title]}


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to viewport meta tag to enable safe area insets on iOS
- Apply `env(safe-area-inset-*)` padding to `AgentDashboard` root container and mobile sidebar
- Apply safe area insets with `max()` fallbacks to `AppLayout` for non-dashboard pages
- Switch `h-screen` to `h-dvh` for proper dynamic viewport height on mobile
- Add test coverage for safe area insets and AppLayout component

## Test plan
- [ ] Verify on iOS Safari (notched device or simulator) that content is not obscured by status bar/notch
- [ ] Verify mobile sidebar does not render behind the status bar
- [ ] Verify non-dashboard pages (settings, schedules) have proper safe area padding
- [ ] Verify desktop layout is unchanged (env() returns 0 on non-notched devices)
- [ ] All frontend tests pass (`bun run test` — 200 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)