### PR TITLE
Rename comms_prompt to internal_system_prompt, inject via runner

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -10,7 +10,7 @@ defmodule Shire.Agent.AgentManager do
   alias Shire.Agents
   alias Shire.Workspace
 
-  defp comms_prompt(agent_name, agent_id, project_id) do
+  defp internal_system_prompt(agent_name, agent_id, project_id) do
     peers_path = Workspace.peers_path(project_id)
     outbox_path = Path.join(Workspace.agent_dir(project_id, agent_id), "outbox/<any-name>.yaml")
     shared_path = Workspace.shared_dir(project_id)
@@ -590,22 +590,15 @@ defmodule Shire.Agent.AgentManager do
 
     vm().cmd!(project_id, "mkdir", ["-p" | dirs], [])
 
-    # Read recipe to determine harness type
-    recipe = read_recipe(project_id, agent_id)
-    harness = recipe["harness"] || "claude_code"
-
-    # Write comms instructions to the file the harness reads
-    comms_file =
-      case harness do
-        "claude_code" -> "CLAUDE.md"
-        _ -> "AGENTS.md"
-      end
-
+    # Write internal system prompt for the runner to inject
     vm().write(
       project_id,
-      Path.join(agent_dir, comms_file),
-      comms_prompt(agent_name, agent_id, project_id)
+      Path.join(agent_dir, "INTERNAL.md"),
+      internal_system_prompt(agent_name, agent_id, project_id)
     )
+
+    # Read recipe for skill deployment
+    recipe = read_recipe(project_id, agent_id)
 
     # Deploy skills from recipe
     deploy_skills(project_id, recipe, agent_dir)

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -445,6 +445,7 @@ max_tokens: 8192
     expect(config.harness).toBe("pi");
     expect(config.model).toBe("anthropic/claude-sonnet-4-6");
     expect(config.system_prompt).toBe("You are helpful.");
+    expect(config.internal_system_prompt).toBe("");
     expect(config.max_tokens).toBe(8192);
   });
 
@@ -455,7 +456,23 @@ max_tokens: 8192
     expect(config.harness).toBe("claude_code");
     expect(config.model).toBe("claude-sonnet-4-6");
     expect(config.system_prompt).toBe("");
+    expect(config.internal_system_prompt).toBe("");
     expect(config.max_tokens).toBe(16384);
+  });
+
+  test("reads INTERNAL.md as internal_system_prompt", async () => {
+    writeFileSync(`${TEST_AGENT_DIR}/recipe.yaml`, "version: 1\nname: test\n");
+    writeFileSync(`${TEST_AGENT_DIR}/INTERNAL.md`, "# Inter-Agent Communication\nYou are **test-agent**.");
+
+    const config = await loadConfig(`${TEST_AGENT_DIR}/recipe.yaml`);
+    expect(config.internal_system_prompt).toBe("# Inter-Agent Communication\nYou are **test-agent**.");
+  });
+
+  test("defaults internal_system_prompt to empty string when INTERNAL.md missing", async () => {
+    writeFileSync(`${TEST_AGENT_DIR}/recipe.yaml`, "version: 1\nname: test\n");
+
+    const config = await loadConfig(`${TEST_AGENT_DIR}/recipe.yaml`);
+    expect(config.internal_system_prompt).toBe("");
   });
 });
 

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -2,7 +2,7 @@
 // Each agent runs in its own workspace directory under /workspace/agents/{id}/.
 import { watch } from "fs";
 import { readFile, readdir, rename, unlink, writeFile, mkdir, stat } from "fs/promises";
-import { basename, join } from "path";
+import { basename, dirname, join } from "path";
 import { parseArgs } from "util";
 import yaml from "js-yaml";
 import { createHarness, type Harness, type HarnessType } from "./harness";
@@ -29,6 +29,7 @@ export interface AgentConfig {
   harness: HarnessType;
   model: string;
   system_prompt: string;
+  internal_system_prompt: string;
   max_tokens?: number;
 }
 
