### PR TITLE
Pi harness: auto-continue latest session on restart

### DIFF
--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -115,7 +115,7 @@ export class PiHarness implements Harness {
       modelRegistry,
       tools: createCodingTools(config.cwd),
       resourceLoader: loader,
-      sessionManager: SessionManager.inMemory(),
+      sessionManager: SessionManager.continueRecent(config.cwd),
       settingsManager,
     });
     return session;


### PR DESCRIPTION
## Summary
- Switch `SessionManager.inMemory()` to `SessionManager.continueRecent(config.cwd)` in the Pi harness
- Pi agents now preserve conversation history across restarts instead of starting fresh each time
- Sessions are stored as JSONL files on the VM filesystem, scoped per agent workspace directory

## Test plan
- [x] All 69 existing tests pass
- [x] ESLint clean
- [x] Prettier clean
- [ ] Manual: restart a Pi agent and verify it continues the previous conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)