### PR TITLE
fix attachment download and zero-byte file race

### DIFF
--- a/lib/shire_web/controllers/attachment_controller.ex
+++ b/lib/shire_web/controllers/attachment_controller.ex
@@ -39,7 +39,7 @@ defmodule ShireWeb.AttachmentController do
     end
   end
 
-  defp validate_id(id), do: if(Regex.match?(~r/\A[a-f0-9\-]+\z/i, id), do: :ok, else: :error)
+  defp validate_id(id), do: if(Regex.match?(~r/\A[a-z0-9\-]+\z/i, id), do: :ok, else: :error)
 
   defp validate_filename(name) do
     if String.contains?(name, ["../", "/", "\\", "\""]) or name == "" do

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -300,14 +300,14 @@ async function processAttachmentOutbox(attachmentsDir: string): Promise<number> 
     return 0;
   }
 
-  // Collect regular files, skip dotfiles and directories
+  // Collect regular files, skip dotfiles, directories, and files still being written (size 0)
   const files: Array<{ name: string; path: string; size: number }> = [];
   for (const entry of entries) {
     if (entry.startsWith(".") || entry.includes("/") || entry.includes("\\")) continue;
     const filePath = join(outboxDir, entry);
     try {
       const s = await stat(filePath);
-      if (s.isFile()) {
+      if (s.isFile() && s.size > 0) {
         files.push({ name: entry, path: filePath, size: s.size });
       }
     } catch {


### PR DESCRIPTION
## Summary
- **Download 400 error**: `validate_id` regex only allowed hex chars `[a-f0-9]` but attachment IDs now include base-36 suffixes (e.g. `1774257560607-3ye0d2`). Widened to `[a-z0-9]`.
- **Zero-byte attachments**: The fs watcher fires when a file is created, before the agent finishes writing. Skip files with `size === 0` so they get picked up on the next cycle when the write is complete.

## Test plan
- [ ] Upload attachment to agent, verify download link works
- [ ] Agent writes file to `attachments/outbox/`, verify it arrives with correct size (not 0 B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)