### PR TITLE
Batch mkdir calls into single vm.cmd! for fewer VM round-trips

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -577,17 +577,18 @@ defmodule Shire.Agent.AgentManager do
     agent_dir = Workspace.agent_dir(project_id, agent_id)
 
     # Create agent directory structure
-    for subdir <- [
-          "inbox",
-          "outbox",
-          "scripts",
-          "documents",
-          "attachments",
-          "attachments/outbox",
-          ".claude/skills"
-        ] do
-      vm().mkdir_p(project_id, Path.join(agent_dir, subdir))
-    end
+    dirs =
+      for subdir <- [
+            "inbox",
+            "outbox",
+            "scripts",
+            "documents",
+            "attachments/outbox",
+            ".claude/skills"
+          ],
+          do: Path.join(agent_dir, subdir)
+
+    vm().cmd!(project_id, "mkdir", ["-p" | dirs], [])
 
     # Read recipe to determine harness type
     recipe = read_recipe(project_id, agent_id)

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -20,16 +20,19 @@ defmodule Shire.Agents do
     |> Multi.run(:vm_setup, fn _repo, %{agent: agent} ->
       agent_dir = Workspace.agent_dir(project_id, agent.id)
 
-      with :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "inbox")),
-           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "outbox")),
-           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "scripts")),
-           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "documents")),
-           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "attachments")),
-           :ok <- vm.mkdir_p(project_id, Path.join(agent_dir, "attachments/outbox")),
-           :ok <- vm.write(project_id, Path.join(agent_dir, "recipe.yaml"), recipe_yaml) do
-        {:ok, agent.id}
-      else
-        {:error, reason} -> {:error, reason}
+      dirs =
+        for subdir <- ["inbox", "outbox", "scripts", "documents", "attachments/outbox"],
+            do: Path.join(agent_dir, subdir)
+
+      try do
+        vm.cmd!(project_id, "mkdir", ["-p" | dirs], [])
+
+        case vm.write(project_id, Path.join(agent_dir, "recipe.yaml"), recipe_yaml) do
+          :ok -> {:ok, agent.id}
+          {:error, reason} -> {:error, reason}
+        end
+      rescue
+        e -> {:error, Exception.message(e)}
       end
     end)
     |> Repo.transaction()

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -610,6 +610,7 @@ defmodule Shire.Agent.AgentManagerTest do
     test "resets state and transitions to bootstrapping", ctx do
       Mox.set_mox_global()
       stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
       stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
       stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
@@ -701,6 +702,7 @@ defmodule Shire.Agent.AgentManagerTest do
     test "works like restart on first attempt", ctx do
       Mox.set_mox_global()
       stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+      stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
       stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
       stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)
@@ -735,8 +737,9 @@ defmodule Shire.Agent.AgentManagerTest do
       stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
       stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
 
-      # write/mkdir_p/rm_rf should NOT be called — fast path skips setup_agent_workspace
+      # write/mkdir_p/cmd!/rm_rf should NOT be called — fast path skips setup_agent_workspace
       Mox.expect(Shire.VirtualMachineMock, :write, 0, fn _project, _path, _content -> :ok end)
+      Mox.expect(Shire.VirtualMachineMock, :cmd!, 0, fn _project, _cmd, _args, _opts -> "" end)
       Mox.expect(Shire.VirtualMachineMock, :mkdir_p, 0, fn _project, _path -> :ok end)
       Mox.expect(Shire.VirtualMachineMock, :rm_rf, 0, fn _project, _path -> :ok end)
 

--- a/test/shire/agent/coordinator_test.exs
+++ b/test/shire/agent/coordinator_test.exs
@@ -13,6 +13,7 @@ defmodule Shire.Agent.CoordinatorTest do
     # Stub all VM calls with safe defaults before starting the Coordinator
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)

--- a/test/shire/project_manager_test.exs
+++ b/test/shire/project_manager_test.exs
@@ -10,6 +10,7 @@ defmodule Shire.ProjectManagerTest do
 
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)

--- a/test/shire_web/controllers/attachment_controller_test.exs
+++ b/test/shire_web/controllers/attachment_controller_test.exs
@@ -10,6 +10,7 @@ defmodule ShireWeb.AttachmentControllerTest do
 
   setup do
     stub(Shire.VirtualMachineMock, :workspace_root, fn _p -> "/workspace" end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _p, _cmd, _args, _opts -> "" end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _p, _path -> :ok end)
     stub(Shire.VirtualMachineMock, :write, fn _p, _path, _c -> :ok end)
     stub(Shire.VirtualMachineMock, :rm_rf, fn _p, _path -> :ok end)

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -9,6 +9,7 @@ defmodule ShireWeb.AgentLiveTest do
 
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)

--- a/test/shire_web/live/project_details_live_test.exs
+++ b/test/shire_web/live/project_details_live_test.exs
@@ -9,6 +9,7 @@ defmodule ShireWeb.ProjectDetailsLiveTest do
 
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:ok, ""} end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)

--- a/test/shire_web/live/project_live_test.exs
+++ b/test/shire_web/live/project_live_test.exs
@@ -9,6 +9,7 @@ defmodule ShireWeb.ProjectLiveTest do
 
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)

--- a/test/shire_web/live/settings_live_test.exs
+++ b/test/shire_web/live/settings_live_test.exs
@@ -11,6 +11,7 @@ defmodule ShireWeb.SettingsLiveTest do
 
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _project, _cmd, _args, _opts -> "" end)
     stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
     stub(Shire.VirtualMachineMock, :read, fn _project, _path -> {:error, :enoent} end)
     stub(Shire.VirtualMachineMock, :mkdir_p, fn _project, _path -> :ok end)


### PR DESCRIPTION
## Summary
- Replace 6-7 sequential `vm.mkdir_p()` calls with a single `vm.cmd!(project_id, "mkdir", ["-p" | dirs], [])` in both `agents.ex` and `agent_manager.ex`
- Reduces VM round-trips from 6-7 to 1 per agent creation/bootstrap (significant for Sprite backend where each call is an RPC to a Firecracker VM)
- Drop redundant `"attachments"` directory from the list since `mkdir -p attachments/outbox` creates it implicitly

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test` — all 315 tests pass, 0 failures
- [x] Code review subagent — no critical issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)