### PR TITLE
contain shared drive preview scroll within panel

### DIFF
--- a/assets/react-components/SharedDrive.tsx
+++ b/assets/react-components/SharedDrive.tsx
@@ -398,7 +398,7 @@ export default function SharedDrive({ project, files, current_path, pushEvent }:
 
           {/* Preview Panel */}
           {previewFile && (
-            <div className="w-1/2 min-w-0 rounded-md border flex flex-col">
+            <div className="w-1/2 min-w-0 rounded-md border flex flex-col max-h-[calc(100vh-12rem)]">
               <div className="flex items-center justify-between border-b px-4 py-2">
                 <span className="text-sm font-medium truncate">{previewFile.name}</span>
                 <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Add `max-h-[calc(100vh-12rem)]` to the shared drive preview panel so file content scrolls within the panel instead of pushing the file browser off-screen

## Test plan
- [ ] Open a large text/markdown file in the shared drive preview
- [ ] Verify the preview content scrolls within its panel
- [ ] Verify the file browser stays visible and doesn't scroll away

🤖 Generated with [Claude Code](https://claude.com/claude-code)