### PR TITLE
use filesystem API for mkdir instead of spawning containers

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -612,7 +612,7 @@ defmodule Shire.Agent.AgentManager do
           ],
           do: Path.join(agent_dir, subdir)
 
-    vm().cmd!(project_id, "mkdir", ["-p" | dirs], [])
+    Enum.each(dirs, &vm().mkdir_p(project_id, &1))
 
     # Write internal system prompt for the runner to inject
     vm().write(

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -25,7 +25,7 @@ defmodule Shire.Agents do
             do: Path.join(agent_dir, subdir)
 
       try do
-        vm.cmd!(project_id, "mkdir", ["-p" | dirs], [])
+        Enum.each(dirs, &vm.mkdir_p(project_id, &1))
 
         case vm.write(project_id, Path.join(agent_dir, "recipe.yaml"), recipe_yaml) do
           :ok -> {:ok, agent.id}

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -72,6 +72,7 @@ defmodule Shire.Agent.AgentManagerTest do
 
     test "persists user message to DB when from is :user", ctx do
       Mox.set_mox_global()
+      stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
       stub(Shire.VirtualMachineMock, :write, fn _project, _path, _content -> :ok end)
 
       {:ok, pid} = start_manager(ctx)


### PR DESCRIPTION
## Summary

- Replace `vm.cmd!("mkdir", ["-p" | dirs])` with `Enum.each(dirs, &vm.mkdir_p/2)` in `agents.ex` and `agent_manager.ex`
- `mkdir_p` routes through the Sprites Filesystem REST API, which doesn't spawn container processes or write PID files to `/run/sprite-env/crun/`
- Follow-up to #96 — further reduces container process churn that fills the Sprite host tmpfs
- Fix pre-existing test bug: re-stub `workspace_root` after `Mox.set_mox_global()` in agent_manager_test

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] All 354 tests pass
- [x] `mix format --check-formatted` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)