### PR TITLE
Replace skeleton flash with delayed loading spinner

### DIFF
--- a/assets/react-components/ChatPanel.tsx
+++ b/assets/react-components/ChatPanel.tsx
@@ -5,7 +5,6 @@ import { Badge } from "./components/ui/badge";
 import { Button } from "./components/ui/button";
 import { Textarea } from "./components/ui/textarea";
 import Markdown from "./components/Markdown";
-import { Skeleton } from "./components/ui/skeleton";
 import { type AgentOverview } from "./types";
 
 export interface Attachment {
@@ -221,6 +220,16 @@ export default function ChatPanel({
     prevScrollHeightRef.current = 0;
   }, [agent.id]);
 
+  // Show loading spinner only after a delay to avoid flash on fast loads
+  const [showLoadingSpinner, setShowLoadingSpinner] = React.useState(false);
+  React.useEffect(() => {
+    if (messagesLoading) {
+      const timer = setTimeout(() => setShowLoadingSpinner(true), 500);
+      return () => clearTimeout(timer);
+    }
+    setShowLoadingSpinner(false);
+  }, [messagesLoading]);
+
   // Listen for streaming text deltas and flush events from LiveView
   React.useEffect(() => {
     const deltaRef = handleEvent("text_delta", (payload: Record<string, unknown>) => {
@@ -352,20 +361,11 @@ export default function ChatPanel({
             <span className="text-xs text-muted-foreground animate-pulse">Loading older messages...</span>
           </div>
         )}
-        {messagesLoading && !hasMessages && (
-          <div className="space-y-3">
-            {/* Skeleton message bubbles */}
-            <div className="flex justify-end">
-              <Skeleton className="h-10 w-48 rounded-lg" />
-            </div>
-            <div className="flex justify-start">
-              <Skeleton className="h-16 w-64 rounded-lg" />
-            </div>
-            <div className="flex justify-end">
-              <Skeleton className="h-10 w-36 rounded-lg" />
-            </div>
-            <div className="flex justify-start">
-              <Skeleton className="h-24 w-72 rounded-lg" />
+        {messagesLoading && !hasMessages && showLoadingSpinner && (
+          <div className="flex items-center justify-center h-full">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="inline-block w-1.5 h-1.5 rounded-full bg-muted-foreground animate-pulse" />
+              Loading messages...
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Replace skeleton message bubbles with a delayed loading spinner that only appears after 500ms
- Avoids distracting flash on fast DB loads while still providing feedback on slower connections
- Uses a simple `setTimeout` in a `useEffect` keyed on `messagesLoading`

## Test plan
- [x] `bunx tsc --noEmit` — passes
- [x] `bun run lint` — clean
- [x] `bun run test` — 233 tests pass
- [x] `mix compile --warnings-as-errors` — passes
- [x] `mix test` — 361 tests pass
- [ ] Manual: switch agents with fast DB — no loading indicator visible
- [ ] Manual: simulate slow load — spinner appears after 500ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)