### PR TITLE
fix bootstrapping status not propagated on server startup

### DIFF
--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -469,17 +469,30 @@ defmodule Shire.Agent.Coordinator do
 
     db_agents = Agents.list_agents(state.project_id)
 
-    monitors =
-      Enum.reduce(db_agents, state.monitors, fn agent, acc ->
-        case start_agent_manager(state.project_id, agent.id, agent.name, acc) do
-          {:ok, _pid, updated_monitors} -> updated_monitors
-          {:error, _} -> acc
+    {monitors, statuses, started_ids} =
+      Enum.reduce(db_agents, {state.monitors, state.statuses, []}, fn agent,
+                                                                      {acc_m, acc_s, acc_ids} ->
+        case start_agent_manager(state.project_id, agent.id, agent.name, acc_m) do
+          {:ok, _pid, updated_monitors} ->
+            {updated_monitors, Map.put(acc_s, agent.id, :bootstrapping), [agent.id | acc_ids]}
+
+          {:error, _} ->
+            {acc_m, acc_s, acc_ids}
         end
       end)
 
+    # Broadcast bootstrapping status to lobby so already-mounted LiveViews see it
+    Enum.each(started_ids, fn agent_id ->
+      Phoenix.PubSub.broadcast(
+        Shire.PubSub,
+        "project:#{state.project_id}:agents:lobby",
+        {:agent_status, agent_id, :bootstrapping}
+      )
+    end)
+
     Logger.info("Project #{state.project_id}: started #{map_size(monitors)} agents")
 
-    {:noreply, %{state | monitors: monitors, deployed: true}}
+    {:noreply, %{state | monitors: monitors, statuses: statuses, deployed: true}}
   rescue
     e ->
       Logger.error("Deploy and scan failed for #{state.project_id}: #{Exception.message(e)}")
@@ -528,15 +541,18 @@ defmodule Shire.Agent.Coordinator do
     opts = [project_id: project_id, agent_id: agent_id, agent_name: agent_name]
     agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}}
 
+    # Subscribe before starting child to catch the initial :bootstrapping broadcast
+    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
+
     case DynamicSupervisor.start_child(agent_sup, {AgentManager, opts}) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
         monitors = Map.put(monitors, ref, agent_id)
-        Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
         Logger.info("Started agent #{agent_name} (#{agent_id}) in project #{project_id}")
         {:ok, pid, monitors}
 
       {:error, reason} ->
+        Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
         Logger.error("Failed to start agent #{agent_name} (#{agent_id}): #{inspect(reason)}")
         {:error, reason}
     end

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -643,6 +643,61 @@ defmodule Shire.Agent.CoordinatorTest do
     end
   end
 
+  describe "deploy_and_scan bootstrapping status propagation" do
+    test "broadcasts :bootstrapping to lobby when agents start during deploy_and_scan" do
+      Mox.set_mox_global()
+
+      stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
+      stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
+      stub(Shire.VirtualMachineMock, :rm_rf, fn _project, _path -> :ok end)
+      stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
+
+      stub(Shire.VirtualMachineMock, :spawn_command, fn _project, _cmd, _args, _opts ->
+        {:error, :not_available_in_test}
+      end)
+
+      # Start with VM not ready so deploy_and_scan defers
+      stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :starting end)
+
+      {:ok, project} = Projects.create_project("test-bootstrap-status")
+      project_id = project.id
+
+      # Create DB agents before starting the coordinator
+      agent_one = create_db_agent(project_id, "boot-agent-one")
+      agent_two = create_db_agent(project_id, "boot-agent-two")
+
+      start_supervised!(
+        {DynamicSupervisor,
+         name: {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}},
+         strategy: :one_for_one},
+        id: :agent_sup_bootstrap
+      )
+
+      start_supervised!(
+        {Shire.Agent.Coordinator, project_id: project_id},
+        id: :coordinator_bootstrap
+      )
+
+      Process.sleep(50)
+
+      # Subscribe to lobby to verify broadcasts
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
+
+      # Now simulate VM becoming ready
+      stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
+      Coordinator.deploy_and_scan(project_id)
+
+      # Lobby should receive :bootstrapping broadcasts for both agents
+      # (agents may subsequently transition to :idle, but the broadcast must happen)
+      agent_one_id = agent_one.id
+      agent_two_id = agent_two.id
+      assert_receive {:agent_status, ^agent_one_id, :bootstrapping}, 1_000
+      assert_receive {:agent_status, ^agent_two_id, :bootstrapping}, 1_000
+    end
+  end
+
   describe "update_agent/3 with invalid new name" do
     test "rejects rename to an invalid slug", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)


### PR DESCRIPTION
## Summary

- Fixed race condition where Coordinator subscribed to agent PubSub topic **after** starting AgentManager, missing the initial `:bootstrapping` broadcast
- Fixed `do_deploy_and_scan` to populate the Coordinator's `statuses` map with `:bootstrapping` for each started agent, and broadcast to the lobby topic so already-mounted LiveViews see the correct status

## Test plan

- [x] New test: verifies `:bootstrapping` broadcasts reach the lobby during `deploy_and_scan`
- [x] All 313 existing tests pass
- [ ] Manual: restart server with existing agents, confirm sidebar shows bootstrapping (pulsing dot) instead of created

🤖 Generated with [Claude Code](https://claude.com/claude-code)