### PR TITLE
Add SSH VM backend for any VPS

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -26,7 +26,7 @@ end
 
 config :shire, ShireWeb.Endpoint, http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
-# VM backend selection: "sprites" (default), "local"
+# VM backend selection: "sprites" (default), "local", "ssh"
 vm_type = System.get_env("SHIRE_VM_TYPE", "sprites")
 sprites_token = System.get_env("SPRITES_TOKEN")
 sprite_vm_prefix = System.get_env("SPRITE_VM_PREFIX")
@@ -40,6 +40,7 @@ if config_env() != :test do
   vm_module =
     case vm_type do
       "local" -> Shire.VirtualMachineLocal
+      "ssh" -> Shire.VirtualMachineSSH
       _ -> Shire.VirtualMachineSprite
     end
 
@@ -48,6 +49,25 @@ if config_env() != :test do
 
   if sprite_vm_prefix do
     config :shire, :sprite_vm_prefix, sprite_vm_prefix
+  end
+
+  if vm_type == "ssh" do
+    config :shire, :ssh,
+      host:
+        System.get_env("SHIRE_SSH_HOST") ||
+          raise("SHIRE_SSH_HOST is required when SHIRE_VM_TYPE=ssh"),
+      port: String.to_integer(System.get_env("SHIRE_SSH_PORT", "22")),
+      user:
+        System.get_env("SHIRE_SSH_USER") ||
+          raise("SHIRE_SSH_USER is required when SHIRE_VM_TYPE=ssh"),
+      key_path:
+        System.get_env("SHIRE_SSH_KEY") ||
+          raise("SHIRE_SSH_KEY is required when SHIRE_VM_TYPE=ssh"),
+      workspace_root:
+        System.get_env(
+          "SHIRE_SSH_WORKSPACE_ROOT",
+          "/home/#{System.get_env("SHIRE_SSH_USER")}/shire/projects"
+        )
   end
 end
 

