### PR TITLE
fix pi harness: defer session creation to prevent early exit

### DIFF
--- a/priv/sprite/harness/pi-harness.test.ts
+++ b/priv/sprite/harness/pi-harness.test.ts
@@ -43,10 +43,40 @@ describe("PiHarness", () => {
     expect(harness.isProcessing()).toBe(false);
   });
 
-  test("start() initializes without throwing", async () => {
+  test("start() initializes without throwing and does not create session", async () => {
+    const factory = mock(async () => createMockSession());
+    const harness = new PiHarness();
+    harness._setSessionFactory(factory);
+    await harness.start(baseConfig);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  test("session is created lazily on first sendMessage()", async () => {
+    const factory = mock(async () => createMockSession());
+    const harness = new PiHarness();
+    harness.onEvent(() => {});
+    harness._setSessionFactory(factory);
+    await harness.start(baseConfig);
+    expect(factory).not.toHaveBeenCalled();
+    await harness.sendMessage("Hi");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  test("session is reused across multiple sendMessage() calls", async () => {
+    const factory = mock(async () => createMockSession());
+    const harness = new PiHarness();
+    harness.onEvent(() => {});
+    harness._setSessionFactory(factory);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi");
+    await harness.sendMessage("Again");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  test("sendMessage() throws if start() was not called", async () => {
     const harness = new PiHarness();
     harness._setSessionFactory(async () => createMockSession());
-    await harness.start(baseConfig);
+    await expect(harness.sendMessage("Hi")).rejects.toThrow("Harness not started");
   });
 
   test("sendMessage() maps text_delta events correctly", async () => {
@@ -161,10 +191,41 @@ describe("PiHarness", () => {
 
   test("interrupt() calls abort on the session", async () => {
     const harness = new PiHarness();
+    harness.onEvent(() => {});
     const mockSession = createMockSession();
     harness._setSessionFactory(async () => mockSession);
     await harness.start(baseConfig);
+    // Create session by sending a message first
+    await harness.sendMessage("init");
     await harness.interrupt();
     expect(mockSession.abort).toHaveBeenCalledTimes(1);
+  });
+
+  test("interrupt() is a no-op before session is created", async () => {
+    const harness = new PiHarness();
+    harness._setSessionFactory(async () => createMockSession());
+    await harness.start(baseConfig);
+    // Should not throw even though no session exists yet
+    await harness.interrupt();
+  });
+
+  test("concurrent sendMessage() calls only create one session", async () => {
+    const factory = mock(async () => createMockSession());
+    const harness = new PiHarness();
+    harness.onEvent(() => {});
+    harness._setSessionFactory(factory);
+    await harness.start(baseConfig);
+    await Promise.all([harness.sendMessage("A"), harness.sendMessage("B")]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  test("sendMessage() after stop() does not create a new session", async () => {
+    const factory = mock(async () => createMockSession());
+    const harness = new PiHarness();
+    harness._setSessionFactory(factory);
+    await harness.start(baseConfig);
+    await harness.stop();
+    await expect(harness.sendMessage("too late")).rejects.toThrow("Harness is stopped");
+    expect(factory).not.toHaveBeenCalled();
   });
 });

--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -14,6 +14,7 @@ export class PiHarness implements Harness {
   private processing = false;
   private stopped = false;
   private session: SessionLike | null = null;
+  private sessionPending: Promise<SessionLike> | null = null;
   private config: HarnessConfig | null = null;
   private sessionFactory: SessionFactory | null = null;
 
@@ -24,16 +25,29 @@ export class PiHarness implements Harness {
   async start(config: HarnessConfig): Promise<void> {
     this.config = config;
     this.stopped = false;
-    this.session = await this.createSession(config);
-    this.subscribeToSession(this.session);
+  }
+
+  private async ensureSession(): Promise<SessionLike> {
+    if (this.stopped) throw new Error("Harness is stopped");
+    if (this.session) return this.session;
+    if (!this.config) throw new Error("Harness not started");
+    if (!this.sessionPending) {
+      this.sessionPending = this.createSession(this.config).then((s) => {
+        this.subscribeToSession(s);
+        this.session = s;
+        this.sessionPending = null;
+        return s;
+      });
+    }
+    return this.sessionPending;
   }
 
   async sendMessage(text: string, from?: string): Promise<void> {
-    if (!this.session) throw new Error("Harness not started");
+    const session = await this.ensureSession();
     const content = from ? `[Message from agent "${from}"]\n${text}` : text;
     this.processing = true;
     try {
-      await this.session.prompt(content);
+      await session.prompt(content);
     } catch (err) {
       this.emitEvent({ type: "error", payload: { message: String(err) } });
     } finally {


### PR DESCRIPTION
## Summary
- Pi SDK harness agent runner was exiting immediately with code 0 after ~7 seconds because `createAgentSession()` was called eagerly during `start()`, causing the Bun process event loop to drain before inbox watchers could keep it alive
- Deferred session creation to the first `sendMessage()` call, matching the Claude Code harness lazy pattern
- Added promise coalescing to prevent duplicate sessions from concurrent `sendMessage()` calls
- Added stopped guard to prevent session creation after `stop()`

## Test plan
- [x] 16 Pi harness unit tests pass (including new tests for lazy creation, concurrency, and stop-then-send)
- [x] All 68 sprite runner tests pass
- [x] ESLint and Prettier checks pass
- [x] Elixir compilation with `--warnings-as-errors` passes
- [x] All 312 Elixir tests pass
- [ ] Manual test: create a pi-harness agent, verify it stays running and responds to messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)