### PR TITLE
Fix Pi agent streaming: error visibility and tool event completeness

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -751,6 +751,7 @@ defmodule Shire.Agent.AgentManager do
 
   defp persist_and_broadcast(state, %{"type" => "text_delta"} = event) do
     delta = get_in(event, ["payload", "delta"]) || ""
+    Logger.debug("text_delta for #{state.agent_name}: #{byte_size(delta)} bytes")
     state = %{state | streaming_text: (state.streaming_text || "") <> delta}
     broadcast(state, {:agent_event, state.agent_id, event})
     state
@@ -892,6 +893,30 @@ defmodule Shire.Agent.AgentManager do
   defp persist_and_broadcast(state, %{"type" => "turn_complete"} = event) do
     state = flush_and_broadcast_streaming(state)
     broadcast(state, {:agent_event, state.agent_id, event})
+    state
+  end
+
+  defp persist_and_broadcast(
+         state,
+         %{"type" => "error", "payload" => %{"message" => error_msg}} = event
+       ) do
+    state = flush_and_broadcast_streaming(state)
+    Logger.warning("Agent error for #{state.agent_name}: #{error_msg}")
+
+    case Agents.create_message(%{
+           project_id: state.project_id,
+           agent_id: state.agent_id,
+           role: "system",
+           content: %{"text" => "Error: #{error_msg}"}
+         }) do
+      {:ok, msg} ->
+        enriched = put_in(event, ["message"], serialize_message(msg))
+        broadcast(state, {:agent_event, state.agent_id, enriched})
+
+      {:error, _} ->
+        broadcast(state, {:agent_event, state.agent_id, event})
+    end
+
     state
   end
 

--- a/lib/shire_web/live/agent_live/agent_streaming.ex
+++ b/lib/shire_web/live/agent_live/agent_streaming.ex
@@ -117,6 +117,18 @@ defmodule ShireWeb.AgentLive.AgentStreaming do
       %{"type" => "turn_complete"} ->
         {messages, nil}
 
+      %{"type" => "error", "message" => msg} ->
+        {messages ++ [msg], nil}
+
+      %{"type" => "error", "payload" => %{"message" => error_msg}} ->
+        error_message = %{
+          role: "system",
+          text: "Error: #{error_msg}",
+          ts: DateTime.utc_now() |> to_string()
+        }
+
+        {messages ++ [error_message], nil}
+
       _ ->
         {messages, nil}
     end

