### PR TITLE
Remove lobby relay: AgentManager broadcasts directly to project topic

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -447,6 +447,13 @@ defmodule Shire.Agent.AgentManager do
 
           {:ok, %{"type" => "processing", "payload" => %{"active" => active}}} ->
             broadcast(acc, {:agent_busy, acc.agent_id, active})
+
+            Phoenix.PubSub.broadcast(
+              Shire.PubSub,
+              "project:#{acc.project_id}:agents",
+              {:agent_busy, acc.agent_id, active}
+            )
+
             acc
 
           {:ok, %{"type" => "attachment", "payload" => %{"id" => att_id, "files" => files}}}
@@ -554,6 +561,14 @@ defmodule Shire.Agent.AgentManager do
       "project:#{state.project_id}:agent:#{state.agent_id}",
       {:agent_status, state.agent_id, status}
     )
+
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{state.project_id}:agents",
+      {:agent_status, state.agent_id, status}
+    )
+
+    Shire.Agent.Coordinator.report_status(state.project_id, state.agent_id, status)
 
     state
   end

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -60,9 +60,9 @@ defmodule Shire.Agent.Coordinator do
     GenServer.cast(via(project_id), :restart_idle_agents)
   end
 
-  @doc "Subscribe the coordinator to an agent's PubSub topic (for status relay)."
-  def watch_agent(project_id, agent_id) do
-    GenServer.cast(via(project_id), {:watch_agent, agent_id})
+  @doc "Reports an agent's status directly to the Coordinator (updates internal tracking)."
+  def report_status(project_id, agent_id, status) do
+    GenServer.cast(via(project_id), {:report_status, agent_id, status})
   end
 
   def send_message(project_id, agent_id, text, opts \\ []) do
@@ -147,7 +147,7 @@ defmodule Shire.Agent.Coordinator do
             {:ok, pid, monitors} ->
               Phoenix.PubSub.broadcast(
                 Shire.PubSub,
-                "project:#{state.project_id}:agents:lobby",
+                "project:#{state.project_id}:agents",
                 {:agent_created, agent.id}
               )
 
@@ -214,7 +214,7 @@ defmodule Shire.Agent.Coordinator do
 
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "project:#{state.project_id}:agents:lobby",
+              "project:#{state.project_id}:agents",
               event
             )
 
@@ -262,7 +262,6 @@ defmodule Shire.Agent.Coordinator do
       end)
 
     if ref, do: Process.demonitor(ref, [:flush])
-    Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{state.project_id}:agent:#{agent_id}")
 
     # Delete agent (Multi: rm folder + delete DB record)
     case Agents.get_agent(agent_id) do
@@ -277,7 +276,7 @@ defmodule Shire.Agent.Coordinator do
 
             Phoenix.PubSub.broadcast(
               Shire.PubSub,
-              "project:#{state.project_id}:agents:lobby",
+              "project:#{state.project_id}:agents",
               {:agent_deleted, agent_id}
             )
 
@@ -383,7 +382,7 @@ defmodule Shire.Agent.Coordinator do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{state.project_id}:agents:lobby",
+        "project:#{state.project_id}:agents",
         {:agent_status, agent_id, :crashed}
       )
 
@@ -391,30 +390,6 @@ defmodule Shire.Agent.Coordinator do
     else
       {:noreply, %{state | monitors: monitors}}
     end
-  end
-
-  @impl true
-  def handle_info({:agent_status, agent_id, status}, state) do
-    statuses = Map.put(state.statuses, agent_id, status)
-
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "project:#{state.project_id}:agents:lobby",
-      {:agent_status, agent_id, status}
-    )
-
-    {:noreply, %{state | statuses: statuses}}
-  end
-
-  @impl true
-  def handle_info({:agent_busy, agent_id, active}, state) do
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "project:#{state.project_id}:agents:lobby",
-      {:agent_busy, agent_id, active}
-    )
-
-    {:noreply, state}
   end
 
   @impl true
@@ -457,9 +432,9 @@ defmodule Shire.Agent.Coordinator do
   end
 
   @impl true
