### PR TITLE
add backdrop blur to mobile sidebar overlay

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -116,7 +116,7 @@ export default function AgentDashboard({
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div className="fixed inset-0 z-40 md:hidden" aria-hidden="true" onClick={() => setSidebarOpen(false)}>
-          <div className="absolute inset-0 bg-background/80" />
+          <div className="absolute inset-0 bg-background/60 backdrop-blur-sm" />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Add `backdrop-blur-sm` to the mobile sidebar overlay for a frosted glass effect
- Reduce overlay opacity from 80% to 60% so the blur is more visible

## Test plan
- [ ] Open on mobile viewport (or resize to < 768px)
- [ ] Toggle the sidebar open and verify the backdrop has a blur effect
- [ ] Verify sidebar still closes when tapping the backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)