@@ -92,10 +93,19 @@ export async function loadPeers(peersPath = PEERS_PATH): Promise<void> {
 export async function loadConfig(path = RECIPE_PATH): Promise<AgentConfig> {
   const raw = await readFile(path, "utf-8");
   const recipe = yaml.load(raw) as Record<string, unknown>;
+
+  let internalSystemPrompt = "";
+  try {
+    internalSystemPrompt = await readFile(join(dirname(path), "INTERNAL.md"), "utf-8");
+  } catch {
+    // INTERNAL.md may not exist yet
+  }
+
   return {
     harness: (recipe.harness as HarnessType) || "claude_code",
     model: (recipe.model as string) || "claude-sonnet-4-6",
     system_prompt: (recipe.system_prompt as string) || "",
+    internal_system_prompt: internalSystemPrompt,
     max_tokens: (recipe.max_tokens as number) || 16384,
   };
 }
@@ -365,6 +375,7 @@ async function main() {
   await harness.start({
     model: config.model,
     systemPrompt: config.system_prompt,
+    internalSystemPrompt: config.internal_system_prompt,
     cwd: AGENT_DIR,
     maxTokens: config.max_tokens,
   });

--- a/priv/sprite/harness/claude-code-harness.test.ts
+++ b/priv/sprite/harness/claude-code-harness.test.ts
@@ -149,6 +149,33 @@ describe("ClaudeCodeHarness", () => {
     expect(params.options?.permissionMode).toBe("bypassPermissions");
   });
 
+  test("sendMessage() composes internalSystemPrompt with systemPrompt", async () => {
+    const mockQuery = createMockQuery([resultSuccess("Hi", "s1")]);
+    const harness = new ClaudeCodeHarness(mockQuery);
+    harness.onEvent(() => {});
+
+    await harness.start({
+      ...baseConfig,
+      internalSystemPrompt: "# Internal\nYou are agent-1.",
+    });
+    await harness.sendMessage("Hello");
+
+    const params = mockQuery.mock.calls[0][0];
+    expect(params.options?.systemPrompt).toBe("# Internal\nYou are agent-1.\n\nYou are a helpful assistant.");
+  });
+
+  test("sendMessage() uses only systemPrompt when internalSystemPrompt is absent", async () => {
+    const mockQuery = createMockQuery([resultSuccess("Hi", "s1")]);
+    const harness = new ClaudeCodeHarness(mockQuery);
+    harness.onEvent(() => {});
+
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hello");
+
+    const params = mockQuery.mock.calls[0][0];
+    expect(params.options?.systemPrompt).toBe("You are a helpful assistant.");
+  });
+
   test("sendMessage() passes continue: true in query options", async () => {
     const mockQuery = createMockQuery([resultSuccess("Hi", "sess-123")]);
     const harness = new ClaudeCodeHarness(mockQuery);

--- a/priv/sprite/harness/claude-code-harness.ts
+++ b/priv/sprite/harness/claude-code-harness.ts
@@ -32,7 +32,7 @@ export class ClaudeCodeHarness implements Harness {
         prompt: content,
         options: {
           model: this.config.model,
-          systemPrompt: this.config.systemPrompt,
+          systemPrompt: [this.config.internalSystemPrompt, this.config.systemPrompt].filter(Boolean).join("\n\n"),
           cwd: this.config.cwd,
           allowedTools: ["Bash", "Read", "Edit", "Write", "Skill"],
           settingSources: ["project"],

--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -100,7 +100,7 @@ export class PiHarness implements Harness {
       cwd: config.cwd,
       settingsManager,
       systemPromptOverride: (base) => {
-        const parts = [base, config.systemPrompt].filter(Boolean);
+        const parts = [base, config.internalSystemPrompt, config.systemPrompt].filter(Boolean);
         return parts.length > 0 ? parts.join("\n\n") : undefined;
       },
     });

--- a/priv/sprite/harness/types.ts
+++ b/priv/sprite/harness/types.ts
@@ -2,6 +2,7 @@
 export interface HarnessConfig {
   model: string;
   systemPrompt: string;
+  internalSystemPrompt?: string;
   cwd: string;
   maxTokens?: number;
 }


### PR DESCRIPTION
## Summary
- Renamed `comms_prompt` to `internal_system_prompt` in `agent_manager.ex`
- Write to `INTERNAL.md` instead of `CLAUDE.md`/`AGENTS.md` (no longer harness-dependent)
- Runner reads `INTERNAL.md` and passes it to the harness as `internalSystemPrompt`
- Each harness injects it between the base prompt and the agent's custom `system_prompt`

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 350 tests, 0 failures
- [x] `bun test` (priv/sprite) — 72 tests, 0 failures (4 new tests added)
- [x] `bun run lint` + `bun run format:check` passes for priv/sprite and assets
- [ ] Manual: create an agent, verify INTERNAL.md is written and inter-agent comms work

🤖 Generated with [Claude Code](https://claude.com/claude-code)