### PR TITLE
Fix DM Sans font loading

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5,7 +5,6 @@
 @import "tw-animate-css";
 @plugin "@tailwindcss/typography";
 @import "@xterm/xterm/css/xterm.css";
-@import "@fontsource-variable/dm-sans";
 
 @source "../css";
 @source "../js";

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10,6 +10,7 @@ import { LiveSocket } from "phoenix_live_view";
 import { getHooks } from "live_react";
 import components from "../react-components";
 import topbar from "topbar";
+import "@fontsource-variable/dm-sans";
 import "../css/app.css";
 
 const hooks = {


### PR DESCRIPTION
## Summary

- Move `@fontsource-variable/dm-sans` import from `app.css` to `app.js`

## Context

The `@import` in app.css was processed by Tailwind v4's CSS parser, which can't resolve `node_modules` paths for non-Tailwind packages. Moving it to app.js lets Vite resolve and bundle the font CSS correctly.

Verified via Playwright: `getComputedStyle(body).fontFamily` now returns `"DM Sans Variable"` as the primary font.

## Test plan

- [x] Verified DM Sans renders in browser via Playwright
- [x] All frontend checks pass (tsc, lint, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)