### PR TITLE
Add file preview panel to shared drive

### DIFF
--- a/assets/react-components/SharedDrive.tsx
+++ b/assets/react-components/SharedDrive.tsx
@@ -20,8 +20,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./components/ui/alert-dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/tabs";
 import AppLayout from "./components/AppLayout";
-import { ChevronLeft, Folder, File } from "lucide-react";
+import Markdown from "./components/Markdown";
+import { ChevronLeft, Folder, File, X, Download } from "lucide-react";
 import { navigate as navigateTo } from "./lib/navigate";
 
 export interface SharedDriveFile {
@@ -35,7 +37,67 @@ interface SharedDriveProps {
   project: { id: string; name: string };
   files: SharedDriveFile[];
   current_path: string;
-  pushEvent: (event: string, payload: Record<string, unknown>) => void;
+  pushEvent: (
+    event: string,
+    payload: Record<string, unknown>,
+    onReply?: (reply: Record<string, unknown>) => void,
+  ) => void;
+}
+
+type PreviewType = "markdown" | "text" | "image" | "pdf" | "unsupported";
+
+const TEXT_EXTENSIONS = new Set([
+  "txt",
+  "json",
+  "yaml",
+  "yml",
+  "toml",
+  "csv",
+  "log",
+  "sh",
+  "bash",
+  "zsh",
+  "js",
+  "ts",
+  "jsx",
+  "tsx",
+  "py",
+  "rb",
+  "ex",
+  "exs",
+  "erl",
+  "rs",
+  "go",
+  "java",
+  "c",
+  "cpp",
+  "h",
+  "html",
+  "css",
+  "scss",
+  "xml",
+  "sql",
+  "env",
+  "gitignore",
+  "dockerfile",
+  "makefile",
+]);
+
+const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "svg", "webp", "ico", "bmp"]);
+
+function getFileExtension(name: string): string {
+  const lower = name.toLowerCase();
+  const dotIndex = lower.lastIndexOf(".");
+  return dotIndex > 0 ? lower.slice(dotIndex + 1) : lower;
+}
+
+function getPreviewType(name: string): PreviewType {
+  const ext = getFileExtension(name);
+  if (ext === "md") return "markdown";
+  if (TEXT_EXTENSIONS.has(ext)) return "text";
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (ext === "pdf") return "pdf";
+  return "unsupported";
 }
 
 function formatSize(bytes: number): string {
@@ -68,6 +130,68 @@ function Breadcrumbs({ path, onNavigate }: { path: string; onNavigate: (path: st
   );
 }
 
+function PreviewContent({
+  file,
+  projectName,
+  content,
+  loading,
+  error,
+}: {
+  file: SharedDriveFile;
+  projectName: string;
+  content: string | null;
+  loading: boolean;
+  error: string | null;
+}) {
+  const type = getPreviewType(file.name);
+  const previewUrl = `/projects/${projectName}/shared/preview?path=${encodeURIComponent(file.path)}`;
+
+  if (error) {
+    return <p className="text-sm text-destructive p-4">{error}</p>;
+  }
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground p-4">Loading preview...</p>;
+  }
+
+  switch (type) {
+    case "markdown":
+      return content !== null ? (
+        <Tabs defaultValue="preview">
+          <TabsList>
+            <TabsTrigger value="preview">Preview</TabsTrigger>
+            <TabsTrigger value="source">Source</TabsTrigger>
+          </TabsList>
+          <TabsContent value="preview" className="overflow-auto">
+            <Markdown>{content}</Markdown>
+          </TabsContent>
+          <TabsContent value="source" className="overflow-auto">
+            <pre className="text-sm font-mono whitespace-pre-wrap bg-muted rounded p-4">{content}</pre>
+          </TabsContent>
+        </Tabs>
+      ) : null;
+
+    case "text":
+      return content !== null ? (
+        <pre className="text-sm font-mono whitespace-pre-wrap bg-muted rounded p-4 overflow-auto">{content}</pre>
+      ) : null;
+
+    case "image":
+      return <img src={previewUrl} alt={file.name} className="max-w-full max-h-[70vh] object-contain" />;
+
+    case "pdf":
+      return <iframe src={previewUrl} className="w-full h-[70vh] rounded border" title={file.name} />;
+
+    case "unsupported":
+      return (
+        <div className="flex flex-col items-center justify-center py-12 gap-4 text-muted-foreground">
+          <File className="h-12 w-12" />
+          <p className="text-sm">Preview is not available for this file type.</p>
+        </div>
+      );
+  }
+}
+
 export default function SharedDrive({ project, files, current_path, pushEvent }: SharedDriveProps) {
   const [newFolderOpen, setNewFolderOpen] = React.useState(false);
   const [newFolderName, setNewFolderName] = React.useState("");
@@ -75,9 +199,47 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
   const [uploadError, setUploadError] = React.useState<string | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
+  const [previewFile, setPreviewFile] = React.useState<SharedDriveFile | null>(null);
+  const [previewContent, setPreviewContent] = React.useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = React.useState(false);
+  const [previewError, setPreviewError] = React.useState<string | null>(null);
+  const currentPreviewPath = React.useRef<string | null>(null);
+
   const navigate = (path: string) => {
     setUploadError(null);
+    setPreviewFile(null);
+    currentPreviewPath.current = null;
     pushEvent("navigate", { path });
+  };
+
+  const handlePreview = (file: SharedDriveFile) => {
+    if (previewFile?.path === file.path) {
+      setPreviewFile(null);
+      currentPreviewPath.current = null;
+      return;
+    }
+
+    const type = getPreviewType(file.name);
+    setPreviewFile(file);
+    setPreviewContent(null);
+    setPreviewError(null);
+    currentPreviewPath.current = file.path;
+
+    if (type === "markdown" || type === "text") {
+      setPreviewLoading(true);
+      const expectedPath = file.path;
+      pushEvent("preview-file", { path: file.path }, (reply) => {
+        if (currentPreviewPath.current !== expectedPath) return;
+        setPreviewLoading(false);
+        if (reply.error) {
+          setPreviewError(reply.error as string);
+        } else {
+          setPreviewContent(reply.content as string);
+        }
+      });
+    } else {
+      setPreviewLoading(false);
+    }
   };
 
   const handleCreateFolder = () => {
@@ -94,6 +256,9 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
       pushEvent("delete-file", { path: file.path });
     }
     setDeleteTarget(null);
+    if (previewFile?.path === file.path) {
+      setPreviewFile(null);
+    }
   };
 
   const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50 MB
@@ -119,14 +284,12 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
     };
     reader.readAsDataURL(file);
 
