### PR TITLE
Add dark/light/system theme toggle

### DIFF
--- a/assets/react-components/SettingsPage.tsx
+++ b/assets/react-components/SettingsPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "./components/ui/alert-dialog";
 import { ChevronLeft, Play, Trash2, Plus, X } from "lucide-react";
 import AppLayout from "./components/AppLayout";
+import ThemeSelector from "./components/ThemeSelector";
 import { navigate } from "./lib/navigate";
 import ActivityLog from "./ActivityLog";
 import Terminal from "./Terminal";
@@ -151,6 +152,7 @@ export default function SettingsPage({
             <TabsTrigger value="scripts">Scripts</TabsTrigger>
             <TabsTrigger value="terminal">Terminal</TabsTrigger>
             <TabsTrigger value="activity">Activity Log</TabsTrigger>
+            <TabsTrigger value="appearance">Appearance</TabsTrigger>
           </TabsList>
 
           <TabsContent value="environment" className="space-y-4 pt-4">
@@ -288,6 +290,10 @@ export default function SettingsPage({
 
           <TabsContent value="activity" className="pt-4">
             <ActivityLog messages={messages} hasMore={has_more_messages} pushEvent={pushEvent} />
+          </TabsContent>
+
+          <TabsContent value="appearance" className="space-y-4 pt-4">
+            <ThemeSelector />
           </TabsContent>
         </Tabs>
       </div>

--- a/assets/react-components/Terminal.tsx
+++ b/assets/react-components/Terminal.tsx
@@ -184,9 +184,18 @@ export default function Terminal({ pushEvent }: TerminalProps) {
     // Connect to server
     pushEventRef.current("connect-terminal", {});
 
+    // Re-read terminal CSS vars when theme changes (`.dark` class toggled on <html>)
+    const themeObserver = new MutationObserver(() => {
+      const bg = getComputedStyle(document.documentElement).getPropertyValue("--terminal-bg").trim() || "#1a1a1a";
+      const fg = getComputedStyle(document.documentElement).getPropertyValue("--terminal-fg").trim() || "#e5e5e5";
+      term.options = { theme: { ...term.options.theme, background: bg, foreground: fg } };
+    });
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+
     return () => {
       clearTimeout(resizeTimeout);
       observer.disconnect();
+      themeObserver.disconnect();
       predictor.dispose();
       dataDisposable.dispose();
       removeHandleEventRef.current(outputRef);

--- a/assets/react-components/components/AppLayout.tsx
+++ b/assets/react-components/components/AppLayout.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
+import { ThemeProvider } from "./ThemeProvider";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <main className="pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] sm:pl-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] lg:pl-[max(2rem,env(safe-area-inset-left))] lg:pr-[max(2rem,env(safe-area-inset-right))]">
-      <div className="mx-auto max-w-5xl">{children}</div>
-    </main>
+    <ThemeProvider>
+      <main className="pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] sm:pl-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] lg:pl-[max(2rem,env(safe-area-inset-left))] lg:pr-[max(2rem,env(safe-area-inset-right))]">
+        <div className="mx-auto max-w-5xl">{children}</div>
+      </main>
+    </ThemeProvider>
   );
 }

--- a/assets/react-components/components/ThemeProvider.tsx
+++ b/assets/react-components/components/ThemeProvider.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  React.useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent | { matches: boolean }) => {
+      const theme = localStorage.getItem("theme");
+      if (!theme || theme === "system") {
+        document.documentElement.classList.toggle("dark", e.matches);
+      }
+    };
+    handler({ matches: mq.matches });
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  return <>{children}</>;
+}

--- a/assets/react-components/components/ThemeSelector.tsx
+++ b/assets/react-components/components/ThemeSelector.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { Button } from "./ui/button";
+import { Label } from "./ui/label";
+
+type Theme = "light" | "dark" | "system";
+
+function applyTheme(theme: Theme) {
+  const isDark = theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+  document.documentElement.classList.toggle("dark", isDark);
+}
+
+const themeOptions: { value: Theme; label: string; icon: React.ReactNode }[] = [
+  { value: "light", label: "Light", icon: <Sun className="h-5 w-5" /> },
+  { value: "dark", label: "Dark", icon: <Moon className="h-5 w-5" /> },
+  { value: "system", label: "System", icon: <Monitor className="h-5 w-5" /> },
+];
+
+export default function ThemeSelector() {
+  const [theme, setThemeState] = React.useState<Theme>(() => {
+    const stored = localStorage.getItem("theme");
+    return stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+  });
+
+  const setTheme = (newTheme: Theme) => {
+    localStorage.setItem("theme", newTheme);
+    setThemeState(newTheme);
+    applyTheme(newTheme);
+  };
+
+  return (
+    <div className="space-y-3">
+      <Label>Theme</Label>
+      <div className="flex gap-3">
+        {themeOptions.map((opt) => (
+          <Button
+            key={opt.value}
+            variant={theme === opt.value ? "default" : "outline"}
+            className="flex flex-col items-center gap-2 h-auto py-4 px-6"
+            onClick={() => setTheme(opt.value)}
+            data-active={theme === opt.value}
+            aria-label={opt.label}
+          >
+            {opt.icon}
+            <span className="text-sm">{opt.label}</span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/assets/test/SettingsPage.test.tsx
+++ b/assets/test/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import SettingsPage from "../react-components/SettingsPage";
 
 vi.mock("../react-components/Terminal", () => ({
@@ -17,6 +17,21 @@ const defaultProps = {
 };
 
 const messages = [{ id: 1, from_agent: "Alice", to_agent: "Bob", text: "Hello!", ts: "2026-03-17T10:00:00Z" }];
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove("dark");
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  });
+});
 
 describe("SettingsPage", () => {
   it("renders with Settings heading", () => {
@@ -141,5 +156,46 @@ describe("SettingsPage", () => {
     await userEvent.type(valueInput, "new");
     await userEvent.click(screen.getByRole("button", { name: "Save Environment" }));
     expect(pushEvent).toHaveBeenCalledWith("save-env", { content: "OLD=new" });
+  });
+
+  it("shows Appearance tab with theme options", async () => {
+    render(<SettingsPage {...defaultProps} />);
+    await userEvent.click(screen.getByText("Appearance"));
+    expect(screen.getByText("Light")).toBeInTheDocument();
+    expect(screen.getByText("Dark")).toBeInTheDocument();
+    expect(screen.getByText("System")).toBeInTheDocument();
+  });
+
+  it("defaults to System theme active in Appearance tab", async () => {
+    render(<SettingsPage {...defaultProps} />);
+    await userEvent.click(screen.getByText("Appearance"));
+    const systemButton = screen.getByRole("button", { name: /System/ });
+    expect(systemButton.getAttribute("data-active")).toBe("true");
+  });
+
+  it("highlights current theme in Appearance tab", async () => {
+    localStorage.setItem("theme", "dark");
+    render(<SettingsPage {...defaultProps} />);
+    await userEvent.click(screen.getByText("Appearance"));
+    const darkButton = screen.getByRole("button", { name: /Dark/ });
+    expect(darkButton.getAttribute("data-active")).toBe("true");
+  });
+
+  it("switches theme when clicking a theme option", async () => {
+    render(<SettingsPage {...defaultProps} />);
+    await userEvent.click(screen.getByText("Appearance"));
+    await userEvent.click(screen.getByRole("button", { name: /Dark/ }));
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("removes .dark class when switching to Light", async () => {
+    localStorage.setItem("theme", "dark");
+    document.documentElement.classList.add("dark");
+    render(<SettingsPage {...defaultProps} />);
+    await userEvent.click(screen.getByText("Appearance"));
+    await userEvent.click(screen.getByRole("button", { name: /Light/ }));
+    expect(localStorage.getItem("theme")).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 });

--- a/assets/test/ThemeProvider.test.tsx
+++ b/assets/test/ThemeProvider.test.tsx
@@ -1,0 +1,102 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ThemeProvider } from "../react-components/components/ThemeProvider";
+
+let matchMediaListeners: Array<(e: { matches: boolean }) => void> = [];
+let matchMediaMatches = false;
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove("dark");
+  matchMediaListeners = [];
+  matchMediaMatches = false;
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)" ? matchMediaMatches : false,
+      media: query,
+      addEventListener: (_event: string, handler: (e: { matches: boolean }) => void) => {
+        matchMediaListeners.push(handler);
+      },
+      removeEventListener: (_event: string, handler: (e: { matches: boolean }) => void) => {
+        matchMediaListeners = matchMediaListeners.filter((h) => h !== handler);
+      },
+    })),
+  );
+});
+
+afterEach(() => {
+  document.documentElement.classList.remove("dark");
+  vi.unstubAllGlobals();
+});
+
+describe("ThemeProvider", () => {
+  it("renders children", () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span>hello</span>
+      </ThemeProvider>,
+    );
+    expect(container.textContent).toBe("hello");
+  });
+
+  it("syncs .dark class on mount when system prefers dark", () => {
+    matchMediaMatches = true;
+    render(
+      <ThemeProvider>
+        <span>test</span>
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("does not add .dark on mount when system prefers light", () => {
+    matchMediaMatches = false;
+    render(
+      <ThemeProvider>
+        <span>test</span>
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("responds to system preference changes when theme is system", () => {
+    render(
+      <ThemeProvider>
+        <span>test</span>
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    act(() => {
+      matchMediaListeners.forEach((fn) => fn({ matches: true }));
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("ignores system preference changes when theme is explicitly set", () => {
+    localStorage.setItem("theme", "light");
+    render(
+      <ThemeProvider>
+        <span>test</span>
+      </ThemeProvider>,
+    );
+
+    act(() => {
+      matchMediaListeners.forEach((fn) => fn({ matches: true }));
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("cleans up listener on unmount", () => {
+    const { unmount } = render(
+      <ThemeProvider>
+        <span>test</span>
+      </ThemeProvider>,
+    );
+    expect(matchMediaListeners.length).toBe(1);
+    unmount();
+    expect(matchMediaListeners.length).toBe(0);
+  });
+});

--- a/assets/test/setup.ts
+++ b/assets/test/setup.ts
@@ -12,6 +12,17 @@ class MockResizeObserver {
 }
 global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
+// Mock matchMedia for jsdom (ThemeProvider uses it)
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })),
+});
+
 // Mock useLiveReact globally — individual tests can override via vi.mocked()
 vi.mock("live_react", () => ({
   useLiveReact: vi.fn(() => ({

--- a/lib/shire_web/components/layouts/root.html.heex
+++ b/lib/shire_web/components/layouts/root.html.heex
@@ -7,6 +7,13 @@
     <.live_title default="Shire" suffix=" · Phoenix Framework">
       {assigns[:page_title]}
     </.live_title>
+    <script>
+      (function() {
+        var t = localStorage.getItem("theme");
+        var dark = t === "dark" || (t !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+        if (dark) document.documentElement.classList.add("dark");
+      })();
+    </script>
     <LiveReact.Reload.vite_assets assets={["js/app.js", "css/app.css"]}>
       <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
       <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>


### PR DESCRIPTION
## Summary
- Adds theme toggle (light/dark/system) to Settings > Appearance tab
- Anti-flash inline script prevents wrong-theme flash on page load
- ThemeProvider listens for OS preference changes in system mode
- Terminal re-reads CSS variables when theme switches

## Test plan
- [ ] Open Settings > Appearance tab, verify light/dark/system buttons render
- [ ] Click Dark — app switches to dark mode immediately
- [ ] Click Light — app switches to light mode
- [ ] Click System — app follows OS preference
- [ ] Refresh page — theme persists (no flash of wrong theme)
- [ ] Toggle OS dark mode while in System — app updates
- [ ] Open Terminal tab after switching theme — colors match

🤖 Generated with [Claude Code](https://claude.com/claude-code)