### PR TITLE
add explicit timeouts to all VM GenServer.call sites

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -142,7 +142,7 @@ defmodule Shire.Agent.AgentManager do
   end
 
   def last_read_message_id(project_id, agent_id) do
-    GenServer.call(via(project_id, agent_id), :last_read_message_id)
+    GenServer.call(via(project_id, agent_id), :last_read_message_id, 5_000)
   end
 
   defp via(project_id, agent_id) do

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -24,12 +24,12 @@ defmodule Shire.Agent.Coordinator do
 
   @doc "Returns the current status for an agent (defaults to :created if not tracked)."
   def agent_status(project_id, agent_id) do
-    GenServer.call(via(project_id), {:agent_status, agent_id})
+    GenServer.call(via(project_id), {:agent_status, agent_id}, 5_000)
   end
 
   @doc "Returns a map of `%{agent_id => status}` for the given agent IDs."
   def agent_statuses(project_id, agent_ids) do
-    GenServer.call(via(project_id), {:agent_statuses, agent_ids})
+    GenServer.call(via(project_id), {:agent_statuses, agent_ids}, 5_000)
   end
 
   @doc "Creates a new agent: inserts DB record, sets up VM workspace, and starts runner."

--- a/lib/shire/virtual_machine_sprite.ex
+++ b/lib/shire/virtual_machine_sprite.ex
@@ -13,6 +13,7 @@ defmodule Shire.VirtualMachineSprite do
   @behaviour Shire.VirtualMachine
 
   @default_cmd_timeout 30_000
+  @fs_call_timeout @default_cmd_timeout + 5_000
   @ready_retries 10
   @ready_backoff 2_000
   @max_backoff 30_000
@@ -56,42 +57,42 @@ defmodule Shire.VirtualMachineSprite do
 
   @impl Shire.VirtualMachine
   def read(project_id, path) do
-    GenServer.call(via(project_id), {:read, path})
+    GenServer.call(via(project_id), {:read, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def write(project_id, path, content) do
-    GenServer.call(via(project_id), {:write, path, content})
+    GenServer.call(via(project_id), {:write, path, content}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def mkdir_p(project_id, path) do
-    GenServer.call(via(project_id), {:mkdir_p, path})
+    GenServer.call(via(project_id), {:mkdir_p, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def mkdir_p_many(project_id, paths) do
-    GenServer.call(via(project_id), {:mkdir_p_many, paths}, 30_000)
+    GenServer.call(via(project_id), {:mkdir_p_many, paths}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def rm(project_id, path) do
-    GenServer.call(via(project_id), {:rm, path})
+    GenServer.call(via(project_id), {:rm, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def rm_rf(project_id, path) do
-    GenServer.call(via(project_id), {:rm_rf, path})
+    GenServer.call(via(project_id), {:rm_rf, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def ls(project_id, path) do
-    GenServer.call(via(project_id), {:ls, path})
+    GenServer.call(via(project_id), {:ls, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def stat(project_id, path) do
-    GenServer.call(via(project_id), {:stat, path})
+    GenServer.call(via(project_id), {:stat, path}, @fs_call_timeout)
   end
 
   # --- Public API: Keepalive ---
@@ -109,7 +110,7 @@ defmodule Shire.VirtualMachineSprite do
 
   @impl Shire.VirtualMachine
   def spawn_command(project_id, command, args \\ [], opts \\ []) do
-    sprite = GenServer.call(via(project_id), :get_sprite)
+    sprite = GenServer.call(via(project_id), :get_sprite, 5_000)
 
     case sprite do
       nil ->

--- a/lib/shire/virtual_machine_ssh.ex
+++ b/lib/shire/virtual_machine_ssh.ex
@@ -19,6 +19,7 @@ defmodule Shire.VirtualMachineSSH do
   )
 
   @default_cmd_timeout 30_000
+  @fs_call_timeout @default_cmd_timeout + 5_000
   @connect_timeout 10_000
   @forward_loop_idle_timeout :timer.minutes(10)
 
@@ -65,49 +66,49 @@ defmodule Shire.VirtualMachineSSH do
 
   @impl Shire.VirtualMachine
   def read(project_id, path) do
-    GenServer.call(via(project_id), {:read, path})
+    GenServer.call(via(project_id), {:read, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def write(project_id, path, content) do
-    GenServer.call(via(project_id), {:write, path, content})
+    GenServer.call(via(project_id), {:write, path, content}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def mkdir_p(project_id, path) do
-    GenServer.call(via(project_id), {:mkdir_p, path})
+    GenServer.call(via(project_id), {:mkdir_p, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def mkdir_p_many(project_id, paths) do
-    GenServer.call(via(project_id), {:mkdir_p_many, paths}, 30_000)
+    GenServer.call(via(project_id), {:mkdir_p_many, paths}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def rm(project_id, path) do
-    GenServer.call(via(project_id), {:rm, path})
+    GenServer.call(via(project_id), {:rm, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def rm_rf(project_id, path) do
-    GenServer.call(via(project_id), {:rm_rf, path})
+    GenServer.call(via(project_id), {:rm_rf, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def ls(project_id, path) do
-    GenServer.call(via(project_id), {:ls, path})
+    GenServer.call(via(project_id), {:ls, path}, @fs_call_timeout)
   end
 
   @impl Shire.VirtualMachine
   def stat(project_id, path) do
-    GenServer.call(via(project_id), {:stat, path})
+    GenServer.call(via(project_id), {:stat, path}, @fs_call_timeout)
   end
 
   # --- Interactive Process ---
 
   @impl Shire.VirtualMachine
   def spawn_command(project_id, command, args \\ [], opts \\ []) do
-    conn = GenServer.call(via(project_id), :get_conn)
+    conn = GenServer.call(via(project_id), :get_conn, 5_000)
 
     if is_nil(conn) do
       {:error, :no_connection}


### PR DESCRIPTION
## Summary
- Filesystem operations (`read`, `write`, `mkdir_p`, `mkdir_p_many`, `rm`, `rm_rf`, `ls`, `stat`) in `VirtualMachineSprite` and `VirtualMachineSSH` were using the default 5s `GenServer.call` timeout despite performing network I/O (Sprite SDK / SFTP) that can easily exceed 5s
- Added `@fs_call_timeout` (35s = `@default_cmd_timeout + 5_000`) to all filesystem call wrappers, matching the existing `cmd()` timeout pattern
- Made pure state lookup timeouts explicit (`get_sprite`, `get_conn`, `agent_status`, `agent_statuses`, `last_read_message_id`) at 5s for consistency

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test` — 354 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)