### PR TITLE
Add bidirectional attachment sending and receiving

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -145,6 +145,7 @@ export default function AgentDashboard({
             <div className="flex-1 min-h-0">
               <ChatPanel
                 agent={selectedAgent}
+                projectName={project.name}
                 messages={messages}
                 hasMore={hasMore}
                 loadingMore={loadingMore}

--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -1,11 +1,18 @@
 import * as React from "react";
 import { useLiveReact } from "live_react";
-import { Square } from "lucide-react";
+import { Paperclip, Square, X, FileIcon, Download } from "lucide-react";
 import { Badge } from "./components/ui/badge";
 import { Button } from "./components/ui/button";
 import { Textarea } from "./components/ui/textarea";
 import Markdown from "./components/Markdown";
 import { type Agent } from "./types";
+
+export interface Attachment {
+  id: string;
+  filename: string;
+  size: number;
+  content_type: string;
+}
 
 export interface Message {
   id?: number;
@@ -18,6 +25,68 @@ export interface Message {
   output?: string | null;
   is_error?: boolean;
   from_agent?: string;
+  attachments?: Attachment[];
+}
+
+interface PendingFile {
+  name: string;
+  size: number;
+  base64: string;
+  content_type: string;
+}
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function AttachmentDisplay({
+  attachments,
+  projectName,
+  agentId,
+}: {
+  attachments: Attachment[];
+  projectName: string;
+  agentId: string;
+}) {
+  if (!attachments.length) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {attachments.map((att) => {
+        const url = `/projects/${projectName}/agents/${agentId}/attachments/${att.id}/${att.filename}`;
+        const isImage = att.content_type.startsWith("image/");
+
+        return isImage ? (
+          <a
+            key={att.id}
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block rounded-md border border-border overflow-hidden hover:opacity-90 transition-opacity"
+          >
+            <img src={url} alt={att.filename} className="max-w-48 max-h-32 object-cover" />
+          </a>
+        ) : (
+          <a
+            key={att.id}
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-3 py-2 rounded-md border border-border hover:bg-muted/50 text-sm"
+          >
+            <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate max-w-40">{att.filename}</span>
+            <span className="text-xs text-muted-foreground whitespace-nowrap">({formatFileSize(att.size)})</span>
+            <Download className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          </a>
+        );
+      })}
+    </div>
+  );
 }
 
 function ToolCallMessage({ msg }: { msg: Message }) {
@@ -114,6 +183,7 @@ function SystemMessage({ msg }: { msg: Message }) {
 
 interface ChatPanelProps {
   agent: Agent;
+  projectName: string;
   messages?: Message[];
   hasMore?: boolean;
   loadingMore?: boolean;
@@ -122,6 +192,7 @@ interface ChatPanelProps {
 
 export default function ChatPanel({
   agent,
+  projectName,
   messages = [],
   hasMore = false,
   loadingMore = false,
@@ -130,6 +201,8 @@ export default function ChatPanel({
   const { handleEvent, removeHandleEvent } = useLiveReact();
   const [input, setInput] = React.useState("");
   const [streamingText, setStreamingText] = React.useState("");
+  const [pendingFiles, setPendingFiles] = React.useState<PendingFile[]>([]);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
@@ -215,11 +288,49 @@ export default function ChatPanel({
     }
   }, [hasMore, loadingMore, pushEvent, messages]);
 
+  const handleFileSelect = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+
+    Array.from(files).forEach((file) => {
+      if (file.size > MAX_FILE_SIZE) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = reader.result as string;
+        setPendingFiles((prev) => [
+          ...prev,
+          { name: file.name, size: file.size, base64, content_type: file.type || "application/octet-stream" },
+        ]);
+      };
+      reader.readAsDataURL(file);
+    });
+
+    // Reset so the same file can be selected again
+    e.target.value = "";
+  }, []);
+
+  const removePendingFile = React.useCallback((index: number) => {
+    setPendingFiles((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
   const handleSend = () => {
     const text = input.trim();
-    if (!text) return;
-    pushEvent("send-message", { text });
+    if (!text && pendingFiles.length === 0) return;
+
+    const payload: Record<string, unknown> = { text: text || "" };
+    if (pendingFiles.length > 0) {
+      payload.attachments = pendingFiles.map((f) => ({
+        name: f.name,
+        content: f.base64,
+        content_type: f.content_type,
+      }));
+    }
+
+    pushEvent("send-message", payload);
     setInput("");
+    setPendingFiles([]);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
@@ -273,9 +384,14 @@ export default function ChatPanel({
                   msg.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
                 }`}
               >
-                <Markdown className={msg.role === "user" ? "prose-invert" : ""} inverted={msg.role === "user"}>
-                  {msg.text ?? ""}
-                </Markdown>
+                {msg.text ? (
+                  <Markdown className={msg.role === "user" ? "prose-invert" : ""} inverted={msg.role === "user"}>
+                    {msg.text}
+                  </Markdown>
+                ) : null}
+                {msg.attachments && msg.attachments.length > 0 && (
+                  <AttachmentDisplay attachments={msg.attachments} projectName={projectName} agentId={agent.id} />
+                )}
               </div>
             </div>
           ),
@@ -297,7 +413,38 @@ export default function ChatPanel({
       </div>
       {agent.status === "active" ? (
         <div className="border-t border-border p-4">
+          <input ref={fileInputRef} type="file" multiple className="hidden" onChange={handleFileSelect} />
+          {pendingFiles.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-2">
+              {pendingFiles.map((file, i) => (
+                <div
+                  key={`${file.name}-${i}`}
+                  className="flex items-center gap-1.5 px-2 py-1 rounded-md border border-border bg-muted/50 text-xs"
+                >
+                  <FileIcon className="h-3 w-3 text-muted-foreground" />
+                  <span className="truncate max-w-32">{file.name}</span>
+                  <span className="text-muted-foreground">({formatFileSize(file.size)})</span>
+                  <button
+                    type="button"
+                    onClick={() => removePendingFile(i)}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="flex gap-2 items-end">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="shrink-0"
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Attach file"
+            >
+              <Paperclip className="h-4 w-4" />
+            </Button>
             <Textarea
               ref={textareaRef}
               value={input}

--- a/assets/test/ChatPanel.test.tsx
+++ b/assets/test/ChatPanel.test.tsx
@@ -25,13 +25,13 @@ const messages: Message[] = [
 
 describe("ChatPanel", () => {
   it("renders empty state when no messages", () => {
-    render(<ChatPanel agent={activeAgent} messages={[]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[]} pushEvent={vi.fn()} />);
     expect(screen.getByText(/Send a message to start working/)).toBeInTheDocument();
   });
 
   it("shows suggestion chips in empty state for active agent", async () => {
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={activeAgent} messages={[]} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[]} pushEvent={pushEvent} />);
     const chip = screen.getByText("What can you help me with?");
     expect(chip).toBeInTheDocument();
     await userEvent.click(chip);
@@ -40,18 +40,18 @@ describe("ChatPanel", () => {
 
   it("shows agent description in empty state when available", () => {
     const agentWithDesc = { ...activeAgent, description: "I help write tests." };
-    render(<ChatPanel agent={agentWithDesc} messages={[]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={agentWithDesc} projectName="test-project" messages={[]} pushEvent={vi.fn()} />);
     expect(screen.getByText("I help write tests.")).toBeInTheDocument();
   });
 
   it("renders messages", () => {
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
     expect(screen.getByText("Hello agent")).toBeInTheDocument();
     expect(screen.getByText("Hello human")).toBeInTheDocument();
   });
 
   it("shows input bar when agent is active", () => {
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
     expect(screen.getByPlaceholderText("Type a message...")).toBeInTheDocument();
     expect(screen.getByText("Send")).toBeInTheDocument();
   });
@@ -63,7 +63,7 @@ describe("ChatPanel", () => {
 
   it("sends message on click", async () => {
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={pushEvent} />);
 
     fireEvent.change(screen.getByPlaceholderText("Type a message..."), { target: { value: "test message" } });
     await userEvent.click(screen.getByText("Send"));
@@ -73,7 +73,7 @@ describe("ChatPanel", () => {
 
   it("sends message on enter key", async () => {
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={pushEvent} />);
 
     fireEvent.change(screen.getByPlaceholderText("Type a message..."), { target: { value: "test message" } });
     fireEvent.keyDown(screen.getByPlaceholderText("Type a message..."), { key: "Enter" });
@@ -83,7 +83,7 @@ describe("ChatPanel", () => {
 
   it("does not send on shift+enter (allows newline)", () => {
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={pushEvent} />);
 
     fireEvent.change(screen.getByPlaceholderText("Type a message..."), { target: { value: "line one" } });
     fireEvent.keyDown(screen.getByPlaceholderText("Type a message..."), { key: "Enter", shiftKey: true });
@@ -93,7 +93,7 @@ describe("ChatPanel", () => {
 
   it("does not send empty message", async () => {
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={pushEvent} />);
 
     await userEvent.click(screen.getByText("Send"));
 
@@ -111,14 +111,16 @@ describe("ChatPanel", () => {
       is_error: false,
       ts: "2026-03-17T00:00:02Z",
     };
-    render(<ChatPanel agent={activeAgent} messages={[toolMsg]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[toolMsg]} pushEvent={vi.fn()} />);
     expect(screen.getByText("read_file")).toBeInTheDocument();
     expect(screen.getByText("done")).toBeInTheDocument();
   });
 
   it("sends load-more with before param when scrolled to top", () => {
     const pushEvent = vi.fn();
-    const { container } = render(<ChatPanel agent={activeAgent} messages={messages} hasMore pushEvent={pushEvent} />);
+    const { container } = render(
+      <ChatPanel agent={activeAgent} projectName="test-project" messages={messages} hasMore pushEvent={pushEvent} />,
+    );
 
     const scrollContainer = container.querySelector(".overflow-y-auto")!;
     Object.defineProperty(scrollContainer, "scrollTop", { value: 0, writable: true });
@@ -129,7 +131,9 @@ describe("ChatPanel", () => {
 
   it("does not send load-more when no messages", () => {
     const pushEvent = vi.fn();
-    const { container } = render(<ChatPanel agent={activeAgent} messages={[]} hasMore pushEvent={pushEvent} />);
+    const { container } = render(
+      <ChatPanel agent={activeAgent} projectName="test-project" messages={[]} hasMore pushEvent={pushEvent} />,
+    );
 
     const scrollContainer = container.querySelector(".overflow-y-auto")!;
     Object.defineProperty(scrollContainer, "scrollTop", { value: 0, writable: true });
@@ -139,7 +143,16 @@ describe("ChatPanel", () => {
   });
 
   it("shows loading indicator when loadingMore", () => {
-    render(<ChatPanel agent={activeAgent} messages={messages} hasMore loadingMore pushEvent={vi.fn()} />);
+    render(
+      <ChatPanel
+        agent={activeAgent}
+        projectName="test-project"
+        messages={messages}
+        hasMore
+        loadingMore
+        pushEvent={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Loading older messages...")).toBeInTheDocument();
   });
 
@@ -157,7 +170,7 @@ describe("ChatPanel", () => {
       uploadTo: vi.fn(),
     });
 
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
 
     // Simulate text_delta events
     act(() => {
@@ -185,7 +198,7 @@ describe("ChatPanel", () => {
       from_agent: "researcher",
       ts: "2026-03-17T00:00:03Z",
     };
-    render(<ChatPanel agent={activeAgent} messages={[interAgentMsg]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[interAgentMsg]} pushEvent={vi.fn()} />);
     expect(screen.getByText("Message from researcher")).toBeInTheDocument();
     expect(screen.queryByText("Here is the analysis result")).not.toBeInTheDocument();
   });
@@ -198,7 +211,7 @@ describe("ChatPanel", () => {
       from_agent: "researcher",
       ts: "2026-03-17T00:00:03Z",
     };
-    render(<ChatPanel agent={activeAgent} messages={[interAgentMsg]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[interAgentMsg]} pushEvent={vi.fn()} />);
     await userEvent.click(screen.getByText("Message from researcher"));
     expect(screen.getByText("Here is the analysis result")).toBeInTheDocument();
   });
@@ -211,7 +224,7 @@ describe("ChatPanel", () => {
       from_agent: "researcher",
       ts: "2026-03-17T00:00:03Z",
     };
-    render(<ChatPanel agent={activeAgent} messages={[interAgentMsg]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[interAgentMsg]} pushEvent={vi.fn()} />);
     const toggle = screen.getByText("Message from researcher");
     await userEvent.click(toggle);
     expect(screen.getByText("Here is the analysis result")).toBeInTheDocument();
@@ -226,7 +239,7 @@ describe("ChatPanel", () => {
       text: "Your outbox message was invalid",
       ts: "2026-03-17T00:00:04Z",
     };
-    render(<ChatPanel agent={activeAgent} messages={[sysMsg]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[sysMsg]} pushEvent={vi.fn()} />);
     expect(screen.getByText("System notification")).toBeInTheDocument();
     expect(screen.queryByText("Your outbox message was invalid")).not.toBeInTheDocument();
   });
@@ -238,7 +251,7 @@ describe("ChatPanel", () => {
       text: "Your outbox message was invalid",
       ts: "2026-03-17T00:00:04Z",
     };
-    render(<ChatPanel agent={activeAgent} messages={[sysMsg]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[sysMsg]} pushEvent={vi.fn()} />);
     await userEvent.click(screen.getByText("System notification"));
     expect(screen.getByText("Your outbox message was invalid")).toBeInTheDocument();
   });
@@ -250,7 +263,7 @@ describe("ChatPanel", () => {
       text: "Your outbox message was invalid",
       ts: "2026-03-17T00:00:04Z",
     };
-    render(<ChatPanel agent={activeAgent} messages={[sysMsg]} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[sysMsg]} pushEvent={vi.fn()} />);
     const toggle = screen.getByText("System notification");
     await userEvent.click(toggle);
     expect(screen.getByText("Your outbox message was invalid")).toBeInTheDocument();
@@ -260,7 +273,7 @@ describe("ChatPanel", () => {
 
   it("shows stop button when agent is busy", () => {
     const busyAgent = { ...activeAgent, busy: true };
-    render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={busyAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
     expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     expect(screen.queryByText("Send")).not.toBeInTheDocument();
   });
@@ -268,20 +281,20 @@ describe("ChatPanel", () => {
   it("sends interrupt-agent event when stop button is clicked", async () => {
     const busyAgent = { ...activeAgent, busy: true };
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={busyAgent} projectName="test-project" messages={messages} pushEvent={pushEvent} />);
     await userEvent.click(screen.getByLabelText("Stop"));
     expect(pushEvent).toHaveBeenCalledWith("interrupt-agent", {});
   });
 
   it("shows send button when agent is not busy", () => {
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
     expect(screen.getByText("Send")).toBeInTheDocument();
     expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
   });
 
   it("shows thinking indicator when agent is busy and not streaming", () => {
     const busyAgent = { ...activeAgent, busy: true };
-    render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={busyAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
     expect(screen.getByText("Thinking...")).toBeInTheDocument();
   });
 
@@ -300,7 +313,7 @@ describe("ChatPanel", () => {
     });
 
     const busyAgent = { ...activeAgent, busy: true };
-    render(<ChatPanel agent={busyAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={busyAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
 
     act(() => {
       handlers["text_delta"]({ delta: "streaming..." });
@@ -310,14 +323,14 @@ describe("ChatPanel", () => {
   });
 
   it("does not show thinking indicator when agent is not busy", () => {
-    render(<ChatPanel agent={activeAgent} messages={messages} pushEvent={vi.fn()} />);
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
     expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
   });
 
   it("shows idle message and restart button when agent is idle", () => {
     const idleAgent: Agent = { ...activeAgent, status: "idle" };
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={idleAgent} messages={messages} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={idleAgent} projectName="test-project" messages={messages} pushEvent={pushEvent} />);
     expect(screen.getByText(/Agent is idle/)).toBeInTheDocument();
     expect(screen.getByText("Restart")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText("Type a message...")).not.toBeInTheDocument();
@@ -326,8 +339,54 @@ describe("ChatPanel", () => {
   it("sends restart-agent event when restart button is clicked", async () => {
     const idleAgent: Agent = { ...activeAgent, status: "idle" };
     const pushEvent = vi.fn();
-    render(<ChatPanel agent={idleAgent} messages={messages} pushEvent={pushEvent} />);
+    render(<ChatPanel agent={idleAgent} projectName="test-project" messages={messages} pushEvent={pushEvent} />);
     await userEvent.click(screen.getByText("Restart"));
     expect(pushEvent).toHaveBeenCalledWith("restart-agent", {});
+  });
+
+  it("shows attach button when agent is active", () => {
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={messages} pushEvent={vi.fn()} />);
+    expect(screen.getByLabelText("Attach file")).toBeInTheDocument();
+  });
+
+  it("renders file attachment as download link", () => {
+    const msgWithAtt: Message = {
+      id: 30,
+      role: "agent",
+      text: "Here is your report",
+      ts: "2026-03-17T00:00:05Z",
+      attachments: [{ id: "abc123", filename: "report.pdf", size: 1024, content_type: "application/pdf" }],
+    };
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[msgWithAtt]} pushEvent={vi.fn()} />);
+    const link = screen.getByText("report.pdf").closest("a");
+    expect(link).toHaveAttribute("href", "/projects/test-project/agents/a1/attachments/abc123/report.pdf");
+  });
+
+  it("renders image attachment as preview", () => {
+    const msgWithImg: Message = {
+      id: 31,
+      role: "agent",
+      text: "",
+      ts: "2026-03-17T00:00:06Z",
+      attachments: [{ id: "img001", filename: "screenshot.png", size: 2048, content_type: "image/png" }],
+    };
+    render(<ChatPanel agent={activeAgent} projectName="test-project" messages={[msgWithImg]} pushEvent={vi.fn()} />);
+    const img = screen.getByAltText("screenshot.png");
+    expect(img).toHaveAttribute("src", "/projects/test-project/agents/a1/attachments/img001/screenshot.png");
+  });
+
+  it("renders user message with attachments", () => {
+    const userMsgWithAtt: Message = {
+      id: 32,
+      role: "user",
+      text: "Check this file",
+      ts: "2026-03-17T00:00:07Z",
+      attachments: [{ id: "def456", filename: "data.csv", size: 512, content_type: "text/csv" }],
+    };
+    render(
+      <ChatPanel agent={activeAgent} projectName="test-project" messages={[userMsgWithAtt]} pushEvent={vi.fn()} />,
+    );
+    expect(screen.getByText("Check this file")).toBeInTheDocument();
+    expect(screen.getByText("data.csv")).toBeInTheDocument();
   });
 });

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -60,6 +60,13 @@ defmodule Shire.Agent.AgentManager do
     - `scripts/` — Save reusable automation scripts (bash, JS/TS, Python) for future use
     - `documents/` — Store internal documents, notes, or references worth keeping
 
+    ## Attachments
+    To share files with the user in chat, write them to your attachments directory:
+    1. Generate a unique ID (e.g. 8 hex characters)
+    2. Create a subdirectory: `attachments/{unique-id}/`
+    3. Write the file inside it: `attachments/{unique-id}/filename.ext`
+    The file will automatically appear as a downloadable attachment in the user's chat.
+
     ## Shared Drive
     All agents can read and write files in `#{shared_path}/`. Use this for sharing documents,
     data, or artifacts that multiple agents need access to.
@@ -102,8 +109,8 @@ defmodule Shire.Agent.AgentManager do
     GenServer.start_link(__MODULE__, opts, name: via(project_id, agent_id))
   end
 
-  def send_message(project_id, agent_id, text, from \\ :user) do
-    GenServer.call(via(project_id, agent_id), {:send_message, text, from}, 60_000)
+  def send_message(project_id, agent_id, text, from \\ :user, opts \\ []) do
+    GenServer.call(via(project_id, agent_id), {:send_message, text, from, opts}, 60_000)
   end
 
   def interrupt(project_id, agent_id) do
@@ -221,12 +228,36 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @impl true
-  def handle_call({:send_message, text, _from}, _from_pid, %{status: :active} = state) do
+  def handle_call({:send_message, text, _from, opts}, _from_pid, %{status: :active} = state) do
+    attachments = Keyword.get(opts, :attachments, [])
+
+    payload =
+      case attachments do
+        [] ->
+          %{"text" => text}
+
+        _ ->
+          attachments_with_paths =
+            Enum.map(attachments, fn att ->
+              path =
+                Workspace.attachment_path(
+                  state.project_id,
+                  state.agent_id,
+                  att["id"],
+                  att["filename"]
+                )
+
+              Map.put(att, "path", path)
+            end)
+
+          %{"text" => text, "attachments" => attachments_with_paths}
+      end
+
     envelope = %{
       "ts" => System.system_time(:millisecond),
       "type" => "user_message",
       "from" => "user",
-      "payload" => %{"text" => text}
+      "payload" => payload
     }
 
     inbox_dir = Path.join(Workspace.agent_dir(state.project_id, state.agent_id), "inbox")
@@ -238,7 +269,9 @@ defmodule Shire.Agent.AgentManager do
            state.agent_id,
            text,
            inbox_path,
-           envelope
+           envelope,
+           nil,
+           attachments: attachments
          ) do
       {:ok, msg} ->
         {:reply, {:ok, msg}, state}
@@ -250,7 +283,7 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @impl true
-  def handle_call({:send_message, _text, _from}, _from_pid, state) do
+  def handle_call({:send_message, _text, _from, _opts}, _from_pid, state) do
     {:reply, {:error, :not_active}, state}
   end
 
@@ -416,6 +449,45 @@ defmodule Shire.Agent.AgentManager do
             broadcast(acc, {:agent_busy, acc.agent_id, active})
             acc
 
+          {:ok,
+           %{
+             "type" => "attachment",
+             "payload" =>
+               %{
+                 "id" => att_id,
+                 "filename" => filename,
+                 "size" => size,
+                 "content_type" => content_type
+               } = _payload
+           }} ->
+            attachment_meta = %{
+              "id" => att_id,
+              "filename" => filename,
+              "size" => size,
+              "content_type" => content_type
+            }
+
+            case Agents.create_message(%{
+                   project_id: acc.project_id,
+                   agent_id: acc.agent_id,
+                   role: "agent",
+                   content: %{"text" => "", "attachments" => [attachment_meta]}
+                 }) do
+              {:ok, msg} ->
+                event = %{
+                  "type" => "attachment",
+                  "payload" => attachment_meta,
+                  "message" => serialize_message(msg)
+                }
+
+                broadcast(acc, {:agent_event, acc.agent_id, event})
+
+              {:error, _} ->
+                :ok
+            end
+
+            acc
+
           {:ok, event} ->
             persist_and_broadcast(acc, event)
 
@@ -496,7 +568,7 @@ defmodule Shire.Agent.AgentManager do
     agent_dir = Workspace.agent_dir(project_id, agent_id)
 
     # Create agent directory structure
-    for subdir <- ["inbox", "outbox", "scripts", "documents", ".claude/skills"] do
+    for subdir <- ["inbox", "outbox", "scripts", "documents", "attachments", ".claude/skills"] do
       vm().mkdir_p(project_id, Path.join(agent_dir, subdir))
     end
 
@@ -858,7 +930,9 @@ defmodule Shire.Agent.AgentManager do
         })
 
       _ ->
-        Map.put(base, :text, msg.content["text"])
+        base
+        |> Map.put(:text, msg.content["text"])
+        |> Map.put(:attachments, msg.content["attachments"] || [])
     end
   end
 

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -61,10 +61,8 @@ defmodule Shire.Agent.AgentManager do
     - `documents/` — Store internal documents, notes, or references worth keeping
 
     ## Attachments
-    To share files with the user in chat, write them to your attachments directory:
-    1. Generate a unique ID (e.g. 8 hex characters)
-    2. Create a subdirectory: `attachments/{unique-id}/`
-    3. Write the file inside it: `attachments/{unique-id}/filename.ext`
+    To share files with the user in chat, write them to your attachments outbox:
+      attachments/outbox/filename.ext
     The file will automatically appear as a downloadable attachment in the user's chat.
 
     ## Shared Drive
@@ -449,34 +447,28 @@ defmodule Shire.Agent.AgentManager do
             broadcast(acc, {:agent_busy, acc.agent_id, active})
             acc
 
-          {:ok,
-           %{
-             "type" => "attachment",
-             "payload" =>
-               %{
-                 "id" => att_id,
-                 "filename" => filename,
-                 "size" => size,
-                 "content_type" => content_type
-               } = _payload
-           }} ->
-            attachment_meta = %{
-              "id" => att_id,
-              "filename" => filename,
-              "size" => size,
-              "content_type" => content_type
-            }
+          {:ok, %{"type" => "attachment", "payload" => %{"id" => att_id, "files" => files}}}
+          when is_list(files) ->
+            attachments =
+              Enum.map(files, fn f ->
+                %{
+                  "id" => att_id,
+                  "filename" => f["filename"],
+                  "size" => f["size"],
+                  "content_type" => f["content_type"]
+                }
+              end)
 
             case Agents.create_message(%{
                    project_id: acc.project_id,
                    agent_id: acc.agent_id,
                    role: "agent",
-                   content: %{"text" => "", "attachments" => [attachment_meta]}
+                   content: %{"text" => "", "attachments" => attachments}
                  }) do
               {:ok, msg} ->
                 event = %{
                   "type" => "attachment",
-                  "payload" => attachment_meta,
+                  "payload" => %{"attachments" => attachments},
                   "message" => serialize_message(msg)
                 }
 
@@ -568,7 +560,15 @@ defmodule Shire.Agent.AgentManager do
     agent_dir = Workspace.agent_dir(project_id, agent_id)
 
     # Create agent directory structure
-    for subdir <- ["inbox", "outbox", "scripts", "documents", "attachments", ".claude/skills"] do
+    for subdir <- [
+          "inbox",
+          "outbox",
+          "scripts",
+          "documents",
+          "attachments",
+          "attachments/outbox",
+          ".claude/skills"
+        ] do
       vm().mkdir_p(project_id, Path.join(agent_dir, subdir))
     end
 

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -65,8 +65,8 @@ defmodule Shire.Agent.Coordinator do
     GenServer.cast(via(project_id), {:watch_agent, agent_id})
   end
 
-  def send_message(project_id, agent_id, text) do
-    AgentManager.send_message(project_id, agent_id, text, :user)
+  def send_message(project_id, agent_id, text, opts \\ []) do
+    AgentManager.send_message(project_id, agent_id, text, :user, opts)
   end
 
   def interrupt_agent(project_id, agent_id) do

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -25,6 +25,7 @@ defmodule Shire.Agents do
            :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "scripts")),
            :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "documents")),
            :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "attachments")),
+           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "attachments/outbox")),
            :ok <- vm.write(project_id, Path.join(agent_dir, "recipe.yaml"), recipe_yaml) do
         {:ok, agent.id}
       else

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -24,6 +24,7 @@ defmodule Shire.Agents do
            :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "outbox")),
            :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "scripts")),
            :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "documents")),