-  def handle_cast({:watch_agent, agent_id}, state) do
-    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{state.project_id}:agent:#{agent_id}")
-    {:noreply, state}
+  def handle_cast({:report_status, agent_id, status}, state) do
+    statuses = Map.put(state.statuses, agent_id, status)
+    {:noreply, %{state | statuses: statuses}}
   end
 
   # --- Private ---
@@ -481,11 +456,11 @@ defmodule Shire.Agent.Coordinator do
         end
       end)
 
-    # Broadcast bootstrapping status to lobby so already-mounted LiveViews see it
+    # Broadcast bootstrapping status so already-mounted LiveViews see it
     Enum.each(started_ids, fn agent_id ->
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{state.project_id}:agents:lobby",
+        "project:#{state.project_id}:agents",
         {:agent_status, agent_id, :bootstrapping}
       )
     end)
@@ -541,9 +516,6 @@ defmodule Shire.Agent.Coordinator do
     opts = [project_id: project_id, agent_id: agent_id, agent_name: agent_name]
     agent_sup = {:via, Registry, {Shire.ProjectRegistry, {:agent_sup, project_id}}}
 
-    # Subscribe before starting child to catch the initial :bootstrapping broadcast
-    Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
-
     case DynamicSupervisor.start_child(agent_sup, {AgentManager, opts}) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
@@ -552,7 +524,6 @@ defmodule Shire.Agent.Coordinator do
         {:ok, pid, monitors}
 
       {:error, reason} ->
-        Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
         Logger.error("Failed to start agent #{agent_name} (#{agent_id}): #{inspect(reason)}")
         {:error, reason}
     end

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -21,7 +21,7 @@ defmodule ShireWeb.AgentLive.Index do
 
       {:ok, _pid} ->
         if connected?(socket) do
-          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents")
         end
 
         agents = Coordinator.list_agents(project_id)

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -548,6 +548,25 @@ defmodule Shire.Agent.AgentManagerTest do
       assert_receive {:agent_status, _, :idle}, 1_000
     end
 
+    test "broadcasts status to project agents topic", ctx do
+      {:ok, pid} = start_manager(ctx)
+
+      Phoenix.PubSub.subscribe(
+        Shire.PubSub,
+        "project:#{ctx.project_id}:agents"
+      )
+
+      ref = make_ref()
+
+      :sys.replace_state(pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      send(pid, {:exit, %{ref: ref}, 1})
+
+      assert_receive {:agent_status, _, :idle}, 1_000
+    end
+
     test "transitions to idle when runner errors", ctx do
       {:ok, pid} = start_manager(ctx)
 
@@ -562,6 +581,28 @@ defmodule Shire.Agent.AgentManagerTest do
       state = AgentManager.get_state(pid)
       assert state.status == :idle
       assert state.command == nil
+    end
+  end
+
+  describe "processing event" do
+    test "broadcasts agent_busy to project agents topic", ctx do
+      {:ok, pid} = start_manager(ctx)
+
+      Phoenix.PubSub.subscribe(
+        Shire.PubSub,
+        "project:#{ctx.project_id}:agents"
+      )
+
+      ref = make_ref()
+
+      :sys.replace_state(pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      line = Jason.encode!(%{"type" => "processing", "payload" => %{"active" => true}})
+      send(pid, {:stdout, %{ref: ref}, line <> "\n"})
+
+      assert_receive {:agent_busy, _, true}, 1_000
     end
   end
 

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -45,14 +45,10 @@ defmodule Shire.Agent.CoordinatorTest do
     %{project_id: project_id}
   end
 
-  defp broadcast_status(project_id, agent_id, status) do
-    Phoenix.PubSub.broadcast(
-      Shire.PubSub,
-      "project:#{project_id}:agent:#{agent_id}",
-      {:agent_status, agent_id, status}
-    )
+  defp report_status(project_id, agent_id, status) do
+    Coordinator.report_status(project_id, agent_id, status)
 
-    # Give the Coordinator time to process the async message
+    # Give the Coordinator time to process the async cast
     Process.sleep(50)
   end
 
@@ -65,10 +61,6 @@ defmodule Shire.Agent.CoordinatorTest do
          project_id: project_id, agent_id: agent_id, agent_name: "test-agent", skip_sprite: true},
         id: supervisor_id
       )
