### PR TITLE
Add URL-per-agent-chat for better navigation

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -6,6 +6,7 @@ import ChatHeader from "./ChatHeader";
 import ChatPanel, { type Message } from "./ChatPanel";
 import WelcomePanel from "./WelcomePanel";
 import { type Agent, type CatalogAgent, type CatalogAgentSummary, type CatalogCategory, type Project } from "./types";
+import { navigate } from "./lib/navigate";
 
 interface AgentDashboardProps {
   project: { id: string; name: string };
@@ -91,7 +92,10 @@ export default function AgentDashboard({
 
   const handleSelectAgent = (id: string) => {
     setSidebarOpen(false);
-    pushEvent("select-agent", { id });
+    const agent = agents.find((a) => a.id === id);
+    if (agent) {
+      navigate(`/projects/${project.name}/agents/${agent.name}`);
+    }
   };
 
   const handleDeleteAgent = (agent: Agent) => {

--- a/assets/react-components/AgentShow.tsx
+++ b/assets/react-components/AgentShow.tsx
@@ -44,7 +44,12 @@ export default function AgentShow({
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" aria-label="Back" onClick={() => navigate(`/projects/${project.name}`)}>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Back"
+              onClick={() => navigate(`/projects/${project.name}/agents/${agent.name}`)}
+            >
               <ChevronLeft className="h-5 w-5" />
             </Button>
             <h1 className="text-2xl font-bold">{agent.name}</h1>

--- a/assets/react-components/AgentSidebar.tsx
+++ b/assets/react-components/AgentSidebar.tsx
@@ -110,7 +110,7 @@ export default function AgentSidebar({
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => navigate(`/projects/${project.name}/agents/${agent.name}`)}>
+                <DropdownMenuItem onClick={() => navigate(`/projects/${project.name}/agents/${agent.name}/settings`)}>
                   Settings
                 </DropdownMenuItem>
                 <DropdownMenuItem

--- a/assets/test/AgentDashboard.test.tsx
+++ b/assets/test/AgentDashboard.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import AgentDashboard from "../react-components/AgentDashboard";
+import { navigate } from "../react-components/lib/navigate";
+
+vi.mock("../react-components/lib/navigate", () => ({
+  navigate: vi.fn(),
+}));
 import { type Agent, type CatalogAgentSummary, type CatalogCategory, type Project } from "../react-components/types";
 
 const agents: Agent[] = [
@@ -61,12 +66,11 @@ describe("AgentDashboard", () => {
     expect(screen.queryByText("Shire")).not.toBeInTheDocument();
   });
 
-  it("calls pushEvent with select-agent when clicking sidebar agent", async () => {
-    const pushEvent = vi.fn();
-    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} pushEvent={pushEvent} />);
+  it("navigates to agent URL when clicking sidebar agent", async () => {
+    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} />);
 
     await userEvent.click(screen.getByText("Agent One"));
-    expect(pushEvent).toHaveBeenCalledWith("select-agent", { id: "a1" });
+    expect(navigate).toHaveBeenCalledWith("/projects/test-project/agents/Agent One");
   });
 
   it("opens new agent dialog from sidebar", async () => {

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -54,8 +54,45 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
+  def handle_params(%{"agent_name" => agent_name}, _url, socket) do
+    project = socket.assigns.project
+
+    case Agents.get_agent_by_name(project.id, agent_name) do
+      nil ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Agent not found")
+         |> push_patch(to: ~p"/projects/#{project.name}")}
+
+      agent_record ->
+        if agent_record.id == socket.assigns.selected_agent_id do
+          {:noreply, assign(socket, :page_title, agent_name)}
+        else
+          {:noreply,
+           socket
+           |> select_agent(project.id, agent_record.id)
+           |> assign(:page_title, agent_name)}
+        end
+    end
+  end
+
   def handle_params(_params, _url, socket) do
-    {:noreply, assign(socket, :page_title, "Agents")}
+    if old = socket.assigns.selected_agent_id do
+      Phoenix.PubSub.unsubscribe(
+        Shire.PubSub,
+        "project:#{socket.assigns.project.id}:agent:#{old}"
+      )
+    end
+
+    {:noreply,
+     assign(socket,
+       page_title: "Agents",
+       selected_agent_id: nil,
+       selected_agent: nil,
+       messages: [],
+       has_more: false,
+       streaming_text: nil
+     )}
   end
 
   # Agent CRUD events
@@ -68,20 +105,14 @@ defmodule ShireWeb.AgentLive.Index do
       :ok ->
         agents = Coordinator.list_agents(project_id)
 
-        selected =
-          if socket.assigns.selected_agent_id == agent_id do
-            nil
-          else
-            socket.assigns.selected_agent_id
-          end
-
-        {:noreply,
-         assign(socket,
-           agents: agents,
-           selected_agent_id: selected,
-           selected_agent: if(selected, do: socket.assigns.selected_agent, else: nil),
-           messages: if(selected, do: socket.assigns.messages, else: [])
-         )}
+        if socket.assigns.selected_agent_id == agent_id do
+          {:noreply,
+           socket
+           |> assign(:agents, agents)
+           |> push_patch(to: ~p"/projects/#{socket.assigns.project.name}")}
+        else
+          {:noreply, assign(socket, :agents, agents)}
+        end
 
       {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed to delete: #{inspect(reason)}")}
@@ -151,46 +182,7 @@ defmodule ShireWeb.AgentLive.Index do
     end
   end
 
-  # Agent selection and chat events
-
-  @impl true
-  def handle_event("select-agent", %{"id" => agent_id}, socket) do
-    project_id = socket.assigns.project.id
-
-    case Coordinator.get_agent(project_id, agent_id) do
-      {:ok, agent} ->
-        if connected?(socket) do
-          if old = socket.assigns.selected_agent_id do
-            Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:agent:#{old}")
-          end
-
-          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
-        end
-
-        {messages, has_more} = Agents.list_messages_for_agent(project_id, agent_id, limit: 50)
-
-        latest_id =
-          case List.last(messages) do
-            nil -> nil
-            msg -> msg.id
-          end
-
-        if latest_id, do: AgentManager.mark_read(project_id, agent_id, latest_id)
-
-        {:noreply,
-         assign(socket,
-           selected_agent_id: agent_id,
-           selected_agent: agent,
-           messages: Enum.map(messages, &Helpers.serialize_message/1),
-           has_more: has_more,
-           streaming_text: nil,
-           unread_counts: Map.put(socket.assigns.unread_counts, agent_id, 0)
-         )}
-
-      {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Agent not found")}
-    end
-  end
+  # Chat events
 
   @impl true
   def handle_event("send-message", %{"text" => text} = params, socket) do
@@ -360,21 +352,27 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
-  def handle_info({:agent_renamed, agent_id, _old_name, _new_name}, socket) do
+  def handle_info({:agent_renamed, agent_id, _old_name, new_name}, socket) do
     project_id = socket.assigns.project.id
     agents = Coordinator.list_agents(project_id)
 
-    selected_agent =
-      if socket.assigns.selected_agent_id == agent_id do
+    if socket.assigns.selected_agent_id == agent_id do
+      selected_agent =
         case Coordinator.get_agent(project_id, agent_id) do
           {:ok, agent} -> agent
           _ -> socket.assigns.selected_agent
         end
-      else
-        socket.assigns.selected_agent
-      end
 
-    {:noreply, assign(socket, agents: agents, selected_agent: selected_agent)}
+      {:noreply,
+       socket
+       |> assign(agents: agents, selected_agent: selected_agent)
+       |> push_patch(
+         to: ~p"/projects/#{socket.assigns.project.name}/agents/#{new_name}",
+         replace: true
+       )}
+    else
+      {:noreply, assign(socket, :agents, agents)}
+    end
   end
 
   @impl true
@@ -383,12 +381,9 @@ defmodule ShireWeb.AgentLive.Index do
 
     if socket.assigns.selected_agent_id == agent_id do
       {:noreply,
-       assign(socket,
-         agents: agents,
-         selected_agent_id: nil,
-         selected_agent: nil,
-         messages: []
-       )}
+       socket
+       |> assign(:agents, agents)
+       |> push_patch(to: ~p"/projects/#{socket.assigns.project.name}")}
     else
       {:noreply, assign(socket, :agents, agents)}
     end
@@ -409,6 +404,41 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   # --- Private helpers ---
+
+  defp select_agent(socket, project_id, agent_id) do
+    case Coordinator.get_agent(project_id, agent_id) do
+      {:ok, agent} ->
+        if connected?(socket) do
+          if old = socket.assigns.selected_agent_id do
+            Phoenix.PubSub.unsubscribe(Shire.PubSub, "project:#{project_id}:agent:#{old}")
+          end
+
+          Phoenix.PubSub.subscribe(Shire.PubSub, "project:#{project_id}:agent:#{agent_id}")
+        end
+
+        {messages, has_more} = Agents.list_messages_for_agent(project_id, agent_id, limit: 50)
+
+        latest_id =
+          case List.last(messages) do
+            nil -> nil
+            msg -> msg.id
+          end
+
+        if latest_id, do: AgentManager.mark_read(project_id, agent_id, latest_id)
+
+        assign(socket,
+          selected_agent_id: agent_id,
+          selected_agent: agent,
+          messages: Enum.map(messages, &Helpers.serialize_message/1),
+          has_more: has_more,
+          streaming_text: nil,
+          unread_counts: Map.put(socket.assigns.unread_counts, agent_id, 0)
+        )
+
+      {:error, _} ->
+        put_flash(socket, :error, "Agent not found")
+    end
+  end
 
   defp store_attachments(_project_id, _agent_id, []), do: {:ok, []}
 

--- a/lib/shire_web/live/agent_live/show.ex
+++ b/lib/shire_web/live/agent_live/show.ex
@@ -142,7 +142,14 @@ defmodule ShireWeb.AgentLive.Show do
   @impl true
   def handle_info({:agent_renamed, _agent_id, _old_name, new_name}, socket) do
     agent = Map.put(socket.assigns.agent, :name, new_name)
-    {:noreply, assign(socket, :agent, agent)}
+
+    {:noreply,
+     socket
+     |> assign(:agent, agent)
+     |> push_patch(
+       to: ~p"/projects/#{socket.assigns.project.name}/agents/#{new_name}/settings",
+       replace: true
+     )}
   end
 
   @impl true

--- a/lib/shire_web/router.ex
+++ b/lib/shire_web/router.ex
@@ -21,7 +21,8 @@ defmodule ShireWeb.Router do
       live "/", ProjectLive.Index, :index
 
       live "/projects/:project_name", AgentLive.Index, :index
-      live "/projects/:project_name/agents/:agent_name", AgentLive.Show, :show
+      live "/projects/:project_name/agents/:agent_name", AgentLive.Index, :chat
+      live "/projects/:project_name/agents/:agent_name/settings", AgentLive.Show, :show
 
       live "/projects/:project_name/settings", SettingsLive.Index, :index
 

--- a/test/shire_web/live/agent_live_test.exs
+++ b/test/shire_web/live/agent_live_test.exs
@@ -88,20 +88,6 @@ defmodule ShireWeb.AgentLiveTest do
       assert html =~ "AgentDashboard"
     end
 
-    # --- select-agent ---
-
-    test "select-agent with nonexistent agent shows error flash", %{
-      conn: conn,
-      project_name: project_name
-    } do
-      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}")
-
-      render_hook(view, "select-agent", %{"id" => "00000000-0000-0000-0000-000000000000"})
-
-      html = render(view)
-      assert html =~ "AgentDashboard"
-    end
-
     # --- delete-agent ---
 
     test "delete-agent does not crash the view", %{conn: conn, project_name: project_name} do
@@ -266,6 +252,36 @@ defmodule ShireWeb.AgentLiveTest do
     end
   end
 
+  describe "Chat (URL-based agent selection)" do
+    test "navigating to agent URL selects the agent", %{
+      conn: conn,
+      project_id: project_id,
+      project_name: project_name
+    } do
+      agent = create_db_agent(project_id, "chat-agent")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      assert html =~ "AgentDashboard"
+    end
+
+    test "navigating to nonexistent agent redirects to project root", %{
+      conn: conn,
+      project_name: project_name
+    } do
+      assert {:error, {:live_redirect, %{to: "/projects/" <> ^project_name}}} =
+               live(conn, ~p"/projects/#{project_name}/agents/nonexistent")
+    end
+
+    test "navigating to project root shows no selected agent", %{
+      conn: conn,
+      project_id: project_id,
+      project_name: project_name
+    } do
+      _agent = create_db_agent(project_id, "some-agent")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_name}")
+      assert html =~ "AgentDashboard"
+    end
+  end
+
   describe "Show" do
     test "renders agent show page", %{
       conn: conn,
@@ -273,7 +289,7 @@ defmodule ShireWeb.AgentLiveTest do
       project_name: project_name
     } do
       agent = create_db_agent(project_id, "test-agent-show")
-      {:ok, _view, html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}/settings")
       assert html =~ "AgentShow"
     end
 
@@ -283,7 +299,7 @@ defmodule ShireWeb.AgentLiveTest do
       project_name: project_name
     } do
       agent = create_db_agent(project_id, "my-agent-show")
-      {:ok, _view, html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}/settings")
       assert html =~ "AgentShow"
     end
 
@@ -293,7 +309,7 @@ defmodule ShireWeb.AgentLiveTest do
       project_name: project_name
     } do
       agent = create_db_agent(project_id, "test-agent-update")
-      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}/settings")
 
       render_hook(view, "update-agent", %{
         "recipe_yaml" =>
@@ -310,7 +326,7 @@ defmodule ShireWeb.AgentLiveTest do
       project_name: project_name
     } do
       agent = create_db_agent(project_id, "delete-me")
-      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}/settings")
 
       render_hook(view, "delete-agent", %{})
       assert_redirect(view, "/projects/#{project_name}")
@@ -322,7 +338,7 @@ defmodule ShireWeb.AgentLiveTest do
       project_name: project_name
     } do
       agent = create_db_agent(project_id, "status-agent")
-      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}/settings")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
@@ -340,7 +356,7 @@ defmodule ShireWeb.AgentLiveTest do
       project_name: project_name
     } do
       agent = create_db_agent(project_id, "status-agent-2")
