### PR TITLE
Restore cursor: pointer on interactive elements

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -159,6 +159,18 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+  button,
+  [role="button"],
+  a,
+  summary,
+  input[type="button"],
+  input[type="submit"],
+  input[type="reset"],
+  input[type="checkbox"],
+  input[type="radio"],
+  label {
+    cursor: pointer;
+  }
 }
 
 /* Make LiveView wrapper divs transparent for layout */


### PR DESCRIPTION
## Summary
- Tailwind's preflight CSS reset overrides `cursor: pointer` to `default` on buttons and other interactive elements
- Adds a `@layer base` rule restoring `cursor: pointer` on `button`, `[role="button"]`, `a`, `summary`, `input[type="button|submit|reset|checkbox|radio"]`, and `label`
- Uses `@layer base` so utility classes (e.g. `cursor-default`, `cursor-not-allowed`) still override correctly

## Test plan
- [ ] Verify buttons, links, checkboxes, radio buttons, and labels show pointer cursor
- [ ] Verify disabled elements still show appropriate cursor (not-allowed or no pointer events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)