-    // Reset input
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
   };
 
   const sortedFiles = [...files].sort((a, b) => {
-    // Directories first, then alphabetical
     if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
     return a.name.localeCompare(b.name);
   });
@@ -156,73 +319,121 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
 
         {uploadError && <p className="text-sm text-destructive">{uploadError}</p>}
 
-        {/* File Table */}
-        <div className="rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead className="w-[100px]">Size</TableHead>
-                <TableHead className="w-[100px] text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {sortedFiles.length === 0 ? (
+        {/* File Table + Preview Panel */}
+        <div className="flex gap-4">
+          {/* File Table */}
+          <div className={`rounded-md border ${previewFile ? "w-1/2" : "w-full"} min-w-0`}>
+            <Table>
+              <TableHeader>
                 <TableRow>
-                  <TableCell colSpan={3} className="text-center text-muted-foreground py-8">
-                    This directory is empty
-                  </TableCell>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="w-[100px]">Size</TableHead>
+                  {!previewFile && <TableHead className="w-[100px] text-right">Actions</TableHead>}
                 </TableRow>
-              ) : (
-                sortedFiles.map((file) => (
-                  <TableRow key={file.path}>
-                    <TableCell>
-                      {file.type === "directory" ? (
-                        <Button
-                          variant="link"
-                          className="flex items-center gap-2 text-foreground h-auto p-0"
-                          onClick={() => navigate("/" + file.path)}
-                        >
-                          <Folder className="h-4 w-4 text-muted-foreground" />
-                          {file.name}
-                        </Button>
-                      ) : (
-                        <div className="flex items-center gap-2">
-                          <File className="h-4 w-4 text-muted-foreground" />
-                          {file.name}
-                        </div>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {file.type === "file" ? formatSize(file.size) : "—"}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex items-center justify-end gap-1">
-                        {file.type === "file" && (
-                          <Button variant="ghost" size="sm" asChild>
-                            <a
-                              href={`/projects/${project.name}/shared/download?path=${encodeURIComponent(file.path)}`}
-                              download
-                            >
-                              Download
-                            </a>
-                          </Button>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="text-destructive hover:text-destructive"
-                          onClick={() => setDeleteTarget(file)}
-                        >
-                          Delete
-                        </Button>
-                      </div>
+              </TableHeader>
+              <TableBody>
+                {sortedFiles.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={previewFile ? 2 : 3} className="text-center text-muted-foreground py-8">
+                      This directory is empty
                     </TableCell>
                   </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
+                ) : (
+                  sortedFiles.map((file) => (
+                    <TableRow key={file.path} className={previewFile?.path === file.path ? "bg-muted/50" : undefined}>
+                      <TableCell>
+                        {file.type === "directory" ? (
+                          <Button
+                            variant="link"
+                            className="flex items-center gap-2 text-foreground h-auto p-0"
+                            onClick={() => navigate("/" + file.path)}
+                          >
+                            <Folder className="h-4 w-4 text-muted-foreground" />
+                            {file.name}
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="link"
+                            className="flex items-center gap-2 text-foreground h-auto p-0"
+                            onClick={() => handlePreview(file)}
+                          >
+                            <File className="h-4 w-4 text-muted-foreground" />
+                            {file.name}
+                          </Button>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {file.type === "file" ? formatSize(file.size) : "—"}
+                      </TableCell>
+                      {!previewFile && (
+                        <TableCell className="text-right">
+                          <div className="flex items-center justify-end gap-1">
+                            {file.type === "file" && (
+                              <Button variant="ghost" size="sm" asChild>
+                                <a
+                                  href={`/projects/${project.name}/shared/download?path=${encodeURIComponent(file.path)}`}
+                                  download
+                                >
+                                  Download
+                                </a>
+                              </Button>
+                            )}
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-destructive hover:text-destructive"
+                              onClick={() => setDeleteTarget(file)}
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Preview Panel */}
+          {previewFile && (
+            <div className="w-1/2 min-w-0 rounded-md border flex flex-col">
+              <div className="flex items-center justify-between border-b px-4 py-2">
+                <span className="text-sm font-medium truncate">{previewFile.name}</span>
+                <div className="flex items-center gap-1">
+                  <Button variant="ghost" size="sm" asChild>
+                    <a
+                      href={`/projects/${project.name}/shared/download?path=${encodeURIComponent(previewFile.path)}`}
+                      download
+                    >
+                      <Download className="h-4 w-4" />
+                    </a>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => setDeleteTarget(previewFile)}
+                  >
+                    Delete
+                  </Button>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setPreviewFile(null)}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+              <div className="flex-1 overflow-auto p-4">
+                <PreviewContent
+                  file={previewFile}
+                  projectName={project.name}
+                  content={previewContent}
+                  loading={previewLoading}
+                  error={previewError}
+                />
+              </div>
+            </div>
+          )}
         </div>
       </div>
 

--- a/assets/test/SharedDrive.test.tsx
+++ b/assets/test/SharedDrive.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import SharedDrive from "../react-components/SharedDrive";
@@ -83,16 +83,14 @@ describe("SharedDrive", () => {
     render(<SharedDrive {...defaultProps} files={sampleFiles} />);
 
     const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
-    // Click delete on a file (not directory)
     await userEvent.click(deleteButtons[1]);
 
     expect(screen.getByText(/permanently delete/)).toBeInTheDocument();
   });
 
-  it("shows download button only for files", () => {
+  it("shows download button only for files when no preview is open", () => {
     render(<SharedDrive {...defaultProps} files={sampleFiles} />);
     const downloadLinks = screen.getAllByRole("link", { name: "Download" });
-    // Only files get download links (2 files, no directory)
     expect(downloadLinks).toHaveLength(2);
   });
 
@@ -100,5 +98,133 @@ describe("SharedDrive", () => {
     render(<SharedDrive {...defaultProps} files={sampleFiles} />);
     expect(screen.getByText("1.0 KB")).toBeInTheDocument();
     expect(screen.getByText("2.0 KB")).toBeInTheDocument();
+  });
+
+  describe("file preview", () => {
+    it("opens preview panel when clicking a file name", async () => {
+      const pushEvent = vi.fn();
+      render(<SharedDrive {...defaultProps} files={sampleFiles} pushEvent={pushEvent} />);
+
+      await userEvent.click(screen.getByText("readme.md"));
+
+      expect(pushEvent).toHaveBeenCalledWith("preview-file", { path: "readme.md" }, expect.any(Function));
+    });
+
+    it("shows loading state while fetching text preview", async () => {
+      const pushEvent = vi.fn();
+      render(<SharedDrive {...defaultProps} files={sampleFiles} pushEvent={pushEvent} />);
+
+      await userEvent.click(screen.getByText("data.json"));
+
+      expect(screen.getByText("Loading preview...")).toBeInTheDocument();
+    });
+
+    it("renders markdown content with Preview/Source tabs", async () => {
+      const pushEvent = vi.fn((_event, _payload, onReply) => {
+        if (onReply) onReply({ content: "# Hello World" });
+      });
+      render(<SharedDrive {...defaultProps} files={sampleFiles} pushEvent={pushEvent} />);
+
+      await userEvent.click(screen.getByText("readme.md"));
+
+      expect(screen.getByRole("tab", { name: "Preview" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Source" })).toBeInTheDocument();
+    });
+
+    it("closes preview when clicking X button", async () => {
+      const pushEvent = vi.fn((_event, _payload, onReply) => {
+        if (onReply) onReply({ content: "# Hello" });
+      });
+      render(<SharedDrive {...defaultProps} files={sampleFiles} pushEvent={pushEvent} />);
+
+      await userEvent.click(screen.getByText("readme.md"));
+      expect(screen.getByText("readme.md", { selector: "span" })).toBeInTheDocument();
+
+      // Find the close button (X icon button)
+      const previewPanel = screen.getByText("readme.md", { selector: "span" }).closest("div");
+      const closeButton = within(previewPanel!.parentElement!)
+        .getAllByRole("button")
+        .find((btn) => {
+          return btn.querySelector("svg.lucide-x");
+        });
+      expect(closeButton).toBeDefined();
+      await userEvent.click(closeButton!);
+
+      // Preview panel should be gone - no span with the filename in preview header
+      expect(screen.queryByText("Loading preview...")).not.toBeInTheDocument();
+    });
+
+    it("closes preview when clicking the same file again", async () => {
+      const pushEvent = vi.fn((_event, _payload, onReply) => {
+        if (onReply) onReply({ content: "test" });
+      });
+      render(<SharedDrive {...defaultProps} files={sampleFiles} pushEvent={pushEvent} />);
+
+      await userEvent.click(screen.getByText("data.json"));
+      // Panel should be open
+      expect(screen.getByText("data.json", { selector: "span" })).toBeInTheDocument();
+
+      // Click same file again
+      await userEvent.click(screen.getByText("data.json", { selector: "button" }));
+      // Preview header span should be gone
+      expect(screen.queryByText("data.json", { selector: "span" })).not.toBeInTheDocument();
+    });
+
+    it("shows image preview via img tag for image files", async () => {
+      const imageFiles: SharedDriveFile[] = [{ name: "photo.png", path: "photo.png", type: "file", size: 5000 }];
+      render(<SharedDrive {...defaultProps} files={imageFiles} />);
+
+      await userEvent.click(screen.getByText("photo.png"));
+
+      const img = screen.getByRole("img", { name: "photo.png" });
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute("src", "/projects/test-project/shared/preview?path=photo.png");
+    });
+
+    it("shows unsupported message for unknown file types", async () => {
+      const unknownFiles: SharedDriveFile[] = [{ name: "archive.zip", path: "archive.zip", type: "file", size: 5000 }];
+      render(<SharedDrive {...defaultProps} files={unknownFiles} />);
+
+      await userEvent.click(screen.getByText("archive.zip"));
+
+      expect(screen.getByText("Preview is not available for this file type.")).toBeInTheDocument();
+    });
+
+    it("shows error when preview-file returns error", async () => {
+      const pushEvent = vi.fn((_event, _payload, onReply) => {
+        if (onReply) onReply({ error: "File too large to preview" });
+      });
+      render(<SharedDrive {...defaultProps} files={sampleFiles} pushEvent={pushEvent} />);
+
+      await userEvent.click(screen.getByText("readme.md"));
+
+      expect(screen.getByText("File too large to preview")).toBeInTheDocument();
+    });
+
+    it("shows PDF preview via iframe", async () => {
+      const pdfFiles: SharedDriveFile[] = [{ name: "doc.pdf", path: "doc.pdf", type: "file", size: 10000 }];
+      render(<SharedDrive {...defaultProps} files={pdfFiles} />);
+
+      await userEvent.click(screen.getByText("doc.pdf"));
+
+      const iframe = screen.getByTitle("doc.pdf");
+      expect(iframe).toBeInTheDocument();
+      expect(iframe).toHaveAttribute("src", "/projects/test-project/shared/preview?path=doc.pdf");
+    });
+
+    it("hides actions column when preview is open", async () => {
+      const pushEvent = vi.fn((_event, _payload, onReply) => {
+        if (onReply) onReply({ content: "content" });
+      });
+      render(<SharedDrive {...defaultProps} files={sampleFiles} pushEvent={pushEvent} />);
+
+      // Actions column should be visible before preview
+      expect(screen.getByText("Actions")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText("readme.md"));
+
+      // Actions column should be hidden when preview is open
+      expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+    });
   });
 });

--- a/lib/shire_web/controllers/shared_drive_controller.ex
+++ b/lib/shire_web/controllers/shared_drive_controller.ex
@@ -4,6 +4,14 @@ defmodule ShireWeb.SharedDriveController do
   alias Shire.Workspace
 
   def download(conn, %{"project_name" => project_name, "path" => path}) do
+    serve_file(conn, project_name, path, :attachment)
+  end
+
+  def preview(conn, %{"project_name" => project_name, "path" => path}) do
+    serve_file(conn, project_name, path, :inline)
+  end
+
+  defp serve_file(conn, project_name, path, disposition) do
     project = Shire.Projects.get_project_by_name!(project_name)
     vm_path = to_vm_path(project.id, path)
 
@@ -12,9 +20,15 @@ defmodule ShireWeb.SharedDriveController do
         filename = Path.basename(path)
         content_type = MIME.from_path(path)
 
+        disposition_value =
+          case disposition do
+            :attachment -> ~s(attachment; filename="#{filename}")
+            :inline -> "inline"
+          end
+
         conn
         |> put_resp_content_type(content_type)
-        |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
+        |> put_resp_header("content-disposition", disposition_value)
         |> send_resp(200, content)
 
       {:error, :no_vm} ->
@@ -28,12 +42,16 @@ defmodule ShireWeb.SharedDriveController do
   defp to_vm_path(project_id, path) do
     drive_path = Workspace.shared_dir(project_id)
     clean = path |> String.trim_leading("/") |> String.trim_trailing("/")
+    candidate = if clean == "", do: drive_path, else: Path.join(drive_path, clean)
 
-    if clean == "" do
-      drive_path
-    else
-      Path.join(drive_path, clean)
+    expanded = Path.expand(candidate)
+    expanded_root = Path.expand(drive_path)
+
+    unless expanded == expanded_root or String.starts_with?(expanded, expanded_root <> "/") do
+      raise ArgumentError, "path traversal detected"
     end
+
+    candidate
   end
 
   defp vm, do: Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)

--- a/lib/shire_web/live/shared_drive_live/index.ex
+++ b/lib/shire_web/live/shared_drive_live/index.ex
@@ -78,6 +78,28 @@ defmodule ShireWeb.SharedDriveLive.Index do
     end
   end
 
+  @max_preview_size 1_048_576
+
+  def handle_event("preview-file", %{"path" => path}, socket) do
+    project_id = socket.assigns.project.id
+    vm_path = to_vm_path(project_id, path)
+
+    case vm().read(project_id, vm_path) do
+      {:ok, content} when byte_size(content) > @max_preview_size ->
+        {:reply, %{error: "File too large to preview"}, socket}
+
+      {:ok, content} ->
+        if String.valid?(content) do
+          {:reply, %{content: content}, socket}
+        else
+          {:reply, %{error: "File contains binary data and cannot be previewed as text"}, socket}
+        end
+
+      {:error, _} ->
+        {:reply, %{error: "Failed to read file"}, socket}
+    end
+  end
+
   def handle_event("upload-file", %{"name" => name, "content" => content}, socket) do
     project_id = socket.assigns.project.id
     path = join_path(socket.assigns.current_path, name)
@@ -136,12 +158,16 @@ defmodule ShireWeb.SharedDriveLive.Index do
   defp to_vm_path(project_id, path) do
     drive_path = Workspace.shared_dir(project_id)
     clean = path |> String.trim_leading("/") |> String.trim_trailing("/")
+    candidate = if clean == "", do: drive_path, else: Path.join(drive_path, clean)
 
-    if clean == "" do
-      drive_path
-    else
-      Path.join(drive_path, clean)
+    expanded = Path.expand(candidate)
+    expanded_root = Path.expand(drive_path)
+
+    unless expanded == expanded_root or String.starts_with?(expanded, expanded_root <> "/") do
+      raise ArgumentError, "path traversal detected"
     end
+
+    candidate
   end
 
   defp join_path("/", name), do: name

--- a/lib/shire_web/router.ex
+++ b/lib/shire_web/router.ex
@@ -37,6 +37,7 @@ defmodule ShireWeb.Router do
     pipe_through :browser
 
     get "/projects/:project_name/shared/download", SharedDriveController, :download
+    get "/projects/:project_name/shared/preview", SharedDriveController, :preview
 
     get "/projects/:project_name/agents/:agent_id/attachments/:attachment_id/:filename",
         AttachmentController,

--- a/test/shire_web/controllers/shared_drive_controller_test.exs
+++ b/test/shire_web/controllers/shared_drive_controller_test.exs
@@ -1,0 +1,85 @@
+defmodule ShireWeb.SharedDriveControllerTest do
+  use ShireWeb.ConnCase, async: false
+
+  import Mox
+
+  alias Shire.Projects
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    stub(Shire.VirtualMachineMock, :workspace_root, fn _p -> "/workspace" end)
+    stub(Shire.VirtualMachineMock, :cmd!, fn _p, _cmd, _args, _opts -> "" end)
+    stub(Shire.VirtualMachineMock, :mkdir_p, fn _p, _path -> :ok end)
+    stub(Shire.VirtualMachineMock, :write, fn _p, _path, _c -> :ok end)
+    stub(Shire.VirtualMachineMock, :rm_rf, fn _p, _path -> :ok end)
+
+    {:ok, project} = Projects.create_project("drive-test")
+    %{project: project}
+  end
+
+  describe "download/2" do
+    test "returns file with attachment disposition", %{conn: conn, project: project} do
+      expect(Shire.VirtualMachineMock, :read, fn _p, path ->
+        assert String.ends_with?(path, "/shared/readme.md")
+        {:ok, "# Hello"}
+      end)
+
+      conn = get(conn, "/projects/#{project.name}/shared/download?path=readme.md")
+
+      assert response(conn, 200) == "# Hello"
+      assert get_resp_header(conn, "content-disposition") |> hd() =~ "attachment"
+    end
+
+    test "returns 404 for missing file", %{conn: conn, project: project} do
+      expect(Shire.VirtualMachineMock, :read, fn _p, _path -> {:error, :not_found} end)
+
+      conn = get(conn, "/projects/#{project.name}/shared/download?path=missing.txt")
+      assert response(conn, 404)
+    end
+  end
+
+  describe "path traversal" do
+    test "rejects path with .. in download", %{conn: conn, project: project} do
+      assert_raise ArgumentError, "path traversal detected", fn ->
+        get(conn, "/projects/#{project.name}/shared/download?path=../../etc/passwd")
+      end
+    end
+
+    test "rejects path with .. in preview", %{conn: conn, project: project} do
+      assert_raise ArgumentError, "path traversal detected", fn ->
+        get(conn, "/projects/#{project.name}/shared/preview?path=../agents/secret")
+      end
+    end
+  end
+
+  describe "preview/2" do
+    test "returns file with inline disposition", %{conn: conn, project: project} do
+      expect(Shire.VirtualMachineMock, :read, fn _p, path ->
+        assert String.ends_with?(path, "/shared/image.png")
+        {:ok, "png-data"}
+      end)
+
+      conn = get(conn, "/projects/#{project.name}/shared/preview?path=image.png")
+
+      assert response(conn, 200) == "png-data"
+      assert get_resp_header(conn, "content-disposition") |> hd() == "inline"
+      assert get_resp_header(conn, "content-type") |> hd() =~ "image/png"
+    end
+
+    test "returns 404 for missing file", %{conn: conn, project: project} do
+      expect(Shire.VirtualMachineMock, :read, fn _p, _path -> {:error, :not_found} end)
+
+      conn = get(conn, "/projects/#{project.name}/shared/preview?path=missing.png")
+      assert response(conn, 404)
+    end
+
+    test "returns 503 when no VM available", %{conn: conn, project: project} do
+      expect(Shire.VirtualMachineMock, :read, fn _p, _path -> {:error, :no_vm} end)
+
+      conn = get(conn, "/projects/#{project.name}/shared/preview?path=file.txt")
+      assert response(conn, 503)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds side-by-side file preview panel to the shared drive page
- Clicking a file name opens a preview panel alongside the file list
- Supports markdown (with rendered/source toggle), text/code files, images, PDFs
- Unsupported file types show a message with download link
- Fixes path traversal vulnerability in `to_vm_path` (both controller and LiveView)
- Adds stale-reply guard to prevent race conditions when switching previews

## Files Changed
- `lib/shire_web/controllers/shared_drive_controller.ex` — new `preview` action + `serve_file` refactor + path traversal fix
- `lib/shire_web/router.ex` — new preview route
- `lib/shire_web/live/shared_drive_live/index.ex` — new `preview-file` event handler + path traversal fix
- `assets/react-components/SharedDrive.tsx` — side-by-side layout, file type detection, PreviewContent component
- `test/shire_web/controllers/shared_drive_controller_test.exs` — new backend tests
- `assets/test/SharedDrive.test.tsx` — updated frontend tests with preview coverage

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test` — 347 tests, 0 failures
- [x] `bun run tsc --noEmit` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run test` — 228 tests, 18 suites all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)