### PR TITLE
fix Pi agent echoing user messages back in chat

### DIFF
--- a/priv/sprite/harness/pi-harness.test.ts
+++ b/priv/sprite/harness/pi-harness.test.ts
@@ -24,7 +24,7 @@ function createMockSession() {
         } as AgentSessionEvent);
         subscriber({
           type: "message_end",
-          message: { content: [{ type: "text", text: "Hello world" }] },
+          message: { role: "assistant", content: [{ type: "text", text: "Hello world" }] },
         } as AgentSessionEvent);
         subscriber({ type: "agent_end" } as AgentSessionEvent);
       }
@@ -103,6 +103,30 @@ describe("PiHarness", () => {
     expect(types).toContain("turn_complete");
     const textEvent = events.find((e) => e.type === "text");
     expect(textEvent?.payload.text).toBe("Hello world");
+  });
+
+  test("sendMessage() does not emit text for user message_end events", async () => {
+    const harness = new PiHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    const mockSession = createMockSession();
+    mockSession.prompt = mock(async () => {
+      mockSession.fireEvent({
+        type: "message_end",
+        message: { role: "user", content: [{ type: "text", text: "Hi there" }] },
+      } as AgentSessionEvent);
+      mockSession.fireEvent({
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      } as AgentSessionEvent);
+      mockSession.fireEvent({ type: "agent_end" } as AgentSessionEvent);
+    });
+    harness._setSessionFactory(async () => mockSession);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi there");
+    const textEvents = events.filter((e) => e.type === "text");
+    expect(textEvents).toHaveLength(1);
+    expect(textEvents[0].payload.text).toBe("Hello");
   });
 
   test("sendMessage() maps tool events", async () => {

--- a/priv/sprite/harness/pi-harness.test.ts
+++ b/priv/sprite/harness/pi-harness.test.ts
@@ -105,7 +105,7 @@ describe("PiHarness", () => {
     expect(textEvent?.payload.text).toBe("Hello world");
   });
 
-  test("sendMessage() does not emit text for user message_end events", async () => {
+  test("sendMessage() only emits text for assistant message_end events", async () => {
     const harness = new PiHarness();
     const events: AgentEvent[] = [];
     harness.onEvent((e) => events.push(e));
@@ -114,6 +114,10 @@ describe("PiHarness", () => {
       mockSession.fireEvent({
         type: "message_end",
         message: { role: "user", content: [{ type: "text", text: "Hi there" }] },
+      } as AgentSessionEvent);
+      mockSession.fireEvent({
+        type: "message_end",
+        message: { role: "toolResult", content: [{ type: "text", text: "tool output" }] },
       } as AgentSessionEvent);
       mockSession.fireEvent({
         type: "message_end",

--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -132,7 +132,8 @@ export class PiHarness implements Harness {
           }
           break;
         case "message_end": {
-          const content = event.message?.content;
+          if (event.message?.role !== "assistant") break;
+          const content = event.message.content;
           const text = Array.isArray(content)
             ? content
                 .filter((b): b is { type: "text"; text: string } => b.type === "text" && "text" in b)

--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -132,7 +132,7 @@ export class PiHarness implements Harness {
           }
           break;
         case "message_end": {
-          if (event.message?.role !== "assistant") break;
+          if (event.message.role !== "assistant") break;
           const content = event.message.content;
           const text = Array.isArray(content)
             ? content


### PR DESCRIPTION
## Summary

- Pi SDK emits `message_end` events for both user and assistant messages. The harness was forwarding all of them, causing the user's input to appear as an agent response in the chat.
- Filter `message_end` to only emit `text` events when `event.message.role === "assistant"`

## Test plan

- [x] Added test: user `message_end` events are filtered, only assistant messages emit `text`
- [x] All 17 pi-harness tests pass
- [x] Lint + format clean
- [ ] Manual: send message to Pi agent, verify no echo of user input

🤖 Generated with [Claude Code](https://claude.com/claude-code)