--- a/lib/shire/virtual_machine_ssh.ex
+++ b/lib/shire/virtual_machine_ssh.ex
@@ -1,0 +1,569 @@
+defmodule Shire.VirtualMachineSSH do
+  @moduledoc """
+  SSH-based implementation of the VirtualMachine behaviour.
+  Connects to any VPS via SSH for command execution and SFTP for filesystem operations.
+
+  Workspace root: configurable via `SHIRE_SSH_WORKSPACE_ROOT` env var,
+  defaults to `/home/{user}/shire/projects`.
+  """
+  use GenServer
+  require Logger
+  require Record
+
+  @behaviour Shire.VirtualMachine
+
+  Record.defrecordp(
+    :file_info,
+    :file_info,
+    Record.extract(:file_info, from_lib: "kernel/include/file.hrl")
+  )
+
+  @default_cmd_timeout 30_000
+  @connect_timeout 10_000
+  @forward_loop_idle_timeout :timer.minutes(10)
+
+  # --- start_link / child_spec ---
+
+  def start_link(opts) do
+    project_id = Keyword.fetch!(opts, :project_id)
+    GenServer.start_link(__MODULE__, project_id, name: via(project_id))
+  end
+
+  defp via(project_id) do
+    {:via, Registry, {Shire.ProjectRegistry, {:vm, project_id}}}
+  end
+
+  # --- Workspace Root ---
+
+  @impl Shire.VirtualMachine
+  def workspace_root(project_id) do
+    Path.join(ssh_config(:workspace_root), project_id)
+  end
+
+  # --- Command Execution ---
+
+  @impl Shire.VirtualMachine
+  def cmd(project_id, command, args \\ [], opts \\ []) do
+    GenServer.call(via(project_id), {:cmd, command, args, opts}, call_timeout(opts))
+  end
+
+  @impl Shire.VirtualMachine
+  def cmd!(project_id, command, args \\ [], opts \\ []) do
+    case cmd(project_id, command, args, opts) do
+      {:ok, output} ->
+        output
+
+      {:error, {:exit, code, output}} ->
+        raise "SSH command failed (exit #{code}): #{command} #{Enum.join(args, " ")}\n#{output}"
+
+      {:error, reason} ->
+        raise "SSH command failed: #{command} #{Enum.join(args, " ")} — #{inspect(reason)}"
+    end
+  end
+
+  # --- Filesystem ---
+
+  @impl Shire.VirtualMachine
+  def read(project_id, path) do
+    GenServer.call(via(project_id), {:read, path})
+  end
+
+  @impl Shire.VirtualMachine
+  def write(project_id, path, content) do
+    GenServer.call(via(project_id), {:write, path, content})
+  end
+
+  @impl Shire.VirtualMachine
+  def mkdir_p(project_id, path) do
+    GenServer.call(via(project_id), {:mkdir_p, path})
+  end
+
+  @impl Shire.VirtualMachine
+  def rm(project_id, path) do
+    GenServer.call(via(project_id), {:rm, path})
+  end
+
+  @impl Shire.VirtualMachine
+  def rm_rf(project_id, path) do
+    GenServer.call(via(project_id), {:rm_rf, path})
+  end
+
+  @impl Shire.VirtualMachine
+  def ls(project_id, path) do
+    GenServer.call(via(project_id), {:ls, path})
+  end
+
+  @impl Shire.VirtualMachine
+  def stat(project_id, path) do
+    GenServer.call(via(project_id), {:stat, path})
+  end
+
+  # --- Interactive Process ---
+
+  @impl Shire.VirtualMachine
+  def spawn_command(project_id, command, args \\ [], opts \\ []) do
+    conn = GenServer.call(via(project_id), :get_conn)
+
+    if is_nil(conn) do
+      {:error, :no_connection}
+    else
+      spawn_ssh_command(conn, project_id, command, args, opts)
+    end
+  end
+
+  @impl Shire.VirtualMachine
+  def write_stdin(%{pid: pid}, data) do
+    if Process.alive?(pid) do
+      send(pid, {:write, data})
+      :ok
+    else
+      {:error, {:process_dead, :noproc}}
+    end
+  end
+
+  @impl Shire.VirtualMachine
+  def resize(%{pid: pid}, rows, cols) do
+    if Process.alive?(pid) do
+      send(pid, {:resize, rows, cols})
+      :ok
+    else
+      {:error, {:process_dead, :noproc}}
+    end
+  end
+
+  # --- Status & Lifecycle ---
+
+  @impl Shire.VirtualMachine
+  def touch_keepalive(_project_id), do: :ok
+
+  @impl Shire.VirtualMachine
+  def vm_status(project_id) do
+    case Registry.lookup(Shire.ProjectRegistry, {:vm, project_id}) do
+      [{_pid, status}] -> status
+      [] -> :stopped
+    end
+  end
+
+  @impl Shire.VirtualMachine
+  def destroy_vm(project_id) do
+    root = workspace_root(project_id)
+
+    case cmd(project_id, "rm", ["-rf", root]) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # --- GenServer Callbacks ---
+
+  @impl GenServer
+  def init(project_id) do
+    root = workspace_root(project_id)
+    update_registry_status(project_id, :starting)
+
+    Phoenix.PubSub.broadcast(
+      Shire.PubSub,
+      "project:#{project_id}:vm",
+      {:vm_starting, project_id}
+    )
+
+    config = Application.get_env(:shire, :ssh)
+
+    case connect(config) do
+      {:ok, conn, sftp} ->
+        sftp_mkdir_p(sftp, root)
+
+        case Shire.VirtualMachine.Setup.run(build_setup_ops(conn, sftp, root)) do
+          :ok -> :ok
+          {:error, reason} -> Logger.error("SSH VM setup failed: #{inspect(reason)}")
+        end
+
+        Logger.info("SSH VM ready for project #{project_id} at #{config[:host]}:#{root}")
+        update_registry_status(project_id, :running)
+
+        Phoenix.PubSub.broadcast(
+          Shire.PubSub,
+          "project:#{project_id}:vm",
+          {:vm_ready, project_id}
+        )
+
+        {:ok,
+         %{
+           project_id: project_id,
+           conn: conn,
+           sftp: sftp,
+           workspace_root: root
+         }}
+
+      {:error, reason} ->
+        Logger.error("Failed to connect SSH for project #{project_id}: #{inspect(reason)}")
+        {:stop, {:ssh_connect_failed, reason}}
+    end
+  end
+
+  # --- handle_call: Command Execution ---
+
+  @impl GenServer
+  def handle_call({:cmd, command, args, opts}, _from, state) do
+    timeout = Keyword.get(opts, :timeout, @default_cmd_timeout)
+    result = ssh_exec(state.conn, command, args, opts, state.workspace_root, timeout)
+    {:reply, result, state}
+  end
+
+  # --- handle_call: Filesystem ---
+
+  def handle_call({:read, path}, _from, state) do
+    result =
+      case :ssh_sftp.read_file(state.sftp, to_charlist(path)) do
+        {:ok, content} -> {:ok, content}
+        {:error, reason} -> {:error, reason}
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:write, path, content}, _from, state) do
+    sftp_mkdir_p(state.sftp, Path.dirname(path))
+
+    result =
+      case :ssh_sftp.write_file(state.sftp, to_charlist(path), content) do
+        :ok -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:mkdir_p, path}, _from, state) do
+    result = sftp_mkdir_p(state.sftp, path)
+    {:reply, result, state}
+  end
+
+  def handle_call({:rm, path}, _from, state) do
+    result =
+      case :ssh_sftp.delete(state.sftp, to_charlist(path)) do
+        :ok -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:rm_rf, _path}, _from, %{conn: nil} = state) do
+    {:reply, {:error, :no_connection}, state}
+  end
+
+  def handle_call({:rm_rf, path}, _from, state) do
+    result =
+      ssh_exec(state.conn, "rm", ["-rf", path], [], state.workspace_root, @default_cmd_timeout)
+
+    result =
+      case result do
+        {:ok, _} -> :ok
+        error -> error
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:ls, path}, _from, state) do
+    result =
+      case :ssh_sftp.list_dir(state.sftp, to_charlist(path)) do
+        {:ok, entries} ->
+          items =
+            entries
+            |> Enum.reject(fn name -> name in [~c".", ~c".."] end)
+            |> Enum.map(fn name ->
+              name_str = to_string(name)
+              full_path = Path.join(path, name_str)
+
+              case :ssh_sftp.read_file_info(state.sftp, to_charlist(full_path)) do
+                {:ok, fi} ->
+                  %{
+                    "name" => name_str,
+                    "isDir" => file_info(fi, :type) == :directory,
+                    "size" => file_info(fi, :size) || 0
+                  }
+
+                {:error, _} ->
+                  %{"name" => name_str, "isDir" => false, "size" => 0}
+              end
+            end)
+
+          {:ok, items}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:stat, path}, _from, state) do
+    result =
+      case :ssh_sftp.read_file_info(state.sftp, to_charlist(path)) do
+        {:ok, fi} ->
+          type_str = if file_info(fi, :type) == :directory, do: "directory", else: "file"
+          {:ok, %{"type" => type_str, "size" => file_info(fi, :size) || 0}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call(:get_conn, _from, state) do
+    {:reply, state.conn, state}
+  end
+
+  @impl GenServer
+  def terminate(reason, state) do
+    Logger.warning(
+      "VirtualMachineSSH stopping (project: #{state.project_id}): #{inspect(reason)}"
+    )
+
+    if state[:sftp], do: :ssh_sftp.stop_channel(state.sftp)
+    if state[:conn], do: :ssh.close(state.conn)
+  end
+
+  # --- Private: SSH Connection ---
+
+  defp connect(config) do
+    host = to_charlist(config[:host])
+    port = config[:port]
+    user = to_charlist(config[:user])
+    key_path = Path.expand(config[:key_path])
+
+    ssh_opts = [
+      {:user, user},
+      {:key_cb, {Shire.VirtualMachineSSH.KeyCb, key_path: key_path}},
+      {:silently_accept_hosts, true},
+      {:connect_timeout, @connect_timeout},
+      {:user_interaction, false}
+    ]
+
+    case :ssh.connect(host, port, ssh_opts) do
+      {:ok, conn} ->
+        case :ssh_sftp.start_channel(conn) do
+          {:ok, sftp} -> {:ok, conn, sftp}
+          {:error, reason} -> {:error, {:sftp_channel, reason}}
+        end
+
+      {:error, reason} ->
+        {:error, {:ssh_connect, reason}}
+    end
+  end
+
+  # --- Private: Command Execution ---
+
+  defp ssh_exec(conn, command, args, opts, workspace_root, timeout) do
+    env_prefix = build_env_prefix(Keyword.get(opts, :env))
+    dir = Keyword.get(opts, :dir, workspace_root)
+    cmd_str = build_command_string(command, args)
+    full_cmd = "#{env_prefix}cd #{shell_escape(dir)} && #{cmd_str}"
+
+    case :ssh_connection.session_channel(conn, timeout) do
+      {:ok, channel} ->
+        :ok = :ssh_connection.exec(conn, channel, to_charlist(full_cmd), timeout)
+        collect_exec_output(conn, channel, timeout)
+
+      {:error, reason} ->
+        {:error, {:channel_open, reason}}
+    end
+  end
+
+  defp collect_exec_output(conn, channel, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    collect_exec_output(conn, channel, deadline, _output = "", _exit_code = nil)
+  end
+
+  defp collect_exec_output(conn, channel, deadline, output, exit_code) do
+    remaining = max(0, deadline - System.monotonic_time(:millisecond))
+
+    receive do
+      {:ssh_cm, ^conn, {:data, ^channel, _type, data}} ->
+        collect_exec_output(conn, channel, deadline, output <> data, exit_code)
+
+      {:ssh_cm, ^conn, {:eof, ^channel}} ->
+        collect_exec_output(conn, channel, deadline, output, exit_code)
+
+      {:ssh_cm, ^conn, {:exit_status, ^channel, code}} ->
+        collect_exec_output(conn, channel, deadline, output, code)
+
+      {:ssh_cm, ^conn, {:closed, ^channel}} ->
+        code = exit_code || 0
+
+        if code == 0 do
+          {:ok, output}
+        else
+          {:error, {:exit, code, output}}
+        end
+    after
+      remaining ->
+        :ssh_connection.close(conn, channel)
+        {:error, :timeout}
+    end
+  end
+
+  # --- Private: Spawned Interactive Process ---
+
+  defp spawn_ssh_command(conn, project_id, command, args, opts) do
+    caller = self()
+    ref = make_ref()
+    env = Keyword.get(opts, :env)
+    dir = Keyword.get(opts, :dir, workspace_root(project_id))
+    tty = Keyword.get(opts, :tty, false)
+
+    pid =
+      spawn(fn ->
+        case :ssh_connection.session_channel(conn, @default_cmd_timeout) do
+          {:ok, channel} ->
+            if tty do
+              :ssh_connection.ptty_alloc(conn, channel, [
+                {:term, ~c"xterm-256color"},
+                {:width, 80},
+                {:height, 24}
+              ])
+            end
+
+            env_prefix = build_env_prefix(env)
+            cmd_str = build_command_string(command, args)
+            full_cmd = "#{env_prefix}cd #{shell_escape(dir)} && #{cmd_str}"
+
+            :ok = :ssh_connection.exec(conn, channel, to_charlist(full_cmd), @default_cmd_timeout)
+            forward_loop(conn, channel, caller, ref, _exit_code = nil)
+
+          {:error, reason} ->
+            send(caller, {:exit, %{ref: ref}, 1})
+            Logger.error("SSH spawn_command channel open failed: #{inspect(reason)}")
+        end
+      end)
+
+    {:ok, %{ref: ref, pid: pid}}
+  rescue
+    e -> {:error, e}
+  end
+
+  defp forward_loop(conn, channel, caller, ref, exit_code) do
+    receive do
+      {:ssh_cm, ^conn, {:data, ^channel, _type, data}} ->
+        send(caller, {:stdout, %{ref: ref}, data})
+        forward_loop(conn, channel, caller, ref, exit_code)
+
+      {:ssh_cm, ^conn, {:eof, ^channel}} ->
+        forward_loop(conn, channel, caller, ref, exit_code)
+
+      {:ssh_cm, ^conn, {:exit_status, ^channel, code}} ->
+        forward_loop(conn, channel, caller, ref, code)
+
+      {:ssh_cm, ^conn, {:closed, ^channel}} ->
+        send(caller, {:exit, %{ref: ref}, exit_code || 0})
+
+      {:write, data} ->
+        :ssh_connection.send(conn, channel, data)
+        forward_loop(conn, channel, caller, ref, exit_code)
+
+      {:resize, rows, cols} ->
+        :ssh_connection.window_change(conn, channel, cols, rows)
+        forward_loop(conn, channel, caller, ref, exit_code)
+    after
+      @forward_loop_idle_timeout ->
+        Logger.warning("SSH forward_loop idle timeout, closing channel")
+        :ssh_connection.close(conn, channel)
+        send(caller, {:exit, %{ref: ref}, 1})
+    end
+  end
+
+  # --- Private: SFTP Helpers ---
+
+  defp sftp_mkdir_p(sftp, path) do
+    path
+    |> Path.split()
+    |> Enum.reduce_while("", fn part, acc ->
+      dir = if acc == "", do: part, else: Path.join(acc, part)
+
+      case :ssh_sftp.make_dir(sftp, to_charlist(dir)) do
+        :ok ->
+          {:cont, dir}
+
+        {:error, :failure} ->
+          # SFTP :failure is generic — verify it's actually a directory
+          case :ssh_sftp.read_file_info(sftp, to_charlist(dir)) do
+            {:ok, fi} when file_info(fi, :type) == :directory -> {:cont, dir}
+            _ -> {:halt, {:error, {:mkdir_p, dir, :not_a_directory}}}
+          end
+
+        {:error, reason} ->
+          {:halt, {:error, {:mkdir_p, dir, reason}}}
+      end
+    end)
+    |> case do
+      {:error, _} = err -> err
+      _dir -> :ok
+    end
+  end
+
+  # --- Private: Command Building ---
+
+  defp build_command_string(command, []), do: shell_escape(command)
+
+  defp build_command_string(command, args) do
+    escaped_args = Enum.map_join(args, " ", &shell_escape/1)
+    "#{shell_escape(command)} #{escaped_args}"
+  end
+
+  defp build_env_prefix(nil), do: ""
+  defp build_env_prefix([]), do: ""
+
+  defp build_env_prefix(env) when is_list(env) do
+    exports =
+      Enum.map_join(env, " ", fn {k, v} ->
+        "export #{shell_escape(to_string(k))}=#{shell_escape(to_string(v))}"
+      end)
+
+    exports <> " && "
+  end
+
+  defp build_env_prefix(env) when is_map(env) do
+    build_env_prefix(Enum.to_list(env))
+  end
+
+  defp shell_escape(arg) do
+    "'" <> String.replace(arg, "'", "'\\''") <> "'"
+  end
+
+  defp call_timeout(opts) do
+    (Keyword.get(opts, :timeout, @default_cmd_timeout) || @default_cmd_timeout) + 5_000
+  end
+
+  defp ssh_config(key) do
+    Application.get_env(:shire, :ssh)[key]
+  end
+
+  defp build_setup_ops(conn, sftp, workspace_root) do
+    %{
+      write: fn path, content ->
+        sftp_mkdir_p(sftp, Path.dirname(path))
+
+        case :ssh_sftp.write_file(sftp, to_charlist(path), content) do
+          :ok -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+      end,
+      mkdir_p: fn path ->
+        sftp_mkdir_p(sftp, path)
+      end,
+      cmd: fn command, args, opts ->
+        timeout = Keyword.get(opts, :timeout, @default_cmd_timeout)
+        ssh_exec(conn, command, args, opts, workspace_root, timeout)
+      end,
+      runner_dir: Path.join(workspace_root, ".runner"),
+      workspace_root: workspace_root
+    }
+  end
+
+  defp update_registry_status(project_id, status) do
+    Registry.update_value(Shire.ProjectRegistry, {:vm, project_id}, fn _ -> status end)
+  end
+end

--- a/lib/shire/virtual_machine_ssh/key_cb.ex
+++ b/lib/shire/virtual_machine_ssh/key_cb.ex
@@ -1,0 +1,67 @@
+defmodule Shire.VirtualMachineSSH.KeyCb do
+  @moduledoc """
+  SSH client key callback for in-memory private key authentication.
+
+  Implements the `:ssh_client_key_api` behaviour. Reads the private key file
+  from the path provided in options, decodes it, and returns it for authentication.
+  Accepts all host keys (no known_hosts verification).
+  """
+
+  @behaviour :ssh_client_key_api
+
+  @impl true
+  def is_host_key(_key, _host, _port, _algorithm, _opts) do
+    true
+  end
+
+  @impl true
+  def user_key(algorithm, opts) do
+    key_path = opts[:key_path] || raise "SSH key_path not provided in KeyCb options"
+
+    case File.read(key_path) do
+      {:ok, pem} ->
+        pem
+        |> :public_key.pem_decode()
+        |> find_key_for_algorithm(algorithm)
+        |> case do
+          {:ok, key} -> {:ok, key}
+          :error -> {:error, :no_matching_key}
+        end
+
+      {:error, reason} ->
+        {:error, {:key_file_unreadable, key_path, reason}}
+    end
+  end
+
+  defp find_key_for_algorithm(pem_entries, algorithm) do
+    Enum.find_value(pem_entries, :error, fn entry ->
+      key = :public_key.pem_entry_decode(entry)
+
+      if key_matches_algorithm?(key, algorithm) do
+        {:ok, key}
+      end
+    end)
+  end
+
+  defp key_matches_algorithm?(key, algorithm) do
+    case {key, algorithm} do
+      {{:RSAPrivateKey, _, _, _, _, _, _, _, _, _, _}, :"ssh-rsa"} ->
+        true
+
+      {{:ECPrivateKey, _, _, _, _}, algo} ->
+        String.starts_with?(Atom.to_string(algo), "ecdsa-sha2-")
+
+      {{:ed_pri, :ed25519, _, _}, :"ssh-ed25519"} ->
+        true
+
+      {{:ed_pri, :ed448, _, _}, :"ssh-ed448"} ->
+        true
+
+      {{:DSAPrivateKey, _, _, _, _, _, _}, :"ssh-dss"} ->
+        true
+
+      _ ->
+        false
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Shire.MixProject do
   def application do
     [
       mod: {Shire.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :ssh]
     ]
   end
 

--- a/test/shire/virtual_machine_ssh_test.exs
+++ b/test/shire/virtual_machine_ssh_test.exs
@@ -1,0 +1,252 @@
+defmodule Shire.VirtualMachineSSHTest do
+  @moduledoc """
+  Tests for VirtualMachineSSH. Requires a reachable SSH server.
+
+  Run with: mix test --include ssh
+
+  Configure via env vars:
+    SHIRE_SSH_HOST (default: localhost)
+    SHIRE_SSH_PORT (default: 22)
+    SHIRE_SSH_USER (default: current user)
+    SHIRE_SSH_KEY  (default: ~/.ssh/id_ed25519)
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :ssh
+
+  alias Shire.VirtualMachineSSH, as: SSH
+
+  setup_all do
+    host = System.get_env("SHIRE_SSH_HOST", "localhost")
+    user = System.get_env("SHIRE_SSH_USER", System.get_env("USER"))
+    key = System.get_env("SHIRE_SSH_KEY", Path.expand("~/.ssh/id_ed25519"))
+    port = String.to_integer(System.get_env("SHIRE_SSH_PORT", "22"))
+
+    workspace_root =
+      System.get_env("SHIRE_SSH_WORKSPACE_ROOT", "/tmp/shire_ssh_test_#{System.os_time(:second)}")
+
+    Application.put_env(:shire, :ssh,
+      host: host,
+      port: port,
+      user: user,
+      key_path: key,
+      workspace_root: workspace_root
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:shire, :ssh)
+    end)
+
+    %{workspace_root: workspace_root}
+  end
+
+  setup %{workspace_root: workspace_root} do
+    project_id = "test-#{:erlang.unique_integer([:positive])}"
+    root = Path.join(workspace_root, project_id)
+
+    # Start the GenServer — this creates the workspace and runs setup
+    start_supervised!(
+      {Shire.VirtualMachineSSH, [project_id: project_id]},
+      restart: :temporary
+    )
+
+    on_exit(fn ->
+      # Clean up remote workspace
+      try do
+        SSH.cmd(project_id, "rm", ["-rf", root])
+      rescue
+        _ -> :ok
+      catch
+        _, _ -> :ok
+      end
+    end)
+
+    %{project_id: project_id, root: root}
+  end
+
+  describe "workspace_root/1" do
+    test "returns path under configured root", %{project_id: project_id, root: root} do
+      assert SSH.workspace_root(project_id) == root
+    end
+  end
+
+  describe "filesystem operations" do
+    test "write/3 creates file and parent dirs", %{project_id: pid, root: root} do
+      path = Path.join([root, "sub", "dir", "test.txt"])
+      assert :ok = SSH.write(pid, path, "hello")
+      assert {:ok, "hello"} = SSH.read(pid, path)
+    end
+
+    test "read/2 reads file content", %{project_id: pid, root: root} do
+      path = Path.join(root, "read_test.txt")
+      :ok = SSH.write(pid, path, "content here")
+      assert {:ok, "content here"} = SSH.read(pid, path)
+    end
+
+    test "read/2 returns error for missing file", %{project_id: pid, root: root} do
+      path = Path.join(root, "nonexistent.txt")
+      assert {:error, _reason} = SSH.read(pid, path)
+    end
+
+    test "mkdir_p/2 creates nested dirs", %{project_id: pid, root: root} do
+      path = Path.join([root, "a", "b", "c"])
+      assert :ok = SSH.mkdir_p(pid, path)
+      assert {:ok, info} = SSH.stat(pid, path)
+      assert info["type"] == "directory"
+    end
+
+    test "rm/2 removes a file", %{project_id: pid, root: root} do
+      path = Path.join(root, "to_delete.txt")
+      :ok = SSH.write(pid, path, "bye")
+      assert :ok = SSH.rm(pid, path)
+      assert {:error, _} = SSH.read(pid, path)
+    end
+
+    test "rm/2 returns error for missing file", %{project_id: pid, root: root} do
+      path = Path.join(root, "nope.txt")
+      assert {:error, _} = SSH.rm(pid, path)
+    end
+
+    test "rm_rf/2 removes directory tree", %{project_id: pid, root: root} do
+      dir = Path.join(root, "tree")
+      :ok = SSH.mkdir_p(pid, Path.join(dir, "nested"))
+      :ok = SSH.write(pid, Path.join(dir, "nested/file.txt"), "data")
+      assert :ok = SSH.rm_rf(pid, dir)
+      assert {:error, _} = SSH.stat(pid, dir)
+    end
+
+    test "ls/2 returns entries with correct format", %{project_id: pid, root: root} do
+      test_dir = Path.join(root, "ls_test")
+      :ok = SSH.mkdir_p(pid, Path.join(test_dir, "subdir"))
+      :ok = SSH.write(pid, Path.join(test_dir, "file.txt"), "hello")
+
+      assert {:ok, entries} = SSH.ls(pid, test_dir)
+      assert is_list(entries)
+
+      names = Enum.map(entries, & &1["name"])
+      assert "subdir" in names
+      assert "file.txt" in names
+
+      dir_entry = Enum.find(entries, &(&1["name"] == "subdir"))
+      assert dir_entry["isDir"] == true
+
+      file_entry = Enum.find(entries, &(&1["name"] == "file.txt"))
+      assert file_entry["isDir"] == false
+      assert file_entry["size"] == 5
+    end
+
+    test "ls/2 returns error for missing dir", %{project_id: pid, root: root} do
+      assert {:error, _} = SSH.ls(pid, Path.join(root, "nope"))
+    end
+
+    test "stat/2 returns file info", %{project_id: pid, root: root} do
+      path = Path.join(root, "stat_test.txt")
+      :ok = SSH.write(pid, path, "12345")
+      assert {:ok, info} = SSH.stat(pid, path)
+      assert info["type"] == "file"
+      assert info["size"] == 5
+    end
+
+    test "stat/2 returns dir info", %{project_id: pid, root: root} do
+      dir = Path.join(root, "stat_dir")
+      :ok = SSH.mkdir_p(pid, dir)
+      assert {:ok, info} = SSH.stat(pid, dir)
+      assert info["type"] == "directory"
+    end
+
+    test "stat/2 returns error for missing path", %{project_id: pid, root: root} do
+      assert {:error, _} = SSH.stat(pid, Path.join(root, "nope"))
+    end
+  end
+
+  describe "cmd/4" do
+    test "runs a command and returns output", %{project_id: pid} do
+      assert {:ok, output} = SSH.cmd(pid, "echo", ["hello"])
+      assert String.trim(output) == "hello"
+    end
+
+    test "returns error for failing command", %{project_id: pid} do
+      assert {:error, {:exit, code, _output}} = SSH.cmd(pid, "false", [])
+      assert code > 0
+    end
+
+    test "passes environment variables", %{project_id: pid} do
+      assert {:ok, output} =
+               SSH.cmd(pid, "sh", ["-c", "echo $MY_VAR"], env: %{"MY_VAR" => "test_val"})
+
+      assert String.trim(output) == "test_val"
+    end
+  end
+
+  describe "cmd!/4" do
+    test "returns output on success", %{project_id: pid} do
+      assert String.trim(SSH.cmd!(pid, "echo", ["world"])) == "world"
+    end
+
+    test "raises on failure", %{project_id: pid} do
+      assert_raise RuntimeError, fn ->
+        SSH.cmd!(pid, "false", [])
+      end
+    end
+  end
+
+  describe "spawn_command/4" do
+    test "spawns process and receives stdout and exit", %{project_id: pid} do
+      assert {:ok, command} = SSH.spawn_command(pid, "echo", ["hello spawn"])
+      assert is_reference(command.ref)
+
+      assert_receive {:stdout, %{ref: ref}, data}, 5_000
+      assert ref == command.ref
+      assert String.contains?(data, "hello spawn")
+
+      assert_receive {:exit, %{ref: ref}, 0}, 5_000
+      assert ref == command.ref
+    end
+
+    test "write_stdin sends data to process", %{project_id: pid} do
+      assert {:ok, command} = SSH.spawn_command(pid, "head", ["-1"])
+      assert is_reference(command.ref)
+
+      :ok = SSH.write_stdin(command, "ping\n")
+
+      assert_receive {:stdout, %{ref: _}, data}, 5_000
+      assert String.contains?(data, "ping")
+
+      assert_receive {:exit, %{ref: _}, 0}, 5_000
+    end
+
+    test "resize returns :ok", %{project_id: pid} do
+      assert {:ok, command} = SSH.spawn_command(pid, "echo", ["hi"])
+      assert :ok = SSH.resize(command, 30, 100)
+      assert_receive {:exit, _, _}, 5_000
+    end
+
+    test "reports non-zero exit code", %{project_id: pid} do
+      assert {:ok, command} = SSH.spawn_command(pid, "sh", ["-c", "exit 42"])
+
+      assert_receive {:exit, %{ref: ref}, 42}, 5_000
+      assert ref == command.ref
+    end
+
+    test "passes env vars to spawned process", %{project_id: pid} do
+      assert {:ok, _command} =
+               SSH.spawn_command(pid, "sh", ["-c", "echo $SPAWN_VAR"],
+                 env: %{"SPAWN_VAR" => "spawned"}
+               )
+
+      assert_receive {:stdout, _, data}, 5_000
+      assert String.contains?(data, "spawned")
+      assert_receive {:exit, _, 0}, 5_000
+    end
+  end
+
+  describe "vm_status/1 and touch_keepalive/1" do
+    test "vm_status returns :running after init", %{project_id: pid} do
+      assert SSH.vm_status(pid) == :running
+    end
+
+    test "touch_keepalive returns :ok", %{project_id: pid} do
+      assert :ok = SSH.touch_keepalive(pid)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,2 @@
-ExUnit.start()
+ExUnit.start(exclude: [:ssh])
 Ecto.Adapters.SQL.Sandbox.mode(Shire.Repo, :manual)


### PR DESCRIPTION
## Summary

- Adds `VirtualMachineSSH` — a new VM backend that connects to any VPS via SSH, implementing all `VirtualMachine` behaviour callbacks
- Uses pure OTP `:ssh` / `:ssh_sftp` / `:ssh_connection` (zero new dependencies)
- Supports command execution, SFTP file operations, interactive process spawning with PTY/resize, and workspace lifecycle
- SSH key-based authentication via a custom `:ssh_client_key_api` callback module
- Configured via env vars: `SHIRE_VM_TYPE=ssh`, `SHIRE_SSH_HOST`, `SHIRE_SSH_USER`, `SHIRE_SSH_KEY`, etc.

## Files

- `lib/shire/virtual_machine_ssh.ex` — Main GenServer with all behaviour callbacks
- `lib/shire/virtual_machine_ssh/key_cb.ex` — SSH client key callback for in-memory key auth
- `config/runtime.exs` — SSH VM type selection + env var config
- `mix.exs` — Added `:ssh` to extra_applications
- `test/shire/virtual_machine_ssh_test.exs` — Full test suite (tagged `@moduletag :ssh`, run with `mix test --include ssh`)
- `test/test_helper.exs` — Excludes SSH tests by default

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test` — all 340 tests pass (SSH tests excluded by default)
- [ ] Manual: `SHIRE_VM_TYPE=ssh SHIRE_SSH_HOST=<host> SHIRE_SSH_USER=<user> SHIRE_SSH_KEY=~/.ssh/id_ed25519 mix test --include ssh`
- [ ] Manual: Boot server with SSH backend, create project, add agent, verify bootstrap + runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)