-      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}/settings")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,
@@ -358,7 +374,7 @@ defmodule ShireWeb.AgentLiveTest do
       project_name: project_name
     } do
       agent = create_db_agent(project_id, "test-agent-event")
-      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}")
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project_name}/agents/#{agent.name}/settings")
 
       Phoenix.PubSub.broadcast(
         Shire.PubSub,


### PR DESCRIPTION
## Summary

- Agent chat is now URL-driven: `/projects/:project_name/agents/:agent_name` opens the chat for that agent
- Browser back/forward, bookmarkable links, and direct URL access all work
- Agent settings moved to `/projects/:project_name/agents/:agent_name/settings`
- Graceful redirect when navigating to a nonexistent agent name
- URL auto-updates on agent rename/delete

## Test plan

- [x] Compile with `--warnings-as-errors` — passes
- [x] `mix test` — 356 tests, 0 failures
- [x] TypeScript typecheck — passes
- [x] ESLint — passes
- [x] Prettier — passes
- [ ] Manual: click agent in sidebar → URL changes, chat loads
- [ ] Manual: browser back/forward navigates between agents
- [ ] Manual: direct URL `/projects/foo/agents/bar` opens correct chat
- [ ] Manual: Settings link goes to `/agents/:name/settings`, back button returns to chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)