### PR TITLE
Change license from MIT to BSL 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,45 @@
-MIT License
+Business Source License 1.1
 
-Copyright (c) 2026 Victor Chan
+Licensor: Victor Yap
+Licensed Work: Shire
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Change Date: 2030-03-24
+Change License: Apache License, Version 2.0
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Additional Use Grant:
+You may use the Licensed Work for non-production purposes, including
+development, testing, and personal projects, at no cost.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may
+vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in
+this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo
+of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Business Source License 1.1
 
-Licensor: Victor Yap
+Licensor: Victor Chan
 Licensed Work: Shire
 
 Change Date: 2030-03-24

--- a/README.md
+++ b/README.md
@@ -209,4 +209,4 @@ When agents go idle, the VM auto-sleeps — preserving installed packages, works
 
 ## 📄 License
 
-[MIT](LICENSE)
+[Business Source License 1.1](LICENSE) — free for non-production use. Converts to Apache 2.0 on 2030-03-24.


### PR DESCRIPTION
## Summary
- Replace MIT license with Business Source License 1.1
- Free for non-production use (development, testing, personal projects)
- Commercial/production use requires a paid license
- Automatically converts to Apache 2.0 on 2030-03-24
- Update README license section accordingly

## Test plan
- [x] LICENSE file contains BSL 1.1 text
- [x] README references BSL 1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)