--- a/priv/sprite/harness/pi-harness.test.ts
+++ b/priv/sprite/harness/pi-harness.test.ts
@@ -127,11 +127,17 @@ describe("PiHarness", () => {
     harness._setSessionFactory(async () => mockSession);
     await harness.start(baseConfig);
     await harness.sendMessage("run ls");
-    const toolEvents = events.filter((e) => e.type === "tool_use");
-    expect(toolEvents).toHaveLength(2);
-    expect(toolEvents[0].payload.status).toBe("started");
-    expect(toolEvents[0].payload.tool).toBe("bash");
-    expect(toolEvents[1].payload.status).toBe("completed");
+    const toolStart = events.filter((e) => e.type === "tool_use");
+    expect(toolStart).toHaveLength(1);
+    expect(toolStart[0].payload.status).toBe("started");
+    expect(toolStart[0].payload.tool).toBe("bash");
+    expect(toolStart[0].payload.tool_use_id).toBe("tc1");
+    expect(toolStart[0].payload.input).toEqual({});
+
+    const toolResult = events.filter((e) => e.type === "tool_result");
+    expect(toolResult).toHaveLength(1);
+    expect(toolResult[0].payload.tool_use_id).toBe("tc1");
+    expect(toolResult[0].payload.is_error).toBe(false);
   });
 
   test("sendMessage() prepends agent prefix for agent messages", async () => {
@@ -158,7 +164,7 @@ describe("PiHarness", () => {
     expect(harness.isProcessing()).toBe(false);
   });
 
-  test("sendMessage() emits error event on SDK failure", async () => {
+  test("sendMessage() emits error and turn_complete on SDK failure", async () => {
     const harness = new PiHarness();
     const events: AgentEvent[] = [];
     harness.onEvent((e) => events.push(e));
@@ -172,6 +178,12 @@ describe("PiHarness", () => {
     const errorEvent = events.find((e) => e.type === "error");
     expect(errorEvent).toBeDefined();
     expect(String(errorEvent!.payload.message)).toContain("Rate limit exceeded");
+    const types = events.map((e) => e.type);
+    expect(types).toContain("turn_complete");
+    // turn_complete should come after error
+    const errorIdx = types.indexOf("error");
+    const turnIdx = types.indexOf("turn_complete");
+    expect(turnIdx).toBeGreaterThan(errorIdx);
   });
 
   test("stop() suppresses further event emission", async () => {

--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -50,6 +50,7 @@ export class PiHarness implements Harness {
       await session.prompt(content);
     } catch (err) {
       this.emitEvent({ type: "error", payload: { message: String(err) } });
+      this.emitEvent({ type: "turn_complete", payload: {} });
     } finally {
       this.processing = false;
     }
@@ -107,6 +108,7 @@ export class PiHarness implements Harness {
     });
     await loader.reload();
 
+    console.error(`[pi-harness] creating session with model ${config.model}, cwd ${config.cwd}`);
     const { session } = await createAgentSession({
       cwd: config.cwd,
       model,
@@ -122,7 +124,9 @@ export class PiHarness implements Harness {
   }
 
   private subscribeToSession(session: SessionLike): void {
+    console.error("[pi-harness] subscribed to session events");
     session.subscribe((event: AgentSessionEvent) => {
+      console.error(`[pi-harness] session event: ${event.type}`);
       switch (event.type) {
         case "message_update":
           if (event.assistantMessageEvent?.type === "text_delta") {
@@ -143,12 +147,24 @@ export class PiHarness implements Harness {
           break;
         }
         case "tool_execution_start":
-          this.emitEvent({ type: "tool_use", payload: { tool: event.toolName, status: "started" } });
+          this.emitEvent({
+            type: "tool_use",
+            payload: {
+              tool: event.toolName,
+              tool_use_id: event.toolCallId,
+              input: event.args ?? {},
+              status: "started",
+            },
+          });
           break;
         case "tool_execution_end":
           this.emitEvent({
-            type: "tool_use",
-            payload: { tool: event.toolName, status: "completed", result: event.result },
+            type: "tool_result",
+            payload: {
+              tool_use_id: event.toolCallId,
+              output: typeof event.result === "string" ? event.result : JSON.stringify(event.result),
+              is_error: event.isError ?? false,
+            },
           });
           break;
         case "agent_end":

--- a/test/shire_web/live/agent_streaming_test.exs
+++ b/test/shire_web/live/agent_streaming_test.exs
@@ -262,6 +262,55 @@ defmodule ShireWeb.AgentLive.AgentStreamingTest do
     end
   end
 
+  describe "process_agent_event/2 with error" do
+    test "appends error message from broadcast when message is included" do
+      msg = %{
+        id: 20,
+        role: "system",
+        content: %{"text" => "Error: Rate limit exceeded"},
+        ts: "2024-01-01T00:00:00Z"
+      }
+
+      socket = mock_socket(%{streaming_text: "partial"})
+
+      event = %{
+        "type" => "error",
+        "payload" => %{"message" => "Rate limit exceeded"},
+        "message" => msg
+      }
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      assert List.last(socket.assigns.messages) == msg
+      assert socket.assigns.streaming_text == nil
+    end
+
+    test "creates fallback error message when no message in broadcast" do
+      socket = mock_socket()
+
+      event = %{
+        "type" => "error",
+        "payload" => %{"message" => "Something went wrong"}
+      }
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      error_msg = List.last(socket.assigns.messages)
+      assert error_msg[:role] == "system"
+      assert error_msg[:text] == "Error: Something went wrong"
+    end
+
+    test "pushes streaming_flush when streaming text was pending" do
+      socket = mock_socket(%{streaming_text: "partial"})
+
+      event = %{
+        "type" => "error",
+        "payload" => %{"message" => "Error occurred"}
+      }
+
+      socket = AgentStreaming.process_agent_event(socket, event)
+      assert ["streaming_flush", %{}] in pushed_events(socket)
+    end
+  end
+
   describe "display-only (no DB calls)" do
     test "does not create messages in DB for text events" do
       msg = %{id: 999, role: "agent", text: "Hello", ts: "2024-01-01T00:00:00Z"}


### PR DESCRIPTION
## Summary

- **Error events now visible in chat**: Pi SDK errors (API key missing, rate limits, model not found) were silently swallowed. `AgentStreaming` and `AgentManager` now handle `"error"` events — persisted as system messages and displayed in the chat UI.
- **Pi harness emits `turn_complete` after errors**: Ensures streaming state is flushed and the client clears partial text.
- **Pi harness tool events include proper IDs**: `tool_use_id` and `input`/`args` are now included in `tool_execution_start`, and `tool_execution_end` emits `tool_result` (matching the Claude Code harness pattern).
- **Debug logging**: stderr logging in Pi harness for session creation and events; `Logger.debug` for `text_delta` in AgentManager.

## Test plan

- [x] Elixir compilation passes (`mix compile --warnings-as-errors`)
- [x] All 350 Elixir tests pass (`mix test`)
- [x] All 68 priv/sprite tests pass (`bun test`)
- [x] ESLint + Prettier pass for priv/sprite
- [x] TypeScript + ESLint pass for assets
- [ ] Manual: Send message to Pi agent with invalid/missing API key → error should appear in chat
- [ ] Manual: Send message to Pi agent with valid config → streaming text should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)