### PR TITLE
Add DM Sans as brand typeface

### DIFF
--- a/assets/bun.lock
+++ b/assets/bun.lock
@@ -4,6 +4,7 @@
   "workspaces": {
     "": {
       "dependencies": {
+        "@fontsource-variable/dm-sans": "^5.2.8",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -334,6 +335,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@fontsource-variable/dm-sans": ["@fontsource-variable/dm-sans@5.2.8", "", {}, "sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5,6 +5,7 @@
 @import "tw-animate-css";
 @plugin "@tailwindcss/typography";
 @import "@xterm/xterm/css/xterm.css";
+@import "@fontsource-variable/dm-sans";
 
 @source "../css";
 @source "../js";
@@ -23,6 +24,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  --font-sans: "DM Sans Variable", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -155,6 +157,8 @@
   }
   body {
     @apply bg-background text-foreground;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check 'react-components/**/*.{ts,tsx}' 'test/**/*.{ts,tsx}' 'js/**/*.js'"
   },
   "dependencies": {
+    "@fontsource-variable/dm-sans": "^5.2.8",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",


### PR DESCRIPTION
## Summary

- Add DM Sans Variable font via `@fontsource-variable/dm-sans` (self-hosted, no external requests)
- Override Tailwind's `--font-sans` to use DM Sans with system font fallbacks
- Add `-webkit-font-smoothing: antialiased` for crisp rendering

## Context

Shire was using Tailwind's default system font stack, which is invisible/generic. DM Sans is a geometric sans-serif with softened terminals — it's warm and approachable (matching the sage green brand) while staying clean for a developer tool. The variable font format means a single file covers all weights (400-700).

## Test plan

- [x] 205 frontend tests pass
- [x] TypeScript, ESLint, Prettier all clean
- [x] Elixir compilation clean
- [ ] Visual: DM Sans renders across all pages (headings, body text, sidebar, chat)
- [ ] Visual: Font loads without FOUT/layout shift (self-hosted, should be instant)
- [ ] Visual: Monospace content (terminal, code blocks) still uses system monospace

🤖 Generated with [Claude Code](https://claude.com/claude-code)