-
-    # Ensure the Coordinator subscribes to this agent's topic for status relay
-    Coordinator.watch_agent(project_id, agent_id)
-    Process.sleep(10)
 
     result
   end
@@ -99,8 +91,8 @@ defmodule Shire.Agent.CoordinatorTest do
   end
 
   describe "delete_agent/2" do
-    test "broadcasts {:agent_deleted, id} on lobby", %{project_id: project_id} do
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
+    test "broadcasts {:agent_deleted, id} on project agents topic", %{project_id: project_id} do
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents")
 
       agent = create_db_agent(project_id, "coord-delete-broadcast")
 
@@ -116,7 +108,7 @@ defmodule Shire.Agent.CoordinatorTest do
       agent = create_db_agent(project_id)
       {:ok, _pid} = start_agent_manager(project_id, agent.id)
 
-      broadcast_status(project_id, agent.id, :idle)
+      report_status(project_id, agent.id, :idle)
       assert :idle == Coordinator.agent_status(project_id, agent.id)
 
       # Restart should succeed for a running (idle) agent
@@ -148,7 +140,7 @@ defmodule Shire.Agent.CoordinatorTest do
     test "returns status after PubSub broadcast", %{project_id: project_id} do
       agent = create_db_agent(project_id)
       {:ok, _pid} = start_agent_manager(project_id, agent.id)
-      broadcast_status(project_id, agent.id, :active)
+      report_status(project_id, agent.id, :active)
       assert :active == Coordinator.agent_status(project_id, agent.id)
     end
   end
@@ -157,7 +149,7 @@ defmodule Shire.Agent.CoordinatorTest do
     test "returns status map for given agent IDs", %{project_id: project_id} do
       agent = create_db_agent(project_id)
       {:ok, _pid} = start_agent_manager(project_id, agent.id)
-      broadcast_status(project_id, agent.id, :bootstrapping)
+      report_status(project_id, agent.id, :bootstrapping)
 
       nonexistent = "00000000-0000-0000-0000-000000000000"
       result = Coordinator.agent_statuses(project_id, [agent.id, nonexistent])
@@ -166,14 +158,12 @@ defmodule Shire.Agent.CoordinatorTest do
     end
   end
 
