### PR TITLE
Improve layout hierarchy: sidebar, agent detail, project cards

### DIFF
--- a/assets/react-components/AgentShow.tsx
+++ b/assets/react-components/AgentShow.tsx
@@ -4,7 +4,6 @@ import { Button, buttonVariants } from "./components/ui/button";
 import { Card, CardContent } from "./components/ui/card";
 import {
   AlertDialog,
-  AlertDialogTrigger,
   AlertDialogContent,
   AlertDialogHeader,
   AlertDialogFooter,
@@ -13,11 +12,19 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from "./components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./components/ui/dropdown-menu";
 import AppLayout from "./components/AppLayout";
 import { navigate } from "./lib/navigate";
 import AgentForm from "./AgentForm";
-import { ChevronLeft, Pencil } from "lucide-react";
+import { ChevronLeft, MoreHorizontal, Pencil } from "lucide-react";
 import { type Agent, statusVariant, harnessLabel } from "./types";
+
+const isRunning = (status: string) => status === "active" || status === "starting" || status === "bootstrapping";
 
 export default function AgentShow({
   project,
@@ -29,6 +36,8 @@ export default function AgentShow({
   pushEvent: (event: string, payload: Record<string, unknown>) => void;
 }) {
   const [editOpen, setEditOpen] = React.useState(false);
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
+  const [restartOpen, setRestartOpen] = React.useState(false);
 
   return (
     <AppLayout>
@@ -46,93 +55,74 @@ export default function AgentShow({
               <Pencil className="h-4 w-4 mr-1" />
               Edit
             </Button>
-            {(agent.status === "active" || agent.status === "starting" || agent.status === "bootstrapping") && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button variant="outline">Restart Agent</Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Restart Agent</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will stop the current runner and restart the agent. The VM will be preserved.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction onClick={() => pushEvent("restart-agent", {})}>Restart</AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            )}
-            {agent.status !== "active" && agent.status !== "starting" && agent.status !== "bootstrapping" && (
+            {isRunning(agent.status) ? (
+              <Button variant="outline" onClick={() => setRestartOpen(true)}>
+                Restart Agent
+              </Button>
+            ) : (
               <Button onClick={() => pushEvent("start-agent", {})}>Start Agent</Button>
             )}
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive">Delete Agent</Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete Agent</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will stop the agent and permanently remove its workspace directory. This cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    className={buttonVariants({ variant: "destructive" })}
-                    onClick={() => pushEvent("delete-agent", {})}
-                  >
-                    Delete
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="More actions">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  Delete Agent
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
 
-        <Card>
-          <CardContent className="pt-6">
-            <dl className="divide-y divide-border">
-              <div className="py-3 grid grid-cols-3 gap-4">
-                <dt className="text-sm font-medium text-muted-foreground">Name</dt>
-                <dd className="text-sm col-span-2">{agent.name}</dd>
-              </div>
-              {agent.description && (
+        <div className="space-y-6">
+          <Card>
+            <CardContent className="pt-6">
+              <dl className="divide-y divide-border">
                 <div className="py-3 grid grid-cols-3 gap-4">
-                  <dt className="text-sm font-medium text-muted-foreground">Description</dt>
-                  <dd className="text-sm col-span-2">{agent.description}</dd>
+                  <dt className="text-sm font-medium text-muted-foreground">Name</dt>
+                  <dd className="text-sm col-span-2">{agent.name}</dd>
                 </div>
-              )}
-              <div className="py-3 grid grid-cols-3 gap-4">
-                <dt className="text-sm font-medium text-muted-foreground">Model</dt>
-                <dd className="text-sm col-span-2">{agent.model || "Not set"}</dd>
-              </div>
-              {agent.harness && (
+                {agent.description && (
+                  <div className="py-3 grid grid-cols-3 gap-4">
+                    <dt className="text-sm font-medium text-muted-foreground">Description</dt>
+                    <dd className="text-sm col-span-2">{agent.description}</dd>
+                  </div>
+                )}
                 <div className="py-3 grid grid-cols-3 gap-4">
-                  <dt className="text-sm font-medium text-muted-foreground">Harness</dt>
+                  <dt className="text-sm font-medium text-muted-foreground">Model</dt>
+                  <dd className="text-sm col-span-2">{agent.model || "Not set"}</dd>
+                </div>
+                {agent.harness && (
+                  <div className="py-3 grid grid-cols-3 gap-4">
+                    <dt className="text-sm font-medium text-muted-foreground">Harness</dt>
+                    <dd className="text-sm col-span-2">
+                      <Badge variant="outline">{harnessLabel(agent.harness)}</Badge>
+                    </dd>
+                  </div>
+                )}
+                <div className="py-3 grid grid-cols-3 gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">Status</dt>
                   <dd className="text-sm col-span-2">
-                    <Badge variant="outline">{harnessLabel(agent.harness)}</Badge>
+                    <Badge variant={statusVariant(agent.status)}>{agent.status}</Badge>
                   </dd>
                 </div>
-              )}
-              <div className="py-3 grid grid-cols-3 gap-4">
-                <dt className="text-sm font-medium text-muted-foreground">Status</dt>
-                <dd className="text-sm col-span-2">
-                  <Badge variant={statusVariant(agent.status)}>{agent.status}</Badge>
-                </dd>
-              </div>
-              <div className="py-3 grid grid-cols-3 gap-4">
-                <dt className="text-sm font-medium text-muted-foreground">System Prompt</dt>
-                <dd className="text-sm col-span-2">
-                  <pre className="whitespace-pre-wrap font-sans">{agent.system_prompt || "Not set"}</pre>
-                </dd>
-              </div>
-            </dl>
-          </CardContent>
-        </Card>
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-sm font-medium text-muted-foreground mb-3">System Prompt</h3>
+              <pre className="whitespace-pre-wrap font-sans text-sm">{agent.system_prompt || "Not set"}</pre>
+            </CardContent>
+          </Card>
+        </div>
       </div>
 
       <AgentForm
@@ -142,6 +132,41 @@ export default function AgentShow({
         pushEvent={pushEvent}
         onClose={() => setEditOpen(false)}
       />
+
+      <AlertDialog open={restartOpen} onOpenChange={setRestartOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restart Agent</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will stop the current runner and restart the agent. The VM will be preserved.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => pushEvent("restart-agent", {})}>Restart</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Agent</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will stop the agent and permanently remove its workspace directory. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={() => pushEvent("delete-agent", {})}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </AppLayout>
   );
 }

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -126,49 +126,53 @@ export default function AgentSidebar({
         )}
       </div>
 
-      <div className="p-3 border-t border-border space-y-1">
-        <Button variant="outline" size="sm" className="w-full" onClick={onNewAgent}>
-          + New Agent
-        </Button>
-        <Button variant="outline" size="sm" className="w-full" onClick={onBrowseCatalog}>
-          Browse Catalog
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start gap-2 text-muted-foreground"
-          onClick={() => navigate(`/projects/${project.name}/details`)}
-        >
-          <FileText className="h-4 w-4" />
-          Project Details
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start gap-2 text-muted-foreground"
-          onClick={() => navigate(`/projects/${project.name}/schedules`)}
-        >
-          <Clock className="h-4 w-4" />
-          Schedules
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start gap-2 text-muted-foreground"
-          onClick={() => navigate(`/projects/${project.name}/settings`)}
-        >
-          <Settings className="h-4 w-4" />
-          Settings
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start gap-2 text-muted-foreground"
-          onClick={() => navigate(`/projects/${project.name}/shared`)}
-        >
-          <FolderOpen className="h-4 w-4" />
-          Shared Drive
-        </Button>
+      <div className="border-t border-border">
+        <div className="p-3 space-y-1.5">
+          <Button variant="outline" size="sm" className="w-full" onClick={onNewAgent}>
+            + New Agent
+          </Button>
+          <Button variant="outline" size="sm" className="w-full" onClick={onBrowseCatalog}>
+            Browse Catalog
+          </Button>
+        </div>
+        <div className="border-t border-border px-3 py-2 space-y-0.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 text-muted-foreground"
+            onClick={() => navigate(`/projects/${project.name}/details`)}
+          >
+            <FileText className="h-4 w-4" />
+            Project Details
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 text-muted-foreground"
+            onClick={() => navigate(`/projects/${project.name}/schedules`)}
+          >
+            <Clock className="h-4 w-4" />
+            Schedules
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 text-muted-foreground"
+            onClick={() => navigate(`/projects/${project.name}/settings`)}
+          >
+            <Settings className="h-4 w-4" />
+            Settings
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 text-muted-foreground"
+            onClick={() => navigate(`/projects/${project.name}/shared`)}
+          >
+            <FolderOpen className="h-4 w-4" />
+            Shared Drive
+          </Button>
+        </div>
       </div>
 
       <AlertDialog

--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -21,8 +21,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./components/ui/dropdown-menu";
 import AppLayout from "./components/AppLayout";
 import { navigate } from "./lib/navigate";
+import { MoreHorizontal } from "lucide-react";
 import type { Project } from "./types";
 
 interface ProjectDashboardProps {
@@ -101,36 +108,43 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
                 <CardContent className="pt-6">
                   <div className="flex items-center justify-between">
                     <h3 className="font-semibold text-lg">{project.name}</h3>
-                    <Badge variant={projectStatusVariant(project.status)}>{project.status}</Badge>
-                  </div>
-                  <div className="mt-4 flex justify-end gap-2">
-                    {(project.status === "stopped" ||
-                      project.status === "error" ||
-                      project.status === "unreachable") && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={restartingId === project.id}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setRestartingId(project.id);
-                          pushEvent("restart-project", { id: project.id });
-                        }}
-                      >
-                        {restartingId === project.id ? "Restarting..." : "Restart"}
-                      </Button>
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-destructive hover:text-destructive"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setDeleteProject(project);
-                      }}
-                    >
-                      Delete
-                    </Button>
+                    <div className="flex items-center gap-2">
+                      <Badge variant={projectStatusVariant(project.status)}>{project.status}</Badge>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            aria-label={`${project.name} actions`}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {(project.status === "stopped" ||
+                            project.status === "error" ||
+                            project.status === "unreachable") && (
+                            <DropdownMenuItem
+                              disabled={restartingId === project.id}
+                              onClick={() => {
+                                setRestartingId(project.id);
+                                pushEvent("restart-project", { id: project.id });
+                              }}
+                            >
+                              {restartingId === project.id ? "Restarting..." : "Restart"}
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => setDeleteProject(project)}
+                          >
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
                   </div>
                 </CardContent>
               </Card>

--- a/assets/test/AgentShow.test.tsx
+++ b/assets/test/AgentShow.test.tsx
@@ -21,6 +21,10 @@ const agent: Agent = {
   harness: "claude_code",
 };
 
+async function openMoreMenu() {
+  await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+}
+
 describe("AgentShow", () => {
   it("renders agent details", () => {
     render(<AgentShow project={{ id: "p1", name: "test-project" }} agent={agent} pushEvent={vi.fn()} />);
@@ -41,7 +45,7 @@ describe("AgentShow", () => {
     expect(screen.getAllByText("Not set")).toHaveLength(2);
   });
 
-  it("shows Start and Delete buttons for created agent", () => {
+  it("shows Start button for created agent", () => {
     render(
       <AgentShow
         project={{ id: "p1", name: "test-project" }}
@@ -50,10 +54,21 @@ describe("AgentShow", () => {
       />,
     );
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
+  });
+
+  it("shows Delete Agent in more menu", async () => {
+    render(
+      <AgentShow
+        project={{ id: "p1", name: "test-project" }}
+        agent={{ ...agent, status: "created" }}
+        pushEvent={vi.fn()}
+      />,
+    );
+    await openMoreMenu();
     expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
-  it("shows Restart and Delete buttons for active agent", () => {
+  it("shows Restart button for active agent", () => {
     render(
       <AgentShow
         project={{ id: "p1", name: "test-project" }}
@@ -62,7 +77,6 @@ describe("AgentShow", () => {
       />,
     );
     expect(screen.getByText("Restart Agent")).toBeInTheDocument();
-    expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
   it("calls pushEvent with start-agent", async () => {
@@ -92,7 +106,7 @@ describe("AgentShow", () => {
     expect(pushEvent).toHaveBeenCalledWith("restart-agent", {});
   });
 
-  it("calls pushEvent with delete-agent after confirming", async () => {
+  it("calls pushEvent with delete-agent after confirming via more menu", async () => {
     const pushEvent = vi.fn();
     render(
       <AgentShow
@@ -101,12 +115,13 @@ describe("AgentShow", () => {
         pushEvent={pushEvent}
       />,
     );
+    await openMoreMenu();
     await userEvent.click(screen.getByText("Delete Agent"));
     await userEvent.click(screen.getByText("Delete"));
     expect(pushEvent).toHaveBeenCalledWith("delete-agent", {});
   });
 
-  it("shows Start and Delete buttons for crashed agent", () => {
+  it("shows Start button for crashed agent", () => {
     render(
       <AgentShow
         project={{ id: "p1", name: "test-project" }}
@@ -115,10 +130,9 @@ describe("AgentShow", () => {
       />,
     );
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
-    expect(screen.getByText("Delete Agent")).toBeInTheDocument();
   });
 
-  it("shows Restart and Delete buttons for bootstrapping agent", () => {
+  it("shows Restart button for bootstrapping agent", () => {
     render(
       <AgentShow
         project={{ id: "p1", name: "test-project" }}
@@ -127,11 +141,10 @@ describe("AgentShow", () => {
       />,
     );
     expect(screen.getByText("Restart Agent")).toBeInTheDocument();
-    expect(screen.getByText("Delete Agent")).toBeInTheDocument();
     expect(screen.queryByText("Start Agent")).not.toBeInTheDocument();
   });
 
-  it("shows Delete button for idle agent", () => {
+  it("shows Start button for idle agent", () => {
     render(
       <AgentShow
         project={{ id: "p1", name: "test-project" }}
@@ -139,7 +152,6 @@ describe("AgentShow", () => {
         pushEvent={vi.fn()}
       />,
     );
-    expect(screen.getByText("Delete Agent")).toBeInTheDocument();
     expect(screen.getByText("Start Agent")).toBeInTheDocument();
   });
 
@@ -152,6 +164,7 @@ describe("AgentShow", () => {
         pushEvent={pushEvent}
       />,
     );
+    await openMoreMenu();
     await userEvent.click(screen.getByText("Delete Agent"));
     await userEvent.click(screen.getByText("Delete"));
     expect(pushEvent).toHaveBeenCalledWith("delete-agent", {});
@@ -180,5 +193,11 @@ describe("AgentShow", () => {
     await userEvent.click(editBtn);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Edit Agent")).toBeInTheDocument();
+  });
+
+  it("renders system prompt in its own card", () => {
+    render(<AgentShow project={{ id: "p1", name: "test-project" }} agent={agent} pushEvent={vi.fn()} />);
+    expect(screen.getByText("System Prompt")).toBeInTheDocument();
+    expect(screen.getByText("You are a helpful assistant.")).toBeInTheDocument();
   });
 });

--- a/assets/test/ProjectDashboard.test.tsx
+++ b/assets/test/ProjectDashboard.test.tsx
@@ -47,15 +47,17 @@ describe("ProjectDashboard", () => {
     expect(screen.getByText("unreachable")).toBeInTheDocument();
   });
 
-  it("shows Restart button for unreachable projects", () => {
+  it("shows Restart option in menu for unreachable projects", async () => {
     const unreachableProjects: Project[] = [{ id: "p11", name: "unreachable-proj", status: "unreachable" }];
     render(<ProjectDashboard projects={unreachableProjects} pushEvent={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     expect(screen.getByText("Restart")).toBeInTheDocument();
   });
 
-  it("does not show Restart button for idle projects", () => {
+  it("does not show Restart option for idle projects", async () => {
     const idleProjects: Project[] = [{ id: "p12", name: "idle-proj", status: "idle" }];
     render(<ProjectDashboard projects={idleProjects} pushEvent={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     expect(screen.queryByText("Restart")).not.toBeInTheDocument();
   });
 
@@ -89,10 +91,12 @@ describe("ProjectDashboard", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows delete confirmation when clicking Delete on a project card", async () => {
+  it("shows delete confirmation when clicking Delete in card menu", async () => {
     render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
-    const deleteButtons = screen.getAllByText("Delete");
-    await userEvent.click(deleteButtons[0]);
+    // Open the first card's dropdown menu
+    const menuButtons = screen.getAllByRole("button", { name: /actions/ });
+    await userEvent.click(menuButtons[0]);
+    await userEvent.click(screen.getByText("Delete"));
     expect(screen.getByText(/destroy the VM and all its data/)).toBeInTheDocument();
   });
 
@@ -100,9 +104,10 @@ describe("ProjectDashboard", () => {
     const pushEvent = vi.fn();
     render(<ProjectDashboard projects={projects} pushEvent={pushEvent} />);
 
-    // Click Delete on first project card
-    const deleteButtons = screen.getAllByText("Delete");
-    await userEvent.click(deleteButtons[0]);
+    // Open the first card's dropdown menu and click Delete
+    const menuButtons = screen.getAllByRole("button", { name: /actions/ });
+    await userEvent.click(menuButtons[0]);
+    await userEvent.click(screen.getByText("Delete"));
 
     // Confirm in alert dialog
     const confirmDelete = screen.getAllByText("Delete").find((el) => el.closest("[role='alertdialog']"));
@@ -111,28 +116,33 @@ describe("ProjectDashboard", () => {
     expect(pushEvent).toHaveBeenCalledWith("delete-project", { id: "p1" });
   });
 
-  it("shows Restart button for stopped projects", () => {
+  it("shows Restart option in menu for stopped projects", async () => {
     const stoppedProjects: Project[] = [{ id: "p5", name: "stopped-proj", status: "stopped" }];
     render(<ProjectDashboard projects={stoppedProjects} pushEvent={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     expect(screen.getByText("Restart")).toBeInTheDocument();
   });
 
-  it("shows Restart button for error projects", () => {
+  it("shows Restart option in menu for error projects", async () => {
     const errorProjects: Project[] = [{ id: "p6", name: "error-proj", status: "error" }];
     render(<ProjectDashboard projects={errorProjects} pushEvent={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     expect(screen.getByText("Restart")).toBeInTheDocument();
   });
 
-  it("does not show Restart button for running projects", () => {
+  it("does not show Restart option for running projects", async () => {
     render(<ProjectDashboard projects={projects} pushEvent={vi.fn()} />);
+    const menuButtons = screen.getAllByRole("button", { name: /actions/ });
+    await userEvent.click(menuButtons[0]);
     expect(screen.queryByText("Restart")).not.toBeInTheDocument();
   });
 
-  it("calls pushEvent with restart-project when clicking Restart", async () => {
+  it("calls pushEvent with restart-project when clicking Restart in menu", async () => {
     const pushEvent = vi.fn();
     const stoppedProjects: Project[] = [{ id: "p7", name: "restart-me", status: "stopped" }];
     render(<ProjectDashboard projects={stoppedProjects} pushEvent={pushEvent} />);
 
+    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     await userEvent.click(screen.getByText("Restart"));
     expect(pushEvent).toHaveBeenCalledWith("restart-project", { id: "p7" });
   });
@@ -142,7 +152,10 @@ describe("ProjectDashboard", () => {
     const stoppedProjects: Project[] = [{ id: "p8", name: "restarting-proj", status: "stopped" }];
     render(<ProjectDashboard projects={stoppedProjects} pushEvent={pushEvent} />);
 
+    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     await userEvent.click(screen.getByText("Restart"));
+    // Reopen menu to check the text
+    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     expect(screen.getByText("Restarting...")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- **Sidebar footer**: Split into two groups separated by a border — action buttons (New Agent, Browse Catalog) above, navigation links (Project Details, Schedules, Settings, Shared Drive) below
- **AgentShow**: Delete moved into "..." dropdown menu; system prompt split into its own card; all AlertDialogs use consistent controlled state pattern
- **ProjectDashboard cards**: Delete and Restart moved into per-card "..." dropdown menus. Cards show just name + status badge

## Context

From design critique: the sidebar had 6 items at same visual weight with no grouping; AgentShow had 3-4 action buttons competing (Edit, Restart, Delete all equally prominent); project cards had an exposed Delete button on every card which felt aggressive.

## Test plan

- [x] 205 frontend tests pass
- [x] 305 backend tests pass
- [x] TypeScript, ESLint, Prettier all clean
- [ ] Visual: sidebar footer shows clear separation between actions and nav
- [ ] Visual: AgentShow header has Edit + Start/Restart as primary, "..." for Delete
- [ ] Visual: project cards show clean name + badge + menu icon
- [ ] Functional: dropdown menus open/close correctly, card click-through still navigates

🤖 Generated with [Claude Code](https://claude.com/claude-code)