### PR TITLE
SSH VM: reconnection, .shire_profile, bootstrap fixes

### DIFF
--- a/assets/react-components/ProjectDashboard.tsx
+++ b/assets/react-components/ProjectDashboard.tsx
@@ -138,7 +138,10 @@ export default function ProjectDashboard({ projects, pushEvent }: ProjectDashboa
                           )}
                           <DropdownMenuItem
                             className="text-destructive focus:text-destructive"
-                            onClick={() => setDeleteProject(project)}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeleteProject(project);
+                            }}
                           >
                             Delete
                           </DropdownMenuItem>

--- a/fly.vps.toml
+++ b/fly.vps.toml
@@ -1,0 +1,30 @@
+app = 'shire-vps'
+primary_region = 'nrt'
+
+[build]
+
+[deploy]
+  release_command = '/app/bin/migrate'
+
+[env]
+  PHX_HOST = 'shire-vps.fly.dev'
+  PORT = '8080'
+  SHIRE_VM_TYPE = 'ssh'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  max_machines_running = 1
+
+  [http_service.concurrency]
+    type = 'connections'
+    hard_limit = 1000
+    soft_limit = 1000
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 2

--- a/lib/shire/virtual_machine_ssh.ex
+++ b/lib/shire/virtual_machine_ssh.ex
@@ -148,9 +148,13 @@ defmodule Shire.VirtualMachineSSH do
   def destroy_vm(project_id) do
     root = workspace_root(project_id)
 
-    case cmd(project_id, "rm", ["-rf", root]) do
-      {:ok, _} -> :ok
-      {:error, reason} -> {:error, reason}
+    try do
+      case cmd(project_id, "rm", ["-rf", root]) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    catch
+      :exit, _ -> :ok
     end
   end
 
@@ -205,14 +209,25 @@ defmodule Shire.VirtualMachineSSH do
 
   @impl GenServer
   def handle_call({:cmd, command, args, opts}, _from, state) do
+    state = ensure_connected(state)
     timeout = Keyword.get(opts, :timeout, @default_cmd_timeout)
-    result = ssh_exec(state.conn, command, args, opts, state.workspace_root, timeout)
-    {:reply, result, state}
+
+    case ssh_exec(state.conn, command, args, opts, state.workspace_root, timeout) do
+      {:error, {:channel_open, :closed}} ->
+        state = ensure_connected(%{state | conn: nil})
+        result = ssh_exec(state.conn, command, args, opts, state.workspace_root, timeout)
+        {:reply, result, state}
+
+      result ->
+        {:reply, result, state}
+    end
   end
 
   # --- handle_call: Filesystem ---
 
   def handle_call({:read, path}, _from, state) do
+    state = ensure_connected(state)
+
     result =
       case :ssh_sftp.read_file(state.sftp, to_charlist(path)) do
         {:ok, content} -> {:ok, content}
@@ -223,6 +238,7 @@ defmodule Shire.VirtualMachineSSH do
   end
 
   def handle_call({:write, path, content}, _from, state) do
+    state = ensure_connected(state)
     sftp_mkdir_p(state.sftp, Path.dirname(path))
 
     result =
@@ -235,11 +251,14 @@ defmodule Shire.VirtualMachineSSH do
   end
 
   def handle_call({:mkdir_p, path}, _from, state) do
+    state = ensure_connected(state)
     result = sftp_mkdir_p(state.sftp, path)
     {:reply, result, state}
   end
 
   def handle_call({:rm, path}, _from, state) do
+    state = ensure_connected(state)
+
     result =
       case :ssh_sftp.delete(state.sftp, to_charlist(path)) do
         :ok -> :ok
@@ -249,11 +268,9 @@ defmodule Shire.VirtualMachineSSH do
     {:reply, result, state}
   end
 
-  def handle_call({:rm_rf, _path}, _from, %{conn: nil} = state) do
-    {:reply, {:error, :no_connection}, state}
-  end
-
   def handle_call({:rm_rf, path}, _from, state) do