+           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "attachments")),
            :ok <- vm.write(project_id, Path.join(agent_dir, "recipe.yaml"), recipe_yaml) do
         {:ok, agent.id}
       else
@@ -107,8 +108,23 @@ defmodule Shire.Agents do
   @doc """
   Sends a message: inserts DB record and writes inbox file on VM atomically.
   """
-  def send_message_with_inbox(project_id, agent_id, text, inbox_path, envelope, vm \\ nil) do
+  def send_message_with_inbox(
+        project_id,
+        agent_id,
+        text,
+        inbox_path,
+        envelope,
+        vm \\ nil,
+        opts \\ []
+      ) do
     vm = vm || vm()
+    attachments = Keyword.get(opts, :attachments, [])
+
+    content =
+      case attachments do
+        [] -> %{"text" => text}
+        _ -> %{"text" => text, "attachments" => attachments}
+      end
 
     Multi.new()
     |> Multi.insert(
@@ -117,7 +133,7 @@ defmodule Shire.Agents do
         project_id: project_id,
         agent_id: agent_id,
         role: "user",
-        content: %{"text" => text}
+        content: content
       })
     )
     |> Multi.run(:write_inbox, fn _repo, _changes ->

--- a/lib/shire/workspace.ex
+++ b/lib/shire/workspace.ex
@@ -15,5 +15,14 @@ defmodule Shire.Workspace do
   def peers_path(project_id), do: Path.join(root(project_id), "peers.yaml")
   def project_doc_path(project_id), do: Path.join(root(project_id), "PROJECT.md")
 
+  def attachments_dir(project_id, agent_id),
+    do: Path.join(agent_dir(project_id, agent_id), "attachments")
+
+  def attachment_dir(project_id, agent_id, attachment_id),
+    do: Path.join(attachments_dir(project_id, agent_id), attachment_id)
+
+  def attachment_path(project_id, agent_id, attachment_id, filename),
+    do: Path.join(attachment_dir(project_id, agent_id, attachment_id), filename)
+
   defp vm, do: Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)
 end

