### PR TITLE
Support raw SSH key and password auth for SSH backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,9 @@ mix precommit
 
 - `SHIRE_VM_TYPE` — selects VM backend: `sprites` (default, Firecracker), `ssh` (any VPS via SSH), or `local` (local filesystem for dev)
 - `SPRITES_TOKEN` — required when using the Sprite backend
-- `SHIRE_SSH_HOST` / `SHIRE_SSH_USER` / `SHIRE_SSH_KEY` — required when using the SSH backend
+- `SHIRE_SSH_HOST` / `SHIRE_SSH_USER` — required when using the SSH backend
+- `SHIRE_SSH_KEY` — raw PEM private key content (one of `SHIRE_SSH_KEY` or `SHIRE_SSH_PASSWORD` required for SSH)
+- `SHIRE_SSH_PASSWORD` — SSH password (alternative to `SHIRE_SSH_KEY`)
 - `SHIRE_SSH_PORT` — SSH port (default: `22`)
 - `SHIRE_SSH_WORKSPACE_ROOT` — workspace root on the remote host (default: `/home/{user}/shire/projects`)
 - `ANTHROPIC_API_KEY` — passed to agents using the Pi SDK harness

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Create a `.env` file in the project root. It's automatically loaded in dev/test 
 | `SHIRE_VM_TYPE` | `sprites` | VM backend: `sprites` (Firecracker), `ssh` (any VPS), or `local` (local filesystem for dev) |
 | `SHIRE_SSH_HOST` | — | SSH hostname (required when `SHIRE_VM_TYPE=ssh`) |
 | `SHIRE_SSH_USER` | — | SSH username (required when `SHIRE_VM_TYPE=ssh`) |
-| `SHIRE_SSH_KEY` | — | Path to SSH private key (required when `SHIRE_VM_TYPE=ssh`) |
+| `SHIRE_SSH_KEY` | — | Raw SSH private key PEM content (one of `SHIRE_SSH_KEY` or `SHIRE_SSH_PASSWORD` required when `SHIRE_VM_TYPE=ssh`) |
+| `SHIRE_SSH_PASSWORD` | — | SSH password (alternative to `SHIRE_SSH_KEY`) |
 | `SHIRE_SSH_PORT` | `22` | SSH port |
 | `SHIRE_SSH_WORKSPACE_ROOT` | `/home/$SHIRE_SSH_USER/shire/projects` | Workspace root on the remote host |
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -52,6 +52,10 @@ if config_env() != :test do
   end
 
   if vm_type == "ssh" do
+    if is_nil(System.get_env("SHIRE_SSH_KEY")) and is_nil(System.get_env("SHIRE_SSH_PASSWORD")) do
+      raise "Either SHIRE_SSH_KEY or SHIRE_SSH_PASSWORD is required when SHIRE_VM_TYPE=ssh"
+    end
+
     config :shire, :ssh,
       host:
         System.get_env("SHIRE_SSH_HOST") ||
@@ -60,9 +64,8 @@ if config_env() != :test do
       user:
         System.get_env("SHIRE_SSH_USER") ||
           raise("SHIRE_SSH_USER is required when SHIRE_VM_TYPE=ssh"),
