### PR TITLE
Add Clear Session feature to reset agent harness context

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -145,7 +145,7 @@ export default function AgentDashboard({
       <div className="flex-1 flex flex-col min-w-0">
         {selectedAgent ? (
           <>
-            <ChatHeader agent={selectedAgent} onMenuToggle={() => setSidebarOpen(!sidebarOpen)} />
+            <ChatHeader agent={selectedAgent} onMenuToggle={() => setSidebarOpen(!sidebarOpen)} pushEvent={pushEvent} />
             <div className="flex-1 min-h-0">
               <ChatPanel
                 agent={selectedAgent}

--- a/assets/react-components/ChatHeader.tsx
+++ b/assets/react-components/ChatHeader.tsx
@@ -1,14 +1,21 @@
-import { Menu } from "lucide-react";
+import { Menu, EllipsisVertical, Eraser } from "lucide-react";
 import { Badge } from "./components/ui/badge";
 import { Button } from "./components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./components/ui/dropdown-menu";
 import { type Agent, statusVariant } from "./types";
 
 interface ChatHeaderProps {
   agent: Agent;
   onMenuToggle?: () => void;
+  pushEvent: (event: string, payload: Record<string, unknown>) => void;
 }
 
-export default function ChatHeader({ agent, onMenuToggle }: ChatHeaderProps) {
+export default function ChatHeader({ agent, onMenuToggle, pushEvent }: ChatHeaderProps) {
   return (
     <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
       {onMenuToggle && (
@@ -18,6 +25,21 @@ export default function ChatHeader({ agent, onMenuToggle }: ChatHeaderProps) {
       )}
       <h2 className="text-lg font-semibold">{agent.name}</h2>
       <Badge variant={statusVariant(agent.status)}>{agent.status}</Badge>
+      <div className="ml-auto">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Agent options">
+              <EllipsisVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => pushEvent("clear-session", {})}>
+              <Eraser className="h-4 w-4 mr-2" />
+              Clear Session
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     </div>
   );
 }

--- a/assets/test/ChatHeader.test.tsx
+++ b/assets/test/ChatHeader.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import ChatHeader from "../react-components/ChatHeader";
+import { type Agent } from "../react-components/types";
+
+const agent: Agent = {
+  id: "a1",
+  name: "test-agent",
+  status: "active",
+  model: "claude-sonnet-4-6",
+  harness: "claude_code",
+};
+
+describe("ChatHeader", () => {
+  it("renders agent name and status", () => {
+    render(<ChatHeader agent={agent} pushEvent={vi.fn()} />);
+    expect(screen.getByText("test-agent")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("calls pushEvent with clear-session when Clear Session is clicked", async () => {
+    const pushEvent = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatHeader agent={agent} pushEvent={pushEvent} />);
+
+    await user.click(screen.getByRole("button", { name: "Agent options" }));
+    await user.click(screen.getByText("Clear Session"));
+
+    expect(pushEvent).toHaveBeenCalledWith("clear-session", {});
+  });
+
+  it("renders mobile menu toggle when onMenuToggle is provided", () => {
+    render(<ChatHeader agent={agent} pushEvent={vi.fn()} onMenuToggle={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
+  });
+});

--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -125,6 +125,10 @@ defmodule Shire.Agent.AgentManager do
     GenServer.call(server, :get_state, 60_000)
   end
 
+  def clear_session(project_id, agent_id) do
+    GenServer.call(via(project_id, agent_id), :clear_session, 15_000)
+  end
+
   def restart(project_id, agent_id) do
     GenServer.call(via(project_id, agent_id), :restart, 60_000)
   end
@@ -327,6 +331,34 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @impl true
+  def handle_call(:clear_session, _from, %{status: :active} = state) do
+    envelope = %{
+      "ts" => System.system_time(:millisecond),
+      "type" => "clear_session",
+      "from" => "user",
+      "payload" => %{}
+    }
+
+    inbox_dir = Path.join(Workspace.agent_dir(state.project_id, state.agent_id), "inbox")
+    filename = "#{envelope["ts"]}-#{random_suffix()}.yaml"
+    inbox_path = Path.join(inbox_dir, filename)
+
+    case vm().write(state.project_id, inbox_path, Ymlr.document!(envelope)) do
+      :ok ->
+        {:reply, :ok, state}
+
+      {:error, reason} ->
+        Logger.warning("Failed to write clear_session: #{inspect(reason)}")
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:clear_session, _from, state) do
+    {:reply, {:error, :not_active}, state}
+  end
+
+  @impl true
   def handle_call(:last_read_message_id, _from, state) do
     {:reply, state.last_read_message_id, state}
   end
@@ -439,6 +471,28 @@ defmodule Shire.Agent.AgentManager do
                 event = %{
                   "type" => "system_message",
                   "payload" => %{"text" => text},
+                  "message" => serialize_message(msg)
+                }
+
+                broadcast(acc, {:agent_event, acc.agent_id, event})
+
+              {:error, _} ->
+                :ok
+            end
+
+            acc
+
+          {:ok, %{"type" => "session_cleared"}} ->
+            case Agents.create_message(%{
+                   project_id: acc.project_id,
+                   agent_id: acc.agent_id,
+                   role: "system",
+                   content: %{"text" => "Session cleared"}
+                 }) do
+              {:ok, msg} ->
+                event = %{
+                  "type" => "system_message",
+                  "payload" => %{"text" => "Session cleared"},
                   "message" => serialize_message(msg)
                 }
 

--- a/lib/shire/agent/coordinator.ex
+++ b/lib/shire/agent/coordinator.ex
@@ -73,6 +73,10 @@ defmodule Shire.Agent.Coordinator do
     AgentManager.interrupt(project_id, agent_id)
   end
 
+  def clear_session(project_id, agent_id) do
+    AgentManager.clear_session(project_id, agent_id)
+  end
+
   @doc "Look up a running agent's pid by ID within a project."
   def lookup(project_id, agent_id) do
     case Registry.lookup(Shire.AgentRegistry, {project_id, agent_id}) do

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -254,6 +254,27 @@ defmodule ShireWeb.AgentLive.Index do
   end
 
   @impl true
+  def handle_event("clear-session", _params, socket) do
+    project_id = socket.assigns.project.id
+    agent_id = socket.assigns.selected_agent_id
+
+    if agent_id do
+      case Coordinator.clear_session(project_id, agent_id) do
+        :ok ->
+          {:noreply, socket}
+
+        {:error, reason} ->
+          {:noreply, put_flash(socket, :error, "Failed to clear session: #{inspect(reason)}")}
+      end
+    else
+      {:noreply, socket}
+    end
+  catch
+    :exit, _ ->
+      {:noreply, put_flash(socket, :error, "Agent is not running.")}
+  end
+
+  @impl true
   def handle_event("interrupt-agent", _params, socket) do
     project_id = socket.assigns.project.id
     agent_id = socket.assigns.selected_agent_id

--- a/priv/sprite/agent-runner.test.ts
+++ b/priv/sprite/agent-runner.test.ts
@@ -56,6 +56,7 @@ function makeEnvelope(overrides: Partial<MessageEnvelope> = {}): MessageEnvelope
 function createMockHarness(): Harness & {
   sendMessage: ReturnType<typeof mock>;
   interrupt: ReturnType<typeof mock>;
+  clearSession: ReturnType<typeof mock>;
   stop: ReturnType<typeof mock>;
   start: ReturnType<typeof mock>;
 } {
@@ -63,6 +64,7 @@ function createMockHarness(): Harness & {
     start: mock(async () => {}),
     sendMessage: mock(async () => {}),
     interrupt: mock(async () => {}),
+    clearSession: mock(async () => {}),
     stop: mock(async () => {}),
     onEvent: mock(() => {}),
     isProcessing: mock(() => false),
@@ -315,6 +317,35 @@ describe("processMessage() — interrupt", () => {
   test("does not call harness.sendMessage for interrupt", async () => {
     const harness = createMockHarness();
     const envelope = makeEnvelope({ type: "interrupt", payload: {} });
+
+    await captureEmits(async () => {
+      await processMessage(harness, envelope);
+    });
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processMessage() — clear_session
+// ---------------------------------------------------------------------------
+
+describe("processMessage() — clear_session", () => {
+  test("calls harness.clearSession() and emits session_cleared event", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({ type: "clear_session", payload: {} });
+
+    const events = await captureEmits(async () => {
+      await processMessage(harness, envelope);
+    });
+
+    expect(harness.clearSession).toHaveBeenCalledTimes(1);
+    expect(events.map((e) => e.type)).toContain("session_cleared");
+  });
+
+  test("does not call harness.sendMessage for clear_session", async () => {
+    const harness = createMockHarness();
+    const envelope = makeEnvelope({ type: "clear_session", payload: {} });
 
     await captureEmits(async () => {
       await processMessage(harness, envelope);

--- a/priv/sprite/agent-runner.ts
+++ b/priv/sprite/agent-runner.ts
@@ -153,6 +153,9 @@ export async function processMessage(harness: Harness, envelope: MessageEnvelope
       emit("system_message_received", { text });
     }
     await harness.sendMessage(prefix + text, from);
+  } else if (envelope.type === "clear_session") {
+    await harness.clearSession();
+    emit("session_cleared", {});
   } else if (envelope.type === "interrupt") {
     await harness.interrupt();
     emit("interrupted", {});

--- a/priv/sprite/harness/claude-code-harness.test.ts
+++ b/priv/sprite/harness/claude-code-harness.test.ts
@@ -448,4 +448,31 @@ describe("ClaudeCodeHarness", () => {
     expect(params.options?.allowedTools).toContain("Skill");
     expect(params.options?.settingSources).toEqual(["project"]);
   });
+
+  test("clearSession() causes next sendMessage to skip continue", async () => {
+    const mockQuery = createMockQuery([resultSuccess("Hi", "s1")]);
+    const harness = new ClaudeCodeHarness(mockQuery);
+    harness.onEvent(() => {});
+
+    await harness.start(baseConfig);
+    await harness.clearSession();
+    await harness.sendMessage("Fresh start");
+
+    const params = mockQuery.mock.calls[0][0];
+    expect(params.options?.continue).toBe(false);
+  });
+
+  test("clearSession() only affects the immediately following sendMessage", async () => {
+    const mockQuery = createMockQuery([resultSuccess("Hi", "s1")]);
+    const harness = new ClaudeCodeHarness(mockQuery);
+    harness.onEvent(() => {});
+
+    await harness.start(baseConfig);
+    await harness.clearSession();
+    await harness.sendMessage("First after clear");
+    await harness.sendMessage("Second after clear");
+
+    expect(mockQuery.mock.calls[0][0].options?.continue).toBe(false);
+    expect(mockQuery.mock.calls[1][0].options?.continue).toBe(true);
+  });
 });

--- a/priv/sprite/harness/claude-code-harness.ts
+++ b/priv/sprite/harness/claude-code-harness.ts
@@ -10,6 +10,7 @@ export class ClaudeCodeHarness implements Harness {
   private config: HarnessConfig | null = null;
   private activeQuery: Query | null = null;
   private queryFn: QueryFn;
+  private shouldContinue = true;
 
   constructor(queryFn?: QueryFn) {
     this.queryFn = queryFn ?? query;
@@ -26,6 +27,8 @@ export class ClaudeCodeHarness implements Harness {
 
     const content = from ? `[Message from agent "${from}"]\n${text}` : text;
 
+    const shouldContinue = this.shouldContinue;
+    this.shouldContinue = true;
     this.processing = true;
     try {
       const q = this.queryFn({
@@ -38,7 +41,7 @@ export class ClaudeCodeHarness implements Harness {
           settingSources: ["project"],
           permissionMode: "bypassPermissions",
           allowDangerouslySkipPermissions: true,
-          continue: true,
+          continue: shouldContinue,
           includePartialMessages: true,
         },
       });
@@ -54,6 +57,10 @@ export class ClaudeCodeHarness implements Harness {
       this.processing = false;
       this.activeQuery = null;
     }
+  }
+
+  async clearSession(): Promise<void> {
+    this.shouldContinue = false;
   }
 
   async interrupt(): Promise<void> {

--- a/priv/sprite/harness/pi-harness.test.ts
+++ b/priv/sprite/harness/pi-harness.test.ts
@@ -268,4 +268,29 @@ describe("PiHarness", () => {
     await expect(harness.sendMessage("too late")).rejects.toThrow("Harness is stopped");
     expect(factory).not.toHaveBeenCalled();
   });
+
+  test("clearSession() causes a new session to be created on next sendMessage()", async () => {
+    const factory = mock(async () => createMockSession());
+    const harness = new PiHarness();
+    harness.onEvent(() => {});
+    harness._setSessionFactory(factory);
+    await harness.start(baseConfig);
+    await harness.sendMessage("First");
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    await harness.clearSession();
+    await harness.sendMessage("Fresh start");
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  test("clearSession() before any message causes fresh session", async () => {
+    const factory = mock(async () => createMockSession());
+    const harness = new PiHarness();
+    harness.onEvent(() => {});
+    harness._setSessionFactory(factory);
+    await harness.start(baseConfig);
+    await harness.clearSession();
+    await harness.sendMessage("Hello");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
 });

--- a/priv/sprite/harness/pi-harness.ts
+++ b/priv/sprite/harness/pi-harness.ts
@@ -17,6 +17,7 @@ export class PiHarness implements Harness {
   private sessionPending: Promise<SessionLike> | null = null;
   private config: HarnessConfig | null = null;
   private sessionFactory: SessionFactory | null = null;
+  private skipContinue = false;
 
   _setSessionFactory(factory: SessionFactory): void {
     this.sessionFactory = factory;
@@ -34,7 +35,7 @@ export class PiHarness implements Harness {
     if (!this.sessionPending) {
       this.sessionPending = this.createSession(this.config).then((s) => {
         this.subscribeToSession(s);
-        this.session = s;
+        if (!this.session) this.session = s;
         this.sessionPending = null;
         return s;
       });
@@ -54,6 +55,14 @@ export class PiHarness implements Harness {
     } finally {
       this.processing = false;
     }
+  }
+
+  async clearSession(): Promise<void> {
+    const old = this.session ?? (await this.sessionPending?.catch(() => null));
+    this.session = null;
+    this.sessionPending = null;
+    this.skipContinue = true;
+    if (old) await old.abort().catch(() => {});
   }
 
   async interrupt(): Promise<void> {
@@ -115,9 +124,10 @@ export class PiHarness implements Harness {
       modelRegistry,
       tools: createCodingTools(config.cwd),
       resourceLoader: loader,
-      sessionManager: SessionManager.continueRecent(config.cwd),
+      sessionManager: this.skipContinue ? undefined : SessionManager.continueRecent(config.cwd),
       settingsManager,
     });
+    this.skipContinue = false;
     return session;
   }
 

--- a/priv/sprite/harness/types.ts
+++ b/priv/sprite/harness/types.ts
@@ -18,6 +18,7 @@ export interface Harness {
   start(config: HarnessConfig): Promise<void>;
   sendMessage(text: string, from?: string): Promise<void>;
   interrupt(): Promise<void>;
+  clearSession(): Promise<void>;
   stop(): Promise<void>;
   onEvent(callback: EventCallback): void;
   isProcessing(): boolean;

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -126,6 +126,38 @@ defmodule Shire.Agent.AgentManagerTest do
     end
   end
 
+  describe "clear_session/2" do
+    test "returns error when agent is not active", ctx do
+      {:ok, pid} = start_manager(ctx)
+
+      assert {:error, :not_active} = GenServer.call(pid, :clear_session)
+    end
+
+    test "writes clear_session envelope to inbox when active", ctx do
+      Mox.set_mox_global()
+      test_pid = self()
+
+      expect(Shire.VirtualMachineMock, :write, fn _project, path, content ->
+        send(test_pid, {:write_called, path, content})
+        :ok
+      end)
+
+      {:ok, pid} = start_manager(ctx)
+
+      ref = make_ref()
+
+      :sys.replace_state(pid, fn state ->
+        %{state | command: %{ref: ref}, command_ref: ref, status: :active}
+      end)
+
+      assert :ok = GenServer.call(pid, :clear_session)
+
+      assert_receive {:write_called, path, content}, 1_000
+      assert path =~ "/inbox/"
+      assert content =~ "clear_session"
+    end
+  end
+
   describe "responsiveness" do
     test "get_state responds immediately even during non-idle statuses", ctx do
       {:ok, pid} = start_manager(ctx)
@@ -347,6 +379,20 @@ defmodule Shire.Agent.AgentManagerTest do
       assert length(agent_msgs) == 2
       texts = Enum.map(agent_msgs, & &1.content["text"]) |> Enum.sort()
       assert texts == ["direct", "streamed"]
+    end
+
+    test "persists session_cleared event as system message in DB", %{pid: pid, ref: ref} do
+      line = Jason.encode!(%{"type" => "session_cleared", "payload" => %{}})
+      send(pid, {:stdout, %{ref: ref}, line <> "\n"})
+
+      assert_receive {:agent_event, _, %{"type" => "system_message", "message" => msg}}, 1_000
+      assert msg[:text] == "Session cleared"
+      assert msg[:role] == "system"
+      assert msg[:id]
+
+      db_msg = Agents.get_message!(msg[:id])
+      assert db_msg.role == "system"
+      assert db_msg.content["text"] == "Session cleared"
     end
 
     test "broadcasts include agent_id in 3-tuple", ctx do


### PR DESCRIPTION
## Summary

- Adds a "Clear Session" action in the ChatHeader dropdown menu that resets the agent's harness conversation context without clearing chat history
- Claude Code harness: skips `continue: true` on the next query call, starting a fresh conversation
- Pi harness: aborts the current session and creates a new one (without `SessionManager.continueRecent`)
- A system message ("Session cleared") is inserted in chat as a visual marker
- Full stack: Harness interface → agent-runner → AgentManager → Coordinator → LiveView → React UI

## Test plan

- [x] `mix precommit` passes (359 tests, 0 failures)
- [x] `bun test` in priv/sprite passes (79 tests, 0 failures)
- [x] `bun run test` in assets passes (234 tests, 0 failures)
- [x] TypeScript type check, ESLint, and Prettier all pass
- [ ] Manual: click "Clear Session" in chat header dropdown, verify system message appears and next agent response starts fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)