--- a/lib/shire_web/controllers/attachment_controller.ex
+++ b/lib/shire_web/controllers/attachment_controller.ex
@@ -1,0 +1,53 @@
+defmodule ShireWeb.AttachmentController do
+  use ShireWeb, :controller
+
+  alias Shire.Workspace
+
+  def download(conn, %{
+        "project_name" => project_name,
+        "agent_id" => agent_id,
+        "attachment_id" => attachment_id,
+        "filename" => filename
+      }) do
+    with :ok <- validate_id(agent_id),
+         :ok <- validate_id(attachment_id),
+         :ok <- validate_filename(filename) do
+      project = Shire.Projects.get_project_by_name!(project_name)
+      vm_path = Workspace.attachment_path(project.id, agent_id, attachment_id, filename)
+
+      case vm().read(project.id, vm_path) do
+        {:ok, content} ->
+          content_type = MIME.from_path(filename)
+
+          conn
+          |> put_resp_content_type(content_type)
+          |> put_resp_header(
+            "content-disposition",
+            ~s(attachment; filename="#{String.replace(filename, "\"", "")}")
+          )
+          |> send_resp(200, content)
+
+        {:error, :no_vm} ->
+          conn |> put_status(503) |> text("No VM available")
+
+        {:error, _} ->
+          conn |> put_status(404) |> text("File not found")
+      end
+    else
+      :error ->
+        conn |> put_status(400) |> text("Invalid parameters")
+    end
+  end
+
+  defp validate_id(id), do: if(Regex.match?(~r/\A[a-f0-9\-]+\z/i, id), do: :ok, else: :error)
+
+  defp validate_filename(name) do
+    if String.contains?(name, ["../", "/", "\\", "\""]) or name == "" do
+      :error
+    else
+      :ok
+    end
+  end
+
+  defp vm, do: Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)
+end

