### PR TITLE
update docs with SSH VM backend and current project structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@
 - **Frontend:** LiveReact (React components inside Phoenix LiveView) + shadcn/ui (Radix + Tailwind v4)
 - **Build:** Vite (not esbuild), Bun (not npm/node)
 - **CSS:** Tailwind v4 with `@theme inline` + oklch CSS variables (shadcn default)
-- **VM:** Pluggable VM backend via `VirtualMachine` behaviour — `VirtualMachineSprite` (Firecracker) for production, `VirtualMachineLocal` (local filesystem + Erlang ports) for development. Selected via `SHIRE_VM_TYPE` env var.
+- **VM:** Pluggable VM backend via `VirtualMachine` behaviour — `VirtualMachineSprite` (Firecracker) for production, `VirtualMachineSSH` (SSH to any VPS) for remote servers, `VirtualMachineLocal` (local filesystem + Erlang ports) for development. Selected via `SHIRE_VM_TYPE` env var.
 - **Agent runtime:** Bun + multi-harness adapter pattern (Pi SDK, Claude Code CLI)
 - **Agent deployment:** Recipe-based (YAML recipes on the VM filesystem, no DB schema)
 - **Agent catalog:** Static YAML agent templates in `priv/catalog/agents/`, read on demand by `Shire.Catalog`
 - **Scheduled tasks:** Oban-based job processing for recurring/one-time automated agent messaging
 - **Inter-agent comms:** File-based inbox/outbox directories + host-side outbox polling + peer discovery via `peers.yaml`
-- **Shared drive:** `/drive` on the VM (Sprite) or local filesystem (Local), synced to all agents at `{workspace_root}/shared/`
+- **Shared drive:** Shared filesystem synced to all agents at `{workspace_root}/shared/` (also mounted at `/drive` on Sprite VMs)
 
 ## Architecture: LiveView + React Split
 
@@ -35,18 +35,19 @@
 
 ## Key Concepts
 
-**Projects** — DB-backed (`projects` table, UUID PK). Each project owns one VM (Sprite or Local) and a set of agents. `ProjectManager` boots all project VMs on startup.
+**Projects** — DB-backed (`projects` table, UUID PK). Each project owns one VM (Sprite, SSH, or Local) and a set of agents. `ProjectManager` boots all project VMs on startup.
 
 **Supervision tree:**
 - `ProjectManager` → `ProjectInstanceSupervisor` (per project, `one_for_all`) → `[VM module, Coordinator, DynamicSupervisor]`
-- VM module is selected at runtime via config (`VirtualMachineSprite` or `VirtualMachineLocal`)
+- VM module is selected at runtime via config (`VirtualMachineSprite`, `VirtualMachineSSH`, or `VirtualMachineLocal`)
 - Registries: `AgentRegistry` (agents by name), `ProjectRegistry` (project supervisors by ID)
 
 **VM backends:**
 - `VirtualMachineSprite` — Production backend using Fly.io Sprites (Firecracker VMs). Workspace at `/workspace`.
+- `VirtualMachineSSH` — SSH backend for connecting to any VPS. Uses SSH key-based auth (via `KeyCb` callback) + SFTP for filesystem operations. Workspace root configurable via `SHIRE_SSH_WORKSPACE_ROOT`.
 - `VirtualMachineLocal` — Development backend using local filesystem (`~/.shire/projects/{project_id}/`) + Erlang ports for process execution.
-- Both implement the `Shire.VirtualMachine` behaviour. `Shire.Workspace` delegates path resolution to the configured backend.
-- `VirtualMachine.Setup` — Shared setup logic (bootstrap + runner deployment) used by both backends during init.
+- All implement the `Shire.VirtualMachine` behaviour. `Shire.Workspace` delegates path resolution to the configured backend.
+- `VirtualMachine.Setup` — Shared setup logic (bootstrap + runner deployment) used by all backends during init.
 
 **Recipes** — YAML files defining agents (`name`, `description`, `harness`, `scripts`). Live on the VM at `{workspace_root}/agents/{id}/recipe.yaml` — no DB schema for recipes. Agents themselves are DB-backed with a unique constraint on `(project_id, name)`.
 
