### PR TITLE
Fix DM Sans font loading in production builds

### DIFF
--- a/assets/vite.config.js
+++ b/assets/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig(({ command }) => {
     optimizeDeps: {
       include: ["react", "react-dom"],
     },
+    base: isDev ? "/" : "/assets/",
     build: {
       outDir: "../priv/static/assets",
       emptyOutDir: true,


### PR DESCRIPTION
## Summary

- Set Vite `base: "/assets/"` for production builds so font file URLs resolve correctly

## Context

DM Sans font files were output to `priv/static/assets/css/` but the built CSS referenced them at `/css/dm-sans-*.woff2` instead of `/assets/css/dm-sans-*.woff2`. Phoenix serves static files under the `/assets/` prefix, so the fonts returned 404 in production.

## Test plan

- [x] `bun run build` outputs correct URLs (`/assets/css/dm-sans-*.woff2`)
- [x] All 209 frontend tests pass
- [x] Dev mode still works (verified via Playwright)
- [ ] Deploy and verify font loads in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)