### PR TITLE
Polish: fix inconsistent icons, inputs, and typography

### DIFF
--- a/assets/react-components/ActivityLog.tsx
+++ b/assets/react-components/ActivityLog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Button } from "./components/ui/button";
+import { Clock } from "lucide-react";
 import type { InterAgentMessage } from "./types";
 
 interface ActivityLogProps {
@@ -51,7 +52,7 @@ export default function ActivityLog({ messages, hasMore, pushEvent }: ActivityLo
               <span>
                 {msg.trigger === "scheduled_task" ? (
                   <>
-                    <span className="mr-1">&#128339;</span>
+                    <Clock className="inline h-3 w-3 mr-1" />
                     <span className="font-medium text-foreground">{msg.task_label}</span>
                   </>
                 ) : (

--- a/assets/react-components/AgentShow.tsx
+++ b/assets/react-components/AgentShow.tsx
@@ -119,7 +119,9 @@ export default function AgentShow({
           <Card>
             <CardContent className="pt-6">
               <h3 className="text-sm font-medium text-muted-foreground mb-3">System Prompt</h3>
-              <pre className="whitespace-pre-wrap font-sans text-sm">{agent.system_prompt || "Not set"}</pre>
+              <pre className="whitespace-pre-wrap font-mono text-sm leading-relaxed">
+                {agent.system_prompt || "Not set"}
+              </pre>
             </CardContent>
           </Card>
         </div>

--- a/assets/react-components/SchedulesPage.tsx
+++ b/assets/react-components/SchedulesPage.tsx
@@ -317,7 +317,7 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
             <p className="text-sm mt-1">Create a schedule to automatically send messages to agents.</p>
           </div>
         ) : (
-          <div className="overflow-x-auto rounded-md border">
+          <div className="overflow-x-auto rounded-md border tabular-nums">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -433,27 +433,23 @@ export default function SchedulesPage({ project, agents, tasks, pushEvent }: Sch
 
             <div className="space-y-2">
               <Label>Type</Label>
-              <div className="flex gap-4">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="schedule_type"
-                    checked={form.schedule_type === "recurring"}
-                    onChange={() => updateForm("schedule_type", "recurring")}
-                    className="accent-primary"
-                  />
-                  <span className="text-sm">Recurring</span>
-                </label>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="schedule_type"
-                    checked={form.schedule_type === "once"}
-                    onChange={() => updateForm("schedule_type", "once")}
-                    className="accent-primary"
-                  />
-                  <span className="text-sm">Once</span>
-                </label>
+              <div className="flex gap-1">
+                <Button
+                  type="button"
+                  variant={form.schedule_type === "recurring" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => updateForm("schedule_type", "recurring")}
+                >
+                  Recurring
+                </Button>
+                <Button
+                  type="button"
+                  variant={form.schedule_type === "once" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => updateForm("schedule_type", "once")}
+                >
+                  Once
+                </Button>
               </div>
             </div>
 

--- a/assets/react-components/SharedDrive.tsx
+++ b/assets/react-components/SharedDrive.tsx
@@ -21,7 +21,7 @@ import {
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
 import AppLayout from "./components/AppLayout";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, Folder, File } from "lucide-react";
 import { navigate as navigateTo } from "./lib/navigate";
 
 export interface SharedDriveFile {
@@ -72,9 +72,11 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
   const [newFolderOpen, setNewFolderOpen] = React.useState(false);
   const [newFolderName, setNewFolderName] = React.useState("");
   const [deleteTarget, setDeleteTarget] = React.useState<SharedDriveFile | null>(null);
+  const [uploadError, setUploadError] = React.useState<string | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const navigate = (path: string) => {
+    setUploadError(null);
     pushEvent("navigate", { path });
   };
 
@@ -101,10 +103,14 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
     if (!file) return;
 
     if (file.size > MAX_UPLOAD_SIZE) {
-      alert(`File is too large (${formatSize(file.size)}). Maximum upload size is ${formatSize(MAX_UPLOAD_SIZE)}.`);
+      setUploadError(
+        `File is too large (${formatSize(file.size)}). Maximum upload size is ${formatSize(MAX_UPLOAD_SIZE)}.`,
+      );
       if (fileInputRef.current) fileInputRef.current.value = "";
       return;
     }
+
+    setUploadError(null);
 
     const reader = new FileReader();
     reader.onload = () => {
@@ -148,6 +154,8 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
           </div>
         </div>
 
+        {uploadError && <p className="text-sm text-destructive">{uploadError}</p>}
+
         {/* File Table */}
         <div className="rounded-md border">
           <Table>
@@ -175,12 +183,12 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
                           className="flex items-center gap-2 text-foreground h-auto p-0"
                           onClick={() => navigate("/" + file.path)}
                         >
-                          <span className="text-muted-foreground">📁</span>
+                          <Folder className="h-4 w-4 text-muted-foreground" />
                           {file.name}
                         </Button>
                       ) : (
                         <div className="flex items-center gap-2">
-                          <span className="text-muted-foreground">📄</span>
+                          <File className="h-4 w-4 text-muted-foreground" />
                           {file.name}
                         </div>
                       )}


### PR DESCRIPTION
## Summary

- **SharedDrive**: Replace emoji file icons (📁📄) with Lucide `Folder`/`File` for cross-platform consistency. Replace `alert()` with inline error message for upload size validation.
- **SchedulesPage**: Replace native `<input type="radio">` with shadcn Button toggle. Add `tabular-nums` to schedule table for aligned time values.
- **AgentShow**: Fix system prompt `<pre>` from `font-sans` to `font-mono leading-relaxed`.
- **ActivityLog**: Replace HTML entity clock emoji with Lucide `Clock` icon.

## Context

Final polish pass catching small inconsistencies: emoji icons that render differently across platforms, native HTML elements that should use shadcn components (per project guidelines), and a monospace/sans-serif mismatch on code-like content.

## Test plan

- [x] 205 frontend tests pass
- [x] 305 backend tests pass
- [x] TypeScript, ESLint, Prettier all clean
- [ ] Visual: SharedDrive shows Lucide folder/file icons instead of emoji
- [ ] Visual: Upload error appears inline (not browser alert) and clears on navigation
- [ ] Visual: Schedule type toggle uses button pair instead of radio inputs
- [ ] Visual: Schedule table numbers are tabular-aligned
- [ ] Visual: System prompt renders in monospace font

🤖 Generated with [Claude Code](https://claude.com/claude-code)