--- a/lib/shire_web/live/agent_live/agent_streaming.ex
+++ b/lib/shire_web/live/agent_live/agent_streaming.ex
@@ -111,6 +111,9 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
       %{"type" => "system_message", "message" => msg} ->
         {messages ++ [msg], nil}
 
+      %{"type" => "attachment", "message" => msg} ->
+        {messages ++ [msg], nil}
+
       %{"type" => "turn_complete"} ->
         {messages, nil}
 

--- a/lib/shire_web/live/agent_live/helpers.ex
+++ b/lib/shire_web/live/agent_live/helpers.ex
@@ -25,7 +25,9 @@ defmodule ShireWeb.AgentLive.Helpers do
         })
 
       _ ->
-        Map.put(base, :text, msg.content["text"])
+        base
+        |> Map.put(:text, msg.content["text"])
+        |> Map.put(:attachments, msg.content["attachments"] || [])
     end
   end
 end

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -5,7 +5,10 @@ defmodule ShireWeb.AgentLive.Index do
   alias Shire.Projects
   alias Shire.Agent.Coordinator
   alias Shire.ProjectManager
+  alias Shire.Workspace
   alias ShireWeb.AgentLive.{AgentStreaming, Helpers}
+
+  @max_attachment_size 50 * 1024 * 1024
 
   @impl true
   def mount(%{"project_name" => project_name}, _session, socket) do