@@ -76,13 +77,19 @@ lib/shire/
     coordinator.ex                # Per-project: VM bootstrap, agent CRUD, message routing
     terminal_session.ex           # Interactive TTY on the VM
   catalog.ex                      # Reads agent templates from priv/catalog/
+  projects/
+    project.ex                    # Ecto schema for projects
   schedules.ex                    # Context: Scheduled task CRUD
   schedules/
     scheduled_task.ex             # Ecto schema for scheduled tasks
+  slug.ex                         # Slug generation
   virtual_machine.ex              # Behaviour (cmd, read, write, spawn_command, etc.)
   virtual_machine/
     setup.ex                      # Shared VM setup logic (bootstrap + runner deployment)
   virtual_machine_sprite.ex       # GenServer wrapping Sprites SDK (production)
+  virtual_machine_ssh.ex          # SSH to any VPS via SSH + SFTP
+  virtual_machine_ssh/
+    key_cb.ex                     # SSH client key callback for key-based auth
   virtual_machine_local.ex        # Local filesystem + Erlang ports (development)
   workspace.ex                    # Workspace path resolution (delegates to VM backend)
   workspace_settings.ex           # Per-project env vars and scripts
@@ -102,11 +109,27 @@ lib/shire_web/live/
   schedule_live/index.ex          # SchedulesPage
 
 assets/react-components/
-  *.tsx                           # One page-level component per LiveView + shared components
-  components/ui/                  # shadcn/ui primitives
+  AgentDashboard.tsx              # Agent list + chat panel for a project
+  AgentShow.tsx                   # Single agent detail view
+  AgentForm.tsx                   # Agent creation/edit form
+  ProjectDashboard.tsx            # Root "/" — project list
+  ProjectDetailsPage.tsx          # Project rename, edit PROJECT.md
+  SettingsPage.tsx                # Project settings (env vars, scripts)
+  SharedDrive.tsx                 # Shared drive file browser
+  SchedulesPage.tsx               # Scheduled tasks management
+  ActivityLog.tsx                 # Agent activity log
+  CatalogBrowser.tsx              # Browse agent catalog templates
+  WelcomePanel.tsx                # Welcome/onboarding panel
+  Terminal.tsx                    # xterm.js interactive terminal
+  ProjectSwitcher.tsx             # Project dropdown switcher
+  AgentSidebar.tsx                # Agent list sidebar
+  ChatHeader.tsx                  # Chat panel header
+  ChatPanel.tsx                   # Chat message list + input
   components/AppLayout.tsx        # Shared layout wrapper
+  components/Markdown.tsx         # Markdown renderer
+  components/ui/                  # shadcn/ui primitives
   lib/navigate.ts                 # LiveView navigation utility
-  test/                           # Vitest component tests (one per component)
+  lib/utils.ts                    # Shared utilities (cn, etc.)
 
 priv/sprite/                      # Agent runtime, deployed to {workspace_root}/.runner/
   agent-runner.ts                 # Daemon: watches inbox, dispatches to harness, emits JSONL
@@ -146,8 +169,11 @@ mix precommit
 
 ## Environment
 
-- `SHIRE_VM_TYPE` — selects VM backend: `sprites` (default, Firecracker) or `local` (local filesystem for dev)
+- `SHIRE_VM_TYPE` — selects VM backend: `sprites` (default, Firecracker), `ssh` (any VPS via SSH), or `local` (local filesystem for dev)
 - `SPRITES_TOKEN` — required when using the Sprite backend
+- `SHIRE_SSH_HOST` / `SHIRE_SSH_USER` / `SHIRE_SSH_KEY` — required when using the SSH backend
+- `SHIRE_SSH_PORT` — SSH port (default: `22`)
+- `SHIRE_SSH_WORKSPACE_ROOT` — workspace root on the remote host (default: `/home/{user}/shire/projects`)
 - `ANTHROPIC_API_KEY` — passed to agents using the Pi SDK harness
 
 ## Guidelines

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Shire is an open platform for deploying, orchestrating, and collaborating with A
 Most agent platforms treat agents as stateless API calls. Shire gives every agent a **home** — a persistent workspace with its own filesystem, tools, and mailbox. Agents don't just run. They *live* here.
 
 - 📁 **Multi-project architecture** — Organize agents into projects, each with its own dedicated VM, shared drive, and settings. Spin up as many isolated environments as you need.
