### PR TITLE
increase Sprite VM ping interval from 2s to 15s

### DIFF
--- a/lib/shire/virtual_machine_sprite.ex
+++ b/lib/shire/virtual_machine_sprite.ex
@@ -16,7 +16,7 @@ defmodule Shire.VirtualMachineSprite do
   @ready_retries 10
   @ready_backoff 2_000
   @max_backoff 30_000
-  @ping_interval 2_000
+  @ping_interval 15_000
   @keepalive_duration :timer.minutes(30)
 
   def start_link(opts) do
@@ -96,6 +96,9 @@ defmodule Shire.VirtualMachineSprite do
     GenServer.cast(via(project_id), :touch_keepalive)
     :ok
   end
+
+  @doc false
+  def ping_interval, do: @ping_interval
 
   # --- Public API: Interactive Process ---
 

--- a/test/shire/virtual_machine_sprite_test.exs
+++ b/test/shire/virtual_machine_sprite_test.exs
@@ -72,6 +72,14 @@ defmodule Shire.VirtualMachineSpriteTest do
   end
 
   describe "VM keep-alive ping" do
+    test "ping interval is at least 10s to avoid filling /run with crun PID files" do
+      # Each Sprites.cmd ping spawns a container process that writes a PID file to
+      # /run/sprite-env/crun/. Too-frequent pings fill the tmpfs and make the VM
+      # unresponsive. 15s stays under the 30s Sprites idle timeout while limiting
+      # PID file accumulation to ~120 per 30-min keepalive window.
+      assert VM.ping_interval() >= 10_000
+    end
+
     test "handle_info(:ping_vm) stops when ping_until has expired" do
       state = %{
         sprite: nil,


### PR DESCRIPTION
## Summary

- Increases `@ping_interval` from 2s to 15s in `VirtualMachineSprite`
- Each `Sprites.cmd("echo", ["ping"])` spawns a container process that writes a PID file to `/run/sprite-env/crun/` on the Sprites host. At 2s intervals, ~900 PID files accumulate per 30-min keepalive window, filling the tmpfs and causing "No space left on device" errors that make the VM unresponsive
- 15s stays under the 30s Sprites idle timeout while reducing PID file churn by 7.5x (~120 per window)
- Adds regression test asserting ping interval >= 10s

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] All 354 tests pass
- [ ] Manual: boot a project, let it run 30+ min, verify no "No space left on device" errors
- [ ] Verify VM stays awake (15s < 30s idle timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)