@@ -179,20 +182,29 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
-  def handle_event("send-message", %{"text" => text}, socket) do
+  def handle_event("send-message", %{"text" => text} = params, socket) do
     project_id = socket.assigns.project.id
     agent_id = socket.assigns.selected_agent_id
+    raw_attachments = Map.get(params, "attachments", [])
 
-    case Coordinator.send_message(project_id, agent_id, text) do
-      {:ok, msg} ->
-        messages = socket.assigns.messages ++ [Helpers.serialize_message(msg)]
-        {:noreply, assign(socket, :messages, messages)}
+    case store_attachments(project_id, agent_id, raw_attachments) do
+      {:ok, attachment_metas} ->
+        opts = if attachment_metas == [], do: [], else: [attachments: attachment_metas]
 
-      :ok ->
-        {:noreply, socket}
+        case Coordinator.send_message(project_id, agent_id, text, opts) do
+          {:ok, msg} ->
+            messages = socket.assigns.messages ++ [Helpers.serialize_message(msg)]
+            {:noreply, assign(socket, :messages, messages)}
+
+          :ok ->
+            {:noreply, socket}
+
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Failed to send: #{inspect(reason)}")}
+        end
 
       {:error, reason} ->
-        {:noreply, put_flash(socket, :error, "Failed to send: #{inspect(reason)}")}
+        {:noreply, put_flash(socket, :error, "Attachment error: #{reason}")}
     end
   catch
     :exit, _ ->
@@ -364,6 +376,57 @@ defmodule ShireWeb.AgentLive.Index do
       end
 
     {:noreply, assign(socket, agent_statuses: statuses, selected_agent: selected_agent)}
+  end
+
+  # --- Private helpers ---
+
+  defp store_attachments(_project_id, _agent_id, []), do: {:ok, []}
+
+  defp store_attachments(project_id, agent_id, raw_attachments) do
+    vm = Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)
+
+    Enum.reduce_while(raw_attachments, {:ok, []}, fn att, {:ok, acc} ->
+      name = att["name"]
+      base64_content = att["content"]
+      content_type = att["content_type"] || "application/octet-stream"
+
+      # Strip data URI prefix if present (e.g. "data:image/png;base64,...")
+      raw_b64 =
+        case String.split(base64_content, ",", parts: 2) do
+          [_prefix, data] -> data
+          [data] -> data
+        end
+
+      case Base.decode64(raw_b64) do
+        {:ok, bytes} ->
+          if byte_size(bytes) > @max_attachment_size do
+            {:halt, {:error, "File #{name} exceeds 50MB limit"}}
+          else
+            safe_name = Path.basename(name)
+            attachment_id = :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
+            dir = Workspace.attachment_dir(project_id, agent_id, attachment_id)
+            path = Workspace.attachment_path(project_id, agent_id, attachment_id, safe_name)
+
+            with :ok <- vm.mkdir_p(project_id, dir),
+                 :ok <- vm.write(project_id, path, bytes) do
+              meta = %{
+                "id" => attachment_id,
+                "filename" => safe_name,
+                "size" => byte_size(bytes),
+                "content_type" => content_type
+              }
+
+              {:cont, {:ok, acc ++ [meta]}}
+            else
+              {:error, reason} ->
+                {:halt, {:error, "Failed to store #{name}: #{inspect(reason)}"}}
+            end
+          end
+
+        :error ->
+          {:halt, {:error, "Invalid base64 for #{name}"}}
+      end
+    end)
   end
 
   @impl true

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -384,49 +384,52 @@ defmodule ShireWeb.AgentLive.Index do
 
   defp store_attachments(project_id, agent_id, raw_attachments) do
     vm = Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)
+    suffix = :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
+    attachment_id = "#{System.system_time(:millisecond)}-#{suffix}"
+    dir = Workspace.attachment_dir(project_id, agent_id, attachment_id)
 