-- 🏠 **Persistent workspaces** — Each agent gets its own workspace directory with inbox/outbox, scripts, and documents — backed by a Firecracker VM in production or local filesystem in development.
+- 🏠 **Persistent workspaces** — Each agent gets its own workspace directory with inbox/outbox, scripts, and documents — backed by a Firecracker VM, remote VPS via SSH, or local filesystem.
+- 🌐 **SSH VM backend** — Connect to any VPS over SSH. Run agents on your own infrastructure with key-based authentication and SFTP file operations.
 - 🔌 **Multi-harness architecture** — Bring your own runtime. Shire supports multiple agent harnesses (Pi SDK, Claude Code CLI) through a unified adapter pattern.
 - 📜 **Recipe-based deployment** — Define agents as simple YAML recipes with setup scripts that run idempotently. No Dockerfiles, no complex configs.
 - 📚 **Agent catalog** — Browse and deploy agents from a built-in catalog of pre-built templates organized by category (design, marketing, engineering, and more).
@@ -48,7 +49,7 @@ Most agent platforms treat agents as stateless API calls. Shire gives every agen
 │  Project A                   │  │  Project B                   │
 │  (ProjectInstanceSupervisor) │  │  (ProjectInstanceSupervisor) │
 │  ┌────────────────────────┐  │  │  ┌────────────────────────┐  │
-│  │ VM (Sprite or Local)   │  │  │  │ VM (Sprite or Local)   │  │
+│  │ VM (Sprite/SSH/Local)  │  │  │  │ VM (Sprite/SSH/Local)  │  │
 │  │ Coordinator            │  │  │  │ Coordinator            │  │
 │  │ AgentMgr A, B, ...     │  │  │  │ AgentMgr C, D, ...     │  │
 │  │ Terminal Session       │  │  │  │ Terminal Session       │  │
@@ -58,7 +59,7 @@ Most agent platforms treat agents as stateless API calls. Shire gives every agen
                ▼                                 ▼
 ┌──────────────────────────────┐  ┌──────────────────────────────┐
 │  VM (A)                      │  │  VM (B)                      │
-│  Sprite or Local per project │  │  Sprite or Local per project │
+│  Sprite, SSH, or Local       │  │  Sprite, SSH, or Local       │
 │                              │  │                              │
 │  {workspace_root}/             │  │  {workspace_root}/             │
 │  ├── agents/                 │  │  ├── agents/                 │