-      key_path:
-        System.get_env("SHIRE_SSH_KEY") ||
-          raise("SHIRE_SSH_KEY is required when SHIRE_VM_TYPE=ssh"),
+      key: System.get_env("SHIRE_SSH_KEY"),
+      password: System.get_env("SHIRE_SSH_PASSWORD"),
       workspace_root:
         System.get_env(
           "SHIRE_SSH_WORKSPACE_ROOT",

--- a/lib/shire/virtual_machine_ssh.ex
+++ b/lib/shire/virtual_machine_ssh.ex
@@ -333,15 +333,16 @@ defmodule Shire.VirtualMachineSSH do
     host = to_charlist(config[:host])
     port = config[:port]
     user = to_charlist(config[:user])
-    key_path = Path.expand(config[:key_path])
 
-    ssh_opts = [
-      {:user, user},
-      {:key_cb, {Shire.VirtualMachineSSH.KeyCb, key_path: key_path}},
-      {:silently_accept_hosts, true},
-      {:connect_timeout, @connect_timeout},
-      {:user_interaction, false}
-    ]
+    auth_opts = auth_opts(config)
+
+    ssh_opts =
+      [
+        {:user, user},
+        {:silently_accept_hosts, true},
+        {:connect_timeout, @connect_timeout},
+        {:user_interaction, false}
+      ] ++ auth_opts
 
     case :ssh.connect(host, port, ssh_opts) do
       {:ok, conn} ->
@@ -352,6 +353,20 @@ defmodule Shire.VirtualMachineSSH do
 
       {:error, reason} ->
         {:error, {:ssh_connect, reason}}
+    end
+  end
+
+  defp auth_opts(config) do
+    case {config[:key], config[:password]} do
+      {key, _} when is_binary(key) and key != "" ->
+        normalized_key = String.replace(key, "\\n", "\n")
+        [{:key_cb, {Shire.VirtualMachineSSH.KeyCb, key_pem: normalized_key}}]
+
+      {_, password} when is_binary(password) and password != "" ->
+        [{:password, to_charlist(password)}]
+
+      _ ->
+        raise "SSH auth requires either SHIRE_SSH_KEY (raw PEM) or SHIRE_SSH_PASSWORD"
     end
   end
 

--- a/lib/shire/virtual_machine_ssh/key_cb.ex
+++ b/lib/shire/virtual_machine_ssh/key_cb.ex
@@ -2,8 +2,8 @@ defmodule Shire.VirtualMachineSSH.KeyCb do
   @moduledoc """
   SSH client key callback for in-memory private key authentication.
 
-  Implements the `:ssh_client_key_api` behaviour. Reads the private key file
-  from the path provided in options, decodes it, and returns it for authentication.
+  Implements the `:ssh_client_key_api` behaviour. Decodes a raw PEM string
+  provided in options and returns the key for authentication.
   Accepts all host keys (no known_hosts verification).
   """
 
@@ -16,20 +16,14 @@ defmodule Shire.VirtualMachineSSH.KeyCb do
 
   @impl true
   def user_key(algorithm, opts) do
-    key_path = opts[:key_path] || raise "SSH key_path not provided in KeyCb options"
+    pem = opts[:key_pem] || raise "SSH key_pem not provided in KeyCb options"
 
-    case File.read(key_path) do
-      {:ok, pem} ->
-        pem
-        |> :public_key.pem_decode()
-        |> find_key_for_algorithm(algorithm)
-        |> case do
-          {:ok, key} -> {:ok, key}
-          :error -> {:error, :no_matching_key}
-        end
-
-      {:error, reason} ->
-        {:error, {:key_file_unreadable, key_path, reason}}
+    pem
+    |> :public_key.pem_decode()
+    |> find_key_for_algorithm(algorithm)
+    |> case do
+      {:ok, key} -> {:ok, key}
+      :error -> {:error, :no_matching_key}
     end
   end
 

--- a/test/shire/virtual_machine_ssh_test.exs
+++ b/test/shire/virtual_machine_ssh_test.exs
@@ -8,7 +8,7 @@ defmodule Shire.VirtualMachineSSHTest do
     SHIRE_SSH_HOST (default: localhost)
     SHIRE_SSH_PORT (default: 22)
     SHIRE_SSH_USER (default: current user)
-    SHIRE_SSH_KEY  (default: ~/.ssh/id_ed25519)
+    SHIRE_SSH_KEY  (raw PEM content; default: reads ~/.ssh/id_ed25519)
   """
   use ExUnit.Case, async: false
 
@@ -19,7 +19,14 @@ defmodule Shire.VirtualMachineSSHTest do
   setup_all do
     host = System.get_env("SHIRE_SSH_HOST", "localhost")
     user = System.get_env("SHIRE_SSH_USER", System.get_env("USER"))
-    key = System.get_env("SHIRE_SSH_KEY", Path.expand("~/.ssh/id_ed25519"))
+    key = System.get_env("SHIRE_SSH_KEY")
+    password = System.get_env("SHIRE_SSH_PASSWORD")
+
+    key =
+      if is_nil(key) and is_nil(password),
+        do: File.read!(Path.expand("~/.ssh/id_ed25519")),
+        else: key
+
     port = String.to_integer(System.get_env("SHIRE_SSH_PORT", "22"))
 
     workspace_root =
@@ -29,7 +36,8 @@ defmodule Shire.VirtualMachineSSHTest do
       host: host,
       port: port,
       user: user,
-      key_path: key,
+      key: key,
+      password: password,
       workspace_root: workspace_root
     )
 


### PR DESCRIPTION
## Summary

- **Raw SSH key support**: `SHIRE_SSH_KEY` now accepts raw PEM content instead of a file path, compatible with Fly.io secrets
- **Password auth**: Added `SHIRE_SSH_PASSWORD` as an alternative to key-based auth
- **SSH reconnection**: Auto-reconnects when the SSH connection drops, with retry-on-failure for `cmd` calls
- **`.shire_profile`**: Dedicated profile file sourced before every SSH command to set PATH (bun, claude) — avoids `.bashrc` non-interactive guard
- **Bootstrap improvements**: Installs `unzip` before bun, writes `.shire_profile`, handles PATH in current session
- **OTP 27+ compat**: Handle `ssh_connection.exec` returning `:success` instead of `:ok`
- **Bug fixes**: Project delete button, inbox size-0 file skip, PEM decode logging, destroy_vm crash handling
- **`fly.vps.toml`**: Separate Fly config for SSH-backed deployment

## Test plan

- [x] `mix compile --warnings-as-errors` — 0 warnings
- [x] `mix format --check-formatted` — formatted
- [x] `mix test --exclude ssh` — 353 tests, 0 failures
- [ ] Manual: deploy to Fly with `SHIRE_VM_TYPE=ssh` and verify project creation, agent spawning, messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)