### PR TITLE
Fix chat code block and user message styling

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -381,14 +381,10 @@ export default function ChatPanel({
             <div key={msg.id ?? `msg-${i}`} className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
               <div
                 className={`px-3 py-1.5 rounded-lg text-sm w-fit max-w-[80%] ${
-                  msg.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
+                  msg.role === "user" ? "bg-primary/10 text-foreground" : "bg-muted"
                 }`}
               >
-                {msg.text ? (
-                  <Markdown className={msg.role === "user" ? "prose-invert" : ""} inverted={msg.role === "user"}>
-                    {msg.text}
-                  </Markdown>
-                ) : null}
+                {msg.text ? <Markdown>{msg.text}</Markdown> : null}
                 {msg.attachments && msg.attachments.length > 0 && (
                   <AttachmentDisplay attachments={msg.attachments} projectName={projectName} agentId={agent.id} />
                 )}

--- a/assets/react-components/components/Markdown.tsx
+++ b/assets/react-components/components/Markdown.tsx
@@ -5,11 +5,10 @@ import remarkGfm from "remark-gfm";
 interface MarkdownProps {
   children: string;
   className?: string;
-  inverted?: boolean;
 }
 
-export default function Markdown({ children, className, inverted }: MarkdownProps) {
-  const codeBg = inverted ? "bg-background/20 text-inherit" : "bg-foreground text-background";
+export default function Markdown({ children, className }: MarkdownProps) {
+  const codeBg = "bg-muted text-foreground";
 
   return (
     <div className={`prose prose-sm max-w-none dark:prose-invert break-words ${className ?? ""}`}>

--- a/assets/test/Markdown.test.tsx
+++ b/assets/test/Markdown.test.tsx
@@ -3,12 +3,12 @@ import { describe, it, expect } from "vitest";
 import Markdown from "../react-components/components/Markdown";
 
 describe("Markdown", () => {
-  it("renders code blocks with inverted background", () => {
+  it("renders code blocks with muted background", () => {
     const { container } = render(<Markdown>{"```js\nconsole.log('hello');\n```"}</Markdown>);
     const pre = container.querySelector("pre");
     expect(pre).toBeInTheDocument();
-    expect(pre?.className).toContain("bg-foreground");
-    expect(pre?.className).toContain("text-background");
+    expect(pre?.className).toContain("bg-muted");
+    expect(pre?.className).toContain("text-foreground");
   });
 
   it("renders block code element with transparent background", () => {
@@ -18,27 +18,11 @@ describe("Markdown", () => {
     expect(code?.className).toContain("bg-transparent");
   });
 
-  it("renders inline code with inverted background", () => {
+  it("renders inline code with muted background", () => {
     const { container } = render(<Markdown>{"Use `myVar` here"}</Markdown>);
     const code = container.querySelector("code");
     expect(code).toBeInTheDocument();
-    expect(code?.className).toContain("bg-foreground");
-    expect(code?.className).toContain("text-background");
-  });
-
-  it("renders code blocks with subtle background when inverted", () => {
-    const { container } = render(<Markdown inverted>{"```js\nconsole.log('hello');\n```"}</Markdown>);
-    const pre = container.querySelector("pre");
-    expect(pre).toBeInTheDocument();
-    expect(pre?.className).toContain("bg-background/20");
-    expect(pre?.className).not.toContain("bg-foreground");
-  });
-
-  it("renders inline code with subtle background when inverted", () => {
-    const { container } = render(<Markdown inverted>{"Use `myVar` here"}</Markdown>);
-    const code = container.querySelector("code");
-    expect(code).toBeInTheDocument();
-    expect(code?.className).toContain("bg-background/20");
-    expect(code?.className).not.toContain("bg-foreground");
+    expect(code?.className).toContain("bg-muted");
+    expect(code?.className).toContain("text-foreground");
   });
 });


### PR DESCRIPTION
## Summary
- Code blocks in chat used `bg-foreground` (solid black) — changed to `bg-muted` for a softer, readable appearance
- User message bubbles used `bg-primary` (dark green + white text) — changed to `bg-primary/10` (light tint + dark text) for better readability on dense messages
- Removed dead `inverted` prop from Markdown component and associated tests

## Test plan
- [ ] Verify code blocks in assistant messages have a soft gray background, not solid black
- [ ] Verify inline code (backtick) also uses the softer style
- [ ] Verify user message bubbles are now a light green tint with dark text
- [ ] Verify readability on long user messages
- [ ] Check dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)