@@ -89,7 +90,7 @@ Shire is built on top of [**Fly.io Sprites**](https://sprites.dev) — lightweig
 
 Shire uses the [Sprites Elixir SDK](https://github.com/superfly/sprites-ex) to manage VM lifecycles, execute commands, sync files, and stream terminal sessions — all from the Phoenix backend.
 
-> 💡 **Local development mode:** Don't have a Sprites account? Set `SHIRE_VM_TYPE=local` to use a local filesystem backend instead. Agent workspaces live at `~/.shire/projects/` and processes run as local Erlang ports.
+> 💡 **Alternative backends:** Don't have a Sprites account? Set `SHIRE_VM_TYPE=ssh` to connect to any VPS over SSH, or `SHIRE_VM_TYPE=local` to use a local filesystem backend. Agent workspaces live at `~/.shire/projects/` in local mode and processes run as local Erlang ports.
 
 ## 🧰 Tech Stack
 
@@ -99,7 +100,7 @@ Shire uses the [Sprites Elixir SDK](https://github.com/superfly/sprites-ex) to m
 | Frontend | LiveReact (React inside Phoenix LiveView), shadcn/ui, Tailwind v4 |
 | Build | Vite, Bun |
 | Agent Runtime | Bun + TypeScript, multi-harness adapter pattern |
-| VM | Pluggable: [Fly.io Sprites](https://sprites.dev) (Firecracker) or Local (dev) |
+| VM | Pluggable: [Fly.io Sprites](https://sprites.dev) (Firecracker), SSH (any VPS), or Local (dev) |
 | Job Processing | [Oban](https://getoban.pro/) (scheduled tasks, recurring jobs) |
 
 ## 🚀 Getting Started
@@ -109,7 +110,7 @@ Shire uses the [Sprites Elixir SDK](https://github.com/superfly/sprites-ex) to m
 - Elixir 1.15+
 - PostgreSQL
 - [Bun](https://bun.sh)
-- A [Sprites](https://sprites.dev) account (for the `SPRITES_TOKEN`) — optional if using the local VM backend
+- A [Sprites](https://sprites.dev) account (for the `SPRITES_TOKEN`) — optional if using the SSH or local VM backend
 
 ### Environment Variables
 
@@ -119,11 +120,11 @@ Create a `.env` file in the project root. It's automatically loaded in dev/test 
 
 | Variable | Description |
 |----------|-------------|
-| `SPRITES_TOKEN` | Sprites SDK authentication token from [sprites.dev](https://sprites.dev) (not needed with local VM backend) |
+| `SPRITES_TOKEN` | Sprites SDK authentication token from [sprites.dev](https://sprites.dev) (not needed with SSH or local VM backend) |
 | `DATABASE_URL` | PostgreSQL connection string (production only — dev uses local defaults) |
 | `SECRET_KEY_BASE` | Phoenix cookie/session secret. Generate with: `mix phx.gen.secret` |
 
-> 💡 In development with local VM backend (`SHIRE_VM_TYPE=local`), no external tokens are needed. With Sprite VMs, only `SPRITES_TOKEN` is required.
+> 💡 In development with local VM backend (`SHIRE_VM_TYPE=local`), no external tokens are needed. The SSH backend (`SHIRE_VM_TYPE=ssh`) requires `SHIRE_SSH_HOST`, `SHIRE_SSH_USER`, and `SHIRE_SSH_KEY`. With Sprite VMs, only `SPRITES_TOKEN` is required.
 
 **Optional:**
 
@@ -135,7 +136,12 @@ Create a `.env` file in the project root. It's automatically loaded in dev/test 
 | `ECTO_IPV6` | — | Set to `true` to enable IPv6 for database connections |
 | `DNS_CLUSTER_QUERY` | — | DNS query for distributed Erlang node discovery |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key, passed to agents using the Pi SDK harness |
-| `SHIRE_VM_TYPE` | `sprites` | VM backend: `sprites` (Firecracker) or `local` (local filesystem for dev) |
+| `SHIRE_VM_TYPE` | `sprites` | VM backend: `sprites` (Firecracker), `ssh` (any VPS), or `local` (local filesystem for dev) |
+| `SHIRE_SSH_HOST` | — | SSH hostname (required when `SHIRE_VM_TYPE=ssh`) |
+| `SHIRE_SSH_USER` | — | SSH username (required when `SHIRE_VM_TYPE=ssh`) |
+| `SHIRE_SSH_KEY` | — | Path to SSH private key (required when `SHIRE_VM_TYPE=ssh`) |
+| `SHIRE_SSH_PORT` | `22` | SSH port |
+| `SHIRE_SSH_WORKSPACE_ROOT` | `/home/$SHIRE_SSH_USER/shire/projects` | Workspace root on the remote host |
 
 ### Setup
 
@@ -167,7 +173,7 @@ cd assets && bun run test          # Frontend tests
 
 ### 1. Create a Project
 
-Projects are the top-level unit in Shire. Each project gets its own dedicated VM (Sprite or Local) with isolated storage and networking. Create one from the dashboard at `/`. 📁
+Projects are the top-level unit in Shire. Each project gets its own dedicated VM (Sprite, SSH, or Local) with isolated storage and networking. Create one from the dashboard at `/`. 📁
 
 ### 2. Define a Recipe
 


### PR DESCRIPTION
## Summary
- Add SSH VM backend (`VirtualMachineSSH`) to CLAUDE.md and README.md alongside Sprite and Local backends
- Update CLAUDE.md folder structure with new files: `virtual_machine_ssh.ex`, `virtual_machine_ssh/key_cb.ex`, `projects/project.ex`, `slug.ex`
- Expand react-components listing in CLAUDE.md to show all page and layout components
- Add SSH environment variables (`SHIRE_SSH_HOST`, `SHIRE_SSH_USER`, `SHIRE_SSH_KEY`, `SHIRE_SSH_PORT`, `SHIRE_SSH_WORKSPACE_ROOT`) to both docs
- Fix shared drive description to be backend-agnostic

## Test plan
- [x] Verified SSH env var names match `config/runtime.exs`
- [x] Verified file paths match actual directory listings
- [x] Code review passed with fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)