-  describe "status updates via PubSub" do
-    test "coordinator updates internal state from agent topic broadcasts", %{
+  describe "status updates via report_status" do
+    test "coordinator updates internal state from report_status", %{
       project_id: project_id
     } do
       agent = create_db_agent(project_id)
-      Coordinator.watch_agent(project_id, agent.id)
-      Process.sleep(10)
-      broadcast_status(project_id, agent.id, :active)
+      report_status(project_id, agent.id, :active)
       assert :active == Coordinator.agent_status(project_id, agent.id)
     end
   end
@@ -234,7 +224,7 @@ defmodule Shire.Agent.CoordinatorTest do
       {:ok, _pid} = start_agent_manager(project_id, agent.id)
 
       # Mark as active so restart is meaningful
-      broadcast_status(project_id, agent.id, :active)
+      report_status(project_id, agent.id, :active)
 
       result =
         Coordinator.update_agent(project_id, agent.id, %{
@@ -244,10 +234,10 @@ defmodule Shire.Agent.CoordinatorTest do
       assert result == :ok
     end
 
-    test "broadcasts {:agent_updated, id} on lobby", %{project_id: project_id} do
+    test "broadcasts {:agent_updated, id} on project agents topic", %{project_id: project_id} do
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents")
 
       agent = create_db_agent(project_id, "coord-update-broadcast")
 
@@ -325,7 +315,7 @@ defmodule Shire.Agent.CoordinatorTest do
       agent = create_db_agent(project_id, "coord-rename-old")
       new_name = "coord-rename-new-#{System.unique_integer([:positive])}"
 
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents")
 
       result =
         Coordinator.update_agent(project_id, agent.id, %{
@@ -360,7 +350,7 @@ defmodule Shire.Agent.CoordinatorTest do
       {:ok, _pid} = start_agent_manager(project_id, agent.id)
 
       # Mark agent as idle (simulating VM sleep killed the runner)
-      broadcast_status(project_id, agent.id, :idle)
+      report_status(project_id, agent.id, :idle)
       assert :idle == Coordinator.agent_status(project_id, agent.id)
 
       # Subscribe to see the restart status change
@@ -381,7 +371,7 @@ defmodule Shire.Agent.CoordinatorTest do
       {:ok, _pid} = start_agent_manager(project_id, agent.id)
 
       # Mark agent as active
-      broadcast_status(project_id, agent.id, :active)
+      report_status(project_id, agent.id, :active)
 
       # Subscribe to see if status changes
       Phoenix.PubSub.subscribe(
@@ -644,7 +634,7 @@ defmodule Shire.Agent.CoordinatorTest do
   end
 
   describe "deploy_and_scan bootstrapping status propagation" do
-    test "broadcasts :bootstrapping to lobby when agents start during deploy_and_scan" do
+    test "broadcasts :bootstrapping to project topic when agents start during deploy_and_scan" do
       Mox.set_mox_global()
 
       stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
@@ -682,14 +672,14 @@ defmodule Shire.Agent.CoordinatorTest do
 
       Process.sleep(50)
 
-      # Subscribe to lobby to verify broadcasts
-      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents:lobby")
+      # Subscribe to project agents topic to verify broadcasts
+      Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agents")
 
       # Now simulate VM becoming ready
       stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
       Coordinator.deploy_and_scan(project_id)
 
-      # Lobby should receive :bootstrapping broadcasts for both agents
+      # Project agents topic should receive :bootstrapping broadcasts for both agents
       # (agents may subsequently transition to :idle, but the broadcast must happen)
       agent_one_id = agent_one.id
       agent_two_id = agent_two.id

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -53,7 +53,7 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentDashboard"
     end
 
-    test "handles {:agent_status, agent_id, status} from lobby", %{
+    test "handles {:agent_status, agent_id, status} from project agents topic", %{
       conn: conn,
       project_id: project_id,
       project_name: project_name
@@ -62,7 +62,7 @@ defmodule ShireWeb.AgentLiveTest do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{project_id}:agents:lobby",
+        "project:#{project_id}:agents",
         {:agent_status, "test-agent", :active}
       )
 
@@ -79,7 +79,7 @@ defmodule ShireWeb.AgentLiveTest do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{project_id}:agents:lobby",
+        "project:#{project_id}:agents",
         {:agent_busy, "test-agent", true}
       )
 
@@ -187,7 +187,7 @@ defmodule ShireWeb.AgentLiveTest do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{project_id}:agents:lobby",
+        "project:#{project_id}:agents",
         {:agent_status, "my-agent", :bootstrapping}
       )
 
@@ -206,7 +206,7 @@ defmodule ShireWeb.AgentLiveTest do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{project_id}:agents:lobby",
+        "project:#{project_id}:agents",
         {:agent_updated, "some-agent"}
       )
 
@@ -225,7 +225,7 @@ defmodule ShireWeb.AgentLiveTest do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{project_id}:agents:lobby",
+        "project:#{project_id}:agents",
         {:agent_deleted, "some-agent"}
       )
 
@@ -256,7 +256,7 @@ defmodule ShireWeb.AgentLiveTest do
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
-        "project:#{project_id}:agents:lobby",
+        "project:#{project_id}:agents",
         {:agent_event, "unselected-agent", %{"type" => "text_delta"}}
       )
 


### PR DESCRIPTION
## Summary

- **Eliminated the Coordinator relay pattern** — Coordinator was subscribing to per-agent PubSub topics and re-broadcasting `:agent_status` and `:agent_busy` events to an `agents:lobby` topic. This indirection added complexity with no benefit.
- **AgentManager now broadcasts directly** to both `project:X:agent:Y` (per-agent, for Show page) and `project:X:agents` (project-level, for Dashboard)
- **Coordinator tracks status via `report_status/3` cast** instead of PubSub subscription relay
- **Renamed topic** `project:X:agents:lobby` → `project:X:agents`

## Test plan

- [x] All 315 Elixir tests pass
- [x] Frontend TypeScript, ESLint, and Vitest all pass
- [x] Added 2 new tests for project-level broadcasts (status + busy)
- [ ] Manual: verify agent status updates on dashboard, create/delete agents, busy indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)