-    Enum.reduce_while(raw_attachments, {:ok, []}, fn att, {:ok, acc} ->
-      name = att["name"]
-      base64_content = att["content"]
-      content_type = att["content_type"] || "application/octet-stream"
+    with :ok <- vm.mkdir_p(project_id, dir) do
+      Enum.reduce_while(raw_attachments, {:ok, []}, fn att, {:ok, acc} ->
+        name = att["name"]
+        base64_content = att["content"]
+        content_type = att["content_type"] || "application/octet-stream"
 
-      # Strip data URI prefix if present (e.g. "data:image/png;base64,...")
-      raw_b64 =
-        case String.split(base64_content, ",", parts: 2) do
-          [_prefix, data] -> data
-          [data] -> data
-        end
-
-      case Base.decode64(raw_b64) do
-        {:ok, bytes} ->
-          if byte_size(bytes) > @max_attachment_size do
-            {:halt, {:error, "File #{name} exceeds 50MB limit"}}
-          else
-            safe_name = Path.basename(name)
-            attachment_id = :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
-            dir = Workspace.attachment_dir(project_id, agent_id, attachment_id)
-            path = Workspace.attachment_path(project_id, agent_id, attachment_id, safe_name)
-
-            with :ok <- vm.mkdir_p(project_id, dir),
-                 :ok <- vm.write(project_id, path, bytes) do
-              meta = %{
-                "id" => attachment_id,
-                "filename" => safe_name,
-                "size" => byte_size(bytes),
-                "content_type" => content_type
-              }
-
-              {:cont, {:ok, acc ++ [meta]}}
-            else
-              {:error, reason} ->
-                {:halt, {:error, "Failed to store #{name}: #{inspect(reason)}"}}
-            end
+        # Strip data URI prefix if present (e.g. "data:image/png;base64,...")
+        raw_b64 =
+          case String.split(base64_content, ",", parts: 2) do
+            [_prefix, data] -> data
+            [data] -> data
           end
 
-        :error ->
-          {:halt, {:error, "Invalid base64 for #{name}"}}
-      end
-    end)
+        case Base.decode64(raw_b64) do
+          {:ok, bytes} ->
+            if byte_size(bytes) > @max_attachment_size do
+              {:halt, {:error, "File #{name} exceeds 50MB limit"}}
+            else
+              safe_name = Path.basename(name)
+              path = Workspace.attachment_path(project_id, agent_id, attachment_id, safe_name)
+
+              case vm.write(project_id, path, bytes) do
+                :ok ->
+                  meta = %{
+                    "id" => attachment_id,
+                    "filename" => safe_name,
+                    "size" => byte_size(bytes),
+                    "content_type" => content_type
+                  }
+
+                  {:cont, {:ok, acc ++ [meta]}}
+
+                {:error, reason} ->
+                  {:halt, {:error, "Failed to store #{name}: #{inspect(reason)}"}}
+              end
+            end
+
+          :error ->
+            {:halt, {:error, "Invalid base64 for #{name}"}}
+        end
+      end)
+    end
   end
 
   @impl true

--- a/lib/shire_web/router.ex
+++ b/lib/shire_web/router.ex
@@ -37,6 +37,10 @@ defmodule ShireWeb.Router do
     pipe_through :browser
 
     get "/projects/:project_name/shared/download", SharedDriveController, :download
+
+    get "/projects/:project_name/agents/:agent_id/attachments/:attachment_id/:filename",
+        AttachmentController,
+        :download
   end
 
   import Oban.Web.Router

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -1,7 +1,7 @@
 // agent-runner.ts — Bun daemon that watches the inbox/outbox and dispatches to configured harness.
 // Each agent runs in its own workspace directory under /workspace/agents/{id}/.
 import { watch } from "fs";
-import { readFile, readdir, unlink, writeFile, mkdir, stat } from "fs/promises";
+import { readFile, readdir, rename, unlink, writeFile, mkdir, stat } from "fs/promises";
 import { basename, join } from "path";
 import { parseArgs } from "util";
 import yaml from "js-yaml";