+    state = ensure_connected(state)
+
     result =
       ssh_exec(state.conn, "rm", ["-rf", path], [], state.workspace_root, @default_cmd_timeout)
 
@@ -267,6 +284,8 @@ defmodule Shire.VirtualMachineSSH do
   end
 
   def handle_call({:ls, path}, _from, state) do
+    state = ensure_connected(state)
+
     result =
       case :ssh_sftp.list_dir(state.sftp, to_charlist(path)) do
         {:ok, entries} ->
@@ -300,6 +319,8 @@ defmodule Shire.VirtualMachineSSH do
   end
 
   def handle_call({:stat, path}, _from, state) do
+    state = ensure_connected(state)
+
     result =
       case :ssh_sftp.read_file_info(state.sftp, to_charlist(path)) do
         {:ok, fi} ->
@@ -314,8 +335,12 @@ defmodule Shire.VirtualMachineSSH do
   end
 
   def handle_call(:get_conn, _from, state) do
+    state = ensure_connected(state)
     {:reply, state.conn, state}
   end
+
+  @impl GenServer
+  def handle_info({:ssh_cm, _, _}, state), do: {:noreply, state}
 
   @impl GenServer
   def terminate(reason, state) do
@@ -325,6 +350,46 @@ defmodule Shire.VirtualMachineSSH do
 
     if state[:sftp], do: :ssh_sftp.stop_channel(state.sftp)
     if state[:conn], do: :ssh.close(state.conn)
+  end
+
+  # --- Private: Connection Management ---
+
+  defp ensure_connected(state) do
+    if ssh_alive?(state.conn) do
+      state
+    else
+      Logger.info("SSH connection lost for project #{state.project_id}, reconnecting...")
+
+      try do
+        if state[:sftp], do: :ssh_sftp.stop_channel(state.sftp)
+        if state[:conn], do: :ssh.close(state.conn)
+      catch
+        _, _ -> :ok
+      end
+
+      config = Application.get_env(:shire, :ssh)
+
+      case connect(config) do
+        {:ok, conn, sftp} ->
+          Logger.info("SSH reconnected for project #{state.project_id}")
+          %{state | conn: conn, sftp: sftp}
+
+        {:error, reason} ->
+          Logger.error("SSH reconnect failed for project #{state.project_id}: #{inspect(reason)}")
+          state
+      end
+    end
+  end
+
+  defp ssh_alive?(nil), do: false
+
+  defp ssh_alive?(conn) do
+    Process.alive?(conn) and
+      match?({:status, _, _, _}, :sys.get_status(conn, 1000))
+  rescue
+    _ -> false
+  catch
+    _, _ -> false
   end
 
   # --- Private: SSH Connection ---
@@ -363,7 +428,10 @@ defmodule Shire.VirtualMachineSSH do
         [{:key_cb, {Shire.VirtualMachineSSH.KeyCb, key_pem: normalized_key}}]
 
       {_, password} when is_binary(password) and password != "" ->
-        [{:password, to_charlist(password)}]
+        [
+          {:password, to_charlist(password)},
+          {:key_cb, {Shire.VirtualMachineSSH.KeyCb, key_pem: nil}}
+        ]
 
       _ ->
         raise "SSH auth requires either SHIRE_SSH_KEY (raw PEM) or SHIRE_SSH_PASSWORD"
@@ -376,12 +444,14 @@ defmodule Shire.VirtualMachineSSH do
     env_prefix = build_env_prefix(Keyword.get(opts, :env))
     dir = Keyword.get(opts, :dir, workspace_root)
     cmd_str = build_command_string(command, args)
-    full_cmd = "#{env_prefix}cd #{shell_escape(dir)} && #{cmd_str}"
+    full_cmd = "#{source_profile()}#{env_prefix}cd #{shell_escape(dir)} && #{cmd_str}"
 
     case :ssh_connection.session_channel(conn, timeout) do
       {:ok, channel} ->