@@ -20,6 +20,7 @@ const AGENT_DIR = (typeof values["agent-dir"] === "string" ? values["agent-dir"]
 const INBOX_DIR = join(AGENT_DIR, "inbox");
 const OUTBOX_DIR = join(AGENT_DIR, "outbox");
 const ATTACHMENTS_DIR = join(AGENT_DIR, "attachments");
+const ATTACHMENT_OUTBOX_DIR = join(ATTACHMENTS_DIR, "outbox");
 const AGENTS_ROOT = join(AGENT_DIR, "../");
 const RECIPE_PATH = join(AGENT_DIR, "recipe.yaml");
 const PEERS_PATH = join(AGENTS_ROOT, "../peers.yaml");
@@ -290,41 +291,61 @@ function mimeFromPath(filename: string): string {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
-// Track already-emitted attachment IDs to avoid duplicates
-const emittedAttachments = new Set<string>();
-
-async function scanAttachments(attachmentsDir: string): Promise<void> {
-  let dirs: string[];
+async function processAttachmentOutbox(attachmentsDir: string): Promise<number> {
+  const outboxDir = join(attachmentsDir, "outbox");
+  let entries: string[];
   try {
-    dirs = await readdir(attachmentsDir);
+    entries = (await readdir(outboxDir)).sort();
   } catch {
-    return;
+    return 0;
   }
 
-  for (const attachmentId of dirs) {
-    if (emittedAttachments.has(attachmentId)) continue;
-    const subdir = join(attachmentsDir, attachmentId);
+  // Collect regular files, skip dotfiles and directories
+  const files: Array<{ name: string; path: string; size: number }> = [];
+  for (const entry of entries) {
+    if (entry.startsWith(".") || entry.includes("/") || entry.includes("\\")) continue;
+    const filePath = join(outboxDir, entry);
     try {
-      const s = await stat(subdir);
-      if (!s.isDirectory()) continue;
-      const files = (await readdir(subdir)).sort();
-      if (files.length === 0) continue;
-      const filename = files[0];
-      const filePath = join(subdir, filename);
-      const fileStat = await stat(filePath);
-      if (!fileStat.isFile()) continue;
-      emittedAttachments.add(attachmentId);
-      emit("attachment", {
-        id: attachmentId,
-        filename,
-        path: filePath,
-        content_type: mimeFromPath(filename),
-        size: fileStat.size,
-      });
+      const s = await stat(filePath);
+      if (s.isFile()) {
+        files.push({ name: entry, path: filePath, size: s.size });
+      }
     } catch {
       // skip unreadable entries
     }
   }
+
+  if (files.length === 0) return 0;
+
+  // Batch all files into one timestamped folder
+  const attachmentId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const destDir = join(attachmentsDir, attachmentId);
+  await mkdir(destDir, { recursive: true });
+
+  const movedFiles: Array<{ filename: string; content_type: string; size: number }> = [];
+
+  for (const file of files) {
+    const destPath = join(destDir, file.name);
+    try {
+      await rename(file.path, destPath);
+      movedFiles.push({
+        filename: file.name,
+        content_type: mimeFromPath(file.name),
+        size: file.size,
+      });
+    } catch (err) {
+      emit("error", { message: `Failed to move attachment ${file.name}: ${err}` });
+    }
+  }
+
+  if (movedFiles.length > 0) {
+    emit("attachment", {
+      id: attachmentId,
+      files: movedFiles,
+    });
+  }
+
+  return movedFiles.length;
 }
 
 // ---------------------------------------------------------------------------
@@ -335,8 +356,8 @@ async function main() {
   const config = await loadConfig();
   await loadPeers();
 
-  // Ensure attachments directory exists
-  await mkdir(ATTACHMENTS_DIR, { recursive: true });
+  // Ensure attachments directories exist
+  await mkdir(ATTACHMENT_OUTBOX_DIR, { recursive: true });
 
   const harness = createHarness(config.harness);
 
@@ -394,9 +415,20 @@ async function main() {
     }
   });
 
-  // Watch attachments directory for agent-created files
-  const attachmentsWatcher = watch(ATTACHMENTS_DIR, async () => {
-    await scanAttachments(ATTACHMENTS_DIR);
+  // Watch attachments outbox for agent-created files
+  await processAttachmentOutbox(ATTACHMENTS_DIR);
+  let processingAttachments = false;
+  const attachmentsWatcher = watch(ATTACHMENT_OUTBOX_DIR, async () => {
+    if (processingAttachments) return;
+    processingAttachments = true;
+    try {
+      let count: number;
+      do {
+        count = await processAttachmentOutbox(ATTACHMENTS_DIR);
+      } while (count > 0);
+    } finally {
+      processingAttachments = false;
+    }
   });
 
   // Heartbeat every 30 seconds

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -1,7 +1,7 @@
 // agent-runner.ts — Bun daemon that watches the inbox/outbox and dispatches to configured harness.
 // Each agent runs in its own workspace directory under /workspace/agents/{id}/.
 import { watch } from "fs";
-import { readFile, readdir, unlink, writeFile } from "fs/promises";
+import { readFile, readdir, unlink, writeFile, mkdir, stat } from "fs/promises";
 import { basename, join } from "path";
 import { parseArgs } from "util";
 import yaml from "js-yaml";
@@ -19,6 +19,7 @@ const { values } = parseArgs({
 const AGENT_DIR = (typeof values["agent-dir"] === "string" ? values["agent-dir"] : null) || "/workspace/agents/default";
 const INBOX_DIR = join(AGENT_DIR, "inbox");
 const OUTBOX_DIR = join(AGENT_DIR, "outbox");
+const ATTACHMENTS_DIR = join(AGENT_DIR, "attachments");
 const AGENTS_ROOT = join(AGENT_DIR, "../");
 const RECIPE_PATH = join(AGENT_DIR, "recipe.yaml");
 const PEERS_PATH = join(AGENTS_ROOT, "../peers.yaml");
@@ -122,9 +123,19 @@ export async function tryHandleInterrupt(harness: Harness, filename: string, inb
 
 export async function processMessage(harness: Harness, envelope: MessageEnvelope): Promise<void> {
   if (envelope.type === "user_message" || envelope.type === "agent_message" || envelope.type === "system_message") {
-    const text = envelope.payload.text as string;
+    let text = envelope.payload.text as string;
     const from = envelope.type === "agent_message" ? envelope.from : undefined;
     const prefix = envelope.type === "system_message" ? "[System] " : "";
+
+    // Append attachment file references so the agent can access them
+    const attachments = envelope.payload.attachments as
+      | Array<{ filename: string; content_type: string; path: string }>
+      | undefined;
+    if (attachments?.length) {
+      const refs = attachments.map((a) => `[Attached file: ${a.filename} (${a.content_type}) at ${a.path}]`).join("\n");
+      text = text ? `${text}\n\n${refs}` : refs;
+    }
+
     if (envelope.type === "agent_message") {
       emit("agent_message_received", { from_agent: envelope.from, text });
     } else if (envelope.type === "system_message") {
@@ -252,12 +263,80 @@ export async function processOutbox(
 }
 
 // ---------------------------------------------------------------------------
+// Attachments — detect agent-created files and emit events
+// ---------------------------------------------------------------------------
+
+const MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".pdf": "application/pdf",
+  ".json": "application/json",
+  ".csv": "text/csv",
+  ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".html": "text/html",
+  ".xml": "application/xml",
+  ".zip": "application/zip",
+  ".tar": "application/x-tar",
+  ".gz": "application/gzip",
+};
+
+function mimeFromPath(filename: string): string {
+  const ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
+  return MIME_TYPES[ext] || "application/octet-stream";
+}
+
+// Track already-emitted attachment IDs to avoid duplicates
+const emittedAttachments = new Set<string>();
+
+async function scanAttachments(attachmentsDir: string): Promise<void> {
+  let dirs: string[];
+  try {
+    dirs = await readdir(attachmentsDir);
+  } catch {
+    return;
+  }
+
+  for (const attachmentId of dirs) {
+    if (emittedAttachments.has(attachmentId)) continue;
+    const subdir = join(attachmentsDir, attachmentId);
+    try {
+      const s = await stat(subdir);
+      if (!s.isDirectory()) continue;
+      const files = (await readdir(subdir)).sort();
+      if (files.length === 0) continue;
+      const filename = files[0];
+      const filePath = join(subdir, filename);
+      const fileStat = await stat(filePath);
+      if (!fileStat.isFile()) continue;
+      emittedAttachments.add(attachmentId);
+      emit("attachment", {
+        id: attachmentId,
+        filename,
+        path: filePath,
+        content_type: mimeFromPath(filename),
+        size: fileStat.size,
+      });
+    } catch {
+      // skip unreadable entries
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main() {
   const config = await loadConfig();
   await loadPeers();
+
+  // Ensure attachments directory exists
+  await mkdir(ATTACHMENTS_DIR, { recursive: true });
 
   const harness = createHarness(config.harness);
 
@@ -315,6 +394,11 @@ async function main() {
     }
   });
 
+  // Watch attachments directory for agent-created files
+  const attachmentsWatcher = watch(ATTACHMENTS_DIR, async () => {
+    await scanAttachments(ATTACHMENTS_DIR);
+  });
+
   // Heartbeat every 30 seconds
   setInterval(() => {
     emit("heartbeat", { status: "alive" });
@@ -324,6 +408,7 @@ async function main() {
   process.on("SIGTERM", () => {
     inboxWatcher.close();
     outboxWatcher.close();
+    attachmentsWatcher.close();
     harness.stop();
     emit("shutdown", {});
     process.exit(0);

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -67,7 +67,7 @@ defmodule Shire.Agent.AgentManagerTest do
     test "returns error when agent is not active", ctx do
       {:ok, pid} = start_manager(ctx)
 
-      assert {:error, :not_active} = GenServer.call(pid, {:send_message, "hello", :user})
+      assert {:error, :not_active} = GenServer.call(pid, {:send_message, "hello", :user, []})
     end
 
     test "persists user message to DB when from is :user", ctx do
@@ -84,7 +84,7 @@ defmodule Shire.Agent.AgentManagerTest do
       end)
 
       assert {:ok, %Shire.Agents.Message{}} =
-               GenServer.call(pid, {:send_message, "hello from user", :user})
+               GenServer.call(pid, {:send_message, "hello from user", :user, []})
 
       {messages, _} = Agents.list_messages_for_agent(ctx.project_id, ctx.agent_id)
       user_msgs = Enum.filter(messages, &(&1.role == "user"))

--- a/test/shire/agents_test.exs
+++ b/test/shire/agents_test.exs
@@ -195,6 +195,59 @@ defmodule Shire.AgentsTest do
       refute Enum.any?(messages, &(&1.content["text"] == "fail"))
     end
 
+    test "send_message_with_inbox stores attachments in content map", %{
+      project: project,
+      agent: agent
+    } do
+      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-att.yaml"
+      envelope = %{"role" => "user", "content" => "with files"}
+
+      attachments = [
+        %{
+          "id" => "abc12345",
+          "filename" => "report.pdf",
+          "size" => 1024,
+          "content_type" => "application/pdf"
+        }
+      ]
+
+      assert {:ok, msg} =
+               Agents.send_message_with_inbox(
+                 project.id,
+                 agent.id,
+                 "check this file",
+                 inbox_path,
+                 envelope,
+                 @vm,
+                 attachments: attachments
+               )
+
+      assert msg.content["text"] == "check this file"
+      assert msg.content["attachments"] == attachments
+    end
+
+    test "send_message_with_inbox omits attachments key when empty", %{
+      project: project,
+      agent: agent
+    } do
+      inbox_path = "/workspace/agents/#{agent.id}/inbox/msg-noatt.yaml"
+      envelope = %{"role" => "user", "content" => "no files"}
+
+      assert {:ok, msg} =
+               Agents.send_message_with_inbox(
+                 project.id,
+                 agent.id,
+                 "just text",
+                 inbox_path,
+                 envelope,
+                 @vm,
+                 attachments: []
+               )
+
+      assert msg.content == %{"text" => "just text"}
+      refute Map.has_key?(msg.content, "attachments")
+    end
+
     test "delete_agent_with_vm/3 deletes agent and its messages", %{project: project} do
       {:ok, del_agent} =
         Agents.create_agent_with_vm(project.id, "delete-test", "version: 1\n", @vm)

--- a/test/shire_web/controllers/attachment_controller_test.exs
+++ b/test/shire_web/controllers/attachment_controller_test.exs
@@ -1,0 +1,81 @@
+defmodule ShireWeb.AttachmentControllerTest do
+  use ShireWeb.ConnCase, async: false
+
+  import Mox
+
+  alias Shire.Projects
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _p -> "/workspace" end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _p, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :write, fn _p, _path, _c -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _p, _path -> :ok end)
+
+    {:ok, project} = Projects.create_project("att-test")
+
+    {:ok, agent} =
+      Shire.Agents.create_agent_with_vm(project.id, "att-agent", "version: 1\n")
+
+    %{project: project, agent: agent}
+  end
+
+  test "downloads attachment file", %{conn: conn, project: project, agent: agent} do
+    expect(Shire.VirtualMachineMock, :read, fn _p, path ->
+      assert String.contains?(path, "/attachments/abc12345/report.pdf")
+      {:ok, "pdf-content"}
+    end)
+
+    conn =
+      get(
+        conn,
+        "/projects/#{project.name}/agents/#{agent.id}/attachments/abc12345/report.pdf"
+      )
+
+    assert response(conn, 200) == "pdf-content"
+    assert get_resp_header(conn, "content-type") |> hd() =~ "application/pdf"
+
+    assert get_resp_header(conn, "content-disposition") |> hd() =~
+             ~s(attachment; filename="report.pdf")
+  end
+
+  test "returns 404 for missing attachment", %{conn: conn, project: project, agent: agent} do
+    expect(Shire.VirtualMachineMock, :read, fn _p, _path ->
+      {:error, :not_found}
+    end)
+
+    conn =
+      get(
+        conn,
+        "/projects/#{project.name}/agents/#{agent.id}/attachments/abc12345/missing.txt"
+      )
+
+    assert response(conn, 404) == "File not found"
+  end
+
+  test "returns 400 for path traversal in filename", %{conn: conn, project: project, agent: agent} do
+    conn =
+      get(
+        conn,
+        "/projects/#{project.name}/agents/#{agent.id}/attachments/abc12345/..%2F..%2Fetc%2Fpasswd"
+      )
+
+    assert response(conn, 400) == "Invalid parameters"
+  end
+
+  test "returns 400 for invalid attachment_id with special chars", %{
+    conn: conn,
+    project: project,
+    agent: agent
+  } do
+    conn =
+      get(
+        conn,
+        "/projects/#{project.name}/agents/#{agent.id}/attachments/invalid!id/file.txt"
+      )
+
+    assert response(conn, 400) == "Invalid parameters"
+  end
+end

--- a/test/shire_web/live/agent_streaming_test.exs
+++ b/test/shire_web/live/agent_streaming_test.exs
@@ -210,7 +210,7 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
         text: "",
         attachments: [
           %{
-            "id" => "abc123",
+            "id" => "1711234567890",
             "filename" => "report.csv",
             "size" => 1024,
             "content_type" => "text/csv"
@@ -224,10 +224,14 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
       event = %{
         "type" => "attachment",
         "payload" => %{
-          "id" => "abc123",
-          "filename" => "report.csv",
-          "size" => 1024,
-          "content_type" => "text/csv"
+          "attachments" => [
+            %{
+              "id" => "1711234567890",
+              "filename" => "report.csv",
+              "size" => 1024,
+              "content_type" => "text/csv"
+            }
+          ]
         },
         "message" => msg
       }

--- a/test/shire_web/live/agent_streaming_test.exs
+++ b/test/shire_web/live/agent_streaming_test.exs
@@ -202,6 +202,44 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
     end
   end
 
+  describe "process_agent_event/2 with attachment" do
+    test "appends attachment message and clears streaming text" do
+      msg = %{
+        id: 10,
+        role: "agent",
+        text: "",
+        attachments: [
+          %{
+            "id" => "abc123",
+            "filename" => "report.csv",
+            "size" => 1024,
+            "content_type" => "text/csv"
+          }
+        ],
+        ts: "2024-01-01T00:00:00Z"
+      }
+
+      socket = mock_socket(%{streaming_text: "partial"})
+
+      event = %{
+        "type" => "attachment",
+        "payload" => %{
+          "id" => "abc123",
+          "filename" => "report.csv",
+          "size" => 1024,
+          "content_type" => "text/csv"
+        },
+        "message" => msg
+      }
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      att_msg = List.last(socket.assigns.messages)
+      assert att_msg[:role] == "agent"
+      assert length(att_msg[:attachments]) == 1
+      assert socket.assigns.streaming_text == nil
+    end
+  end
+
   describe "process_agent_event/2 with turn_complete" do
     test "clears streaming text" do
       socket = mock_socket(%{streaming_text: "partial text"})


### PR DESCRIPTION
## Summary
- Users can attach files to messages via a paperclip button in the chat input area (base64 upload, stored on VM filesystem at `agents/{id}/attachments/`)
- Agents can create files in their `attachments/` directory which automatically appear as downloadable attachments in chat via a filesystem watcher
- New `AttachmentController` HTTP endpoint serves attachment downloads with path traversal protection
- Image attachments show inline previews; other files show as download links with file size

## Test plan
- [ ] Send a message with a file attachment, verify agent receives file path reference
- [ ] Verify the attachment appears in the chat with a download link
- [ ] Send an image attachment, verify inline preview renders
- [ ] Verify download endpoint serves the correct file with proper MIME type
- [ ] Verify path traversal attempts are rejected (400 response)
- [ ] Test agent creating a file in `attachments/{id}/filename` and verifying it appears in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)