-        :ok = :ssh_connection.exec(conn, channel, to_charlist(full_cmd), timeout)
-        collect_exec_output(conn, channel, timeout)
+        case :ssh_connection.exec(conn, channel, to_charlist(full_cmd), timeout) do
+          :success -> collect_exec_output(conn, channel, timeout)
+          {:error, reason} -> {:error, {:exec_failed, reason}}
+        end
 
       {:error, reason} ->
         {:error, {:channel_open, reason}}
@@ -444,10 +514,16 @@ defmodule Shire.VirtualMachineSSH do
 
             env_prefix = build_env_prefix(env)
             cmd_str = build_command_string(command, args)
-            full_cmd = "#{env_prefix}cd #{shell_escape(dir)} && #{cmd_str}"
+            full_cmd = "#{source_profile()}#{env_prefix}cd #{shell_escape(dir)} && #{cmd_str}"
 
-            :ok = :ssh_connection.exec(conn, channel, to_charlist(full_cmd), @default_cmd_timeout)
-            forward_loop(conn, channel, caller, ref, _exit_code = nil)
+            case :ssh_connection.exec(conn, channel, to_charlist(full_cmd), @default_cmd_timeout) do
+              :success ->
+                forward_loop(conn, channel, caller, ref, _exit_code = nil)
+
+              {:error, reason} ->
+                send(caller, {:exit, %{ref: ref}, 1})
+                Logger.error("SSH exec failed: #{inspect(reason)}")
+            end
 
           {:error, reason} ->
             send(caller, {:exit, %{ref: ref}, 1})
@@ -527,6 +603,8 @@ defmodule Shire.VirtualMachineSSH do
     escaped_args = Enum.map_join(args, " ", &shell_escape/1)
     "#{shell_escape(command)} #{escaped_args}"
   end
+
+  defp source_profile, do: "{ [ -f ~/.shire_profile ] && . ~/.shire_profile; } ; "
 
   defp build_env_prefix(nil), do: ""
   defp build_env_prefix([]), do: ""

--- a/lib/shire/virtual_machine_ssh/key_cb.ex
+++ b/lib/shire/virtual_machine_ssh/key_cb.ex
@@ -7,6 +7,8 @@ defmodule Shire.VirtualMachineSSH.KeyCb do
   Accepts all host keys (no known_hosts verification).
   """
 
+  require Logger
+
   @behaviour :ssh_client_key_api
 
   @impl true
@@ -16,14 +18,25 @@ defmodule Shire.VirtualMachineSSH.KeyCb do
 
   @impl true
   def user_key(algorithm, opts) do
-    pem = opts[:key_pem] || raise "SSH key_pem not provided in KeyCb options"
+    case opts[:key_pem] do
+      nil ->
+        {:error, :no_key}
 
-    pem
-    |> :public_key.pem_decode()
-    |> find_key_for_algorithm(algorithm)
-    |> case do
-      {:ok, key} -> {:ok, key}
-      :error -> {:error, :no_matching_key}
+      pem ->
+        case :public_key.pem_decode(pem) do
+          [] ->
+            Logger.error(
+              "SSH key PEM decode returned no entries — key may be malformed or have incorrect newlines"
+            )
+
+            {:error, :no_matching_key}
+
+          entries ->
+            case find_key_for_algorithm(entries, algorithm) do
+              {:ok, key} -> {:ok, key}
+              :error -> {:error, :no_matching_key}
+            end
+        end
     end
   end
 

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -153,13 +153,18 @@ export async function processInbox(harness: Harness, inboxDir = INBOX_DIR): Prom
   const files = await readdir(inboxDir);
   const sorted = files.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).sort();
 
+  let processed = 0;
+
   for (const file of sorted) {
     const path = join(inboxDir, file);
     try {
+      const s = await stat(path);
+      if (s.size === 0) continue;
       const raw = await readFile(path, "utf-8");
       const envelope = yaml.load(raw) as MessageEnvelope;
       await processMessage(harness, envelope);
       await unlink(path);
+      processed++;
     } catch (err) {
       emit("error", { message: `Failed to process ${file}: ${err}` });
       try {
@@ -167,10 +172,11 @@ export async function processInbox(harness: Harness, inboxDir = INBOX_DIR): Prom
       } catch {
         // File may already be gone
       }
+      processed++;
     }
   }
 
-  return sorted.length;
+  return processed;
 }
 
 // ---------------------------------------------------------------------------

--- a/priv/sprite/bootstrap.sh
+++ b/priv/sprite/bootstrap.sh
@@ -13,35 +13,36 @@ mkdir -p "$WORKSPACE_ROOT/.scripts"
 mkdir -p "$WORKSPACE_ROOT/shared"
 mkdir -p "$WORKSPACE_ROOT/agents"
 
+# --- Ensure unzip is available (needed by Bun installer) ---
+if ! command -v unzip &> /dev/null; then
+  echo "Installing unzip..."
+  if command -v apt-get &> /dev/null; then
+    sudo apt-get update -qq && sudo apt-get install -y -qq unzip
+  elif command -v yum &> /dev/null; then
+    sudo yum install -y unzip
+  fi
+fi
+
 # --- Install Bun if not available ---
 if ! command -v bun &> /dev/null; then
   echo "Installing Bun..."
   curl -fsSL https://bun.sh/install | bash || echo "Warning: Bun installation failed"
-  cat >> "$HOME/.bashrc" << 'BASHRC'
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
-BASHRC
-  source "$HOME/.bashrc"
+  export BUN_INSTALL="$HOME/.bun"
+  export PATH="$BUN_INSTALL/bin:$PATH"
 fi
 
 # --- Install Claude Code if not available ---
 if ! command -v claude &> /dev/null; then
   echo "Installing Claude Code..."
   curl -fsSL https://claude.ai/install.sh | bash || echo "Warning: Claude Code installation failed"
-  cat >> "$HOME/.bashrc" << 'BASHRC'
-export PATH="$HOME/.claude/local:$PATH"
-BASHRC
-  source "$HOME/.bashrc"
+  export PATH="$HOME/.local/bin:$HOME/.claude/local:$PATH"
 fi
 
-# Source workspace env vars in every interactive/login shell
-cat >> "$HOME/.bashrc" << BASHRC
-if [ -f "$WORKSPACE_ROOT/.env" ]; then
-  set -a
-  . "$WORKSPACE_ROOT/.env"
-  set +a
-fi
-BASHRC
+# --- Write .shire_profile (sourced by SSH commands, no interactive guard) ---
+cat > "$HOME/.shire_profile" << 'PROFILE'
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$HOME/.local/bin:$HOME/.claude/local:$BUN_INSTALL/bin:$PATH"
+PROFILE
 
 # Create default PROJECT.md if it doesn't exist
 if [ ! -f "$WORKSPACE_ROOT/PROJECT.md" ]; then


### PR DESCRIPTION
## Summary

- **SSH reconnection**: Auto-reconnects when the SSH connection drops, with retry-on-failure for `cmd` calls
- **`.shire_profile`**: Dedicated profile file sourced before every SSH command to set PATH (bun, claude) — avoids `.bashrc` non-interactive guard
- **Bootstrap improvements**: Installs `unzip` before bun, writes `.shire_profile`, handles PATH in current session
- **OTP 27+ compat**: Handle `ssh_connection.exec` returning `:success` instead of `:ok`
- **Bug fixes**: Project delete button, inbox size-0 file skip, PEM decode logging, destroy_vm crash handling, silence `ssh_cm` messages
- **`fly.vps.toml`**: Separate Fly config for SSH-backed deployment

## Test plan

- [x] `mix compile --warnings-as-errors` — 0 warnings
- [x] `mix format --check-formatted` — formatted
- [x] `mix test --exclude ssh` — 353 tests, 0 failures
- [ ] Manual: deploy to Fly with `SHIRE_VM_TYPE=ssh` and verify project creation, agent spawning, messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)