### PR TITLE
Fix catalog empty state flash on first open

### DIFF
--- a/assets/test/AgentDashboard.test.tsx
+++ b/assets/test/AgentDashboard.test.tsx
@@ -96,6 +96,45 @@ describe("AgentDashboard", () => {
     expect(screen.getByText("Create a new agent to get started.")).toBeInTheDocument();
   });
 
+  it("fires load-catalog event when opening catalog with no agents loaded", async () => {
+    const pushEvent = vi.fn();
+    render(<AgentDashboard {...defaultProps} agents={agents} selectedAgent={null} pushEvent={pushEvent} />);
+
+    await userEvent.click(screen.getByText("Browse Catalog"));
+    expect(pushEvent).toHaveBeenCalledWith("load-catalog", {});
+  });
+
+  it("does not fire load-catalog when catalog agents already loaded", async () => {
+    const pushEvent = vi.fn();
+    const catalogAgents: CatalogAgentSummary[] = [
+      {
+        name: "test-agent",
+        display_name: "Test Agent",
+        description: "A test",
+        category: "engineering",
+        emoji: "🤖",
+        tags: [],
+        harness: "claude_code",
+        model: "claude-sonnet-4-6",
+      },
+    ];
+    const catalogCategories: CatalogCategory[] = [{ id: "engineering", name: "Engineering", description: "" }];
+
+    render(
+      <AgentDashboard
+        {...defaultProps}
+        agents={agents}
+        selectedAgent={null}
+        pushEvent={pushEvent}
+        catalogAgents={catalogAgents}
+        catalogCategories={catalogCategories}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Browse Catalog"));
+    expect(pushEvent).not.toHaveBeenCalledWith("load-catalog", {});
+  });
+
   it("opens catalog browser and calls pushEvent on add", async () => {
     const pushEvent = vi.fn();
     const catalogAgents: CatalogAgentSummary[] = [

--- a/assets/test/CatalogBrowser.test.tsx
+++ b/assets/test/CatalogBrowser.test.tsx
@@ -120,9 +120,21 @@ describe("CatalogBrowser", () => {
     expect(screen.getByText("No agents match your search.")).toBeInTheDocument();
   });
 
-  it("shows empty catalog state when no agents provided", () => {
-    render(<CatalogBrowser {...defaultProps} agents={[]} />);
+  it("shows empty catalog state when no agents provided and not loading", () => {
+    render(<CatalogBrowser {...defaultProps} agents={[]} loading={false} />);
     expect(screen.getByText(/no agents in catalog/i)).toBeInTheDocument();
+  });
+
+  it("shows loading spinner when loading is true", () => {
+    render(<CatalogBrowser {...defaultProps} agents={[]} loading />);
+    expect(screen.getByText("Loading catalog...")).toBeInTheDocument();
+    expect(screen.queryByText(/no agents in catalog/i)).not.toBeInTheDocument();
+  });
+
+  it("does not show loading spinner when agents are loaded", () => {
+    render(<CatalogBrowser {...defaultProps} loading={false} />);
+    expect(screen.queryByText("Loading catalog...")).not.toBeInTheDocument();
+    expect(screen.getByText("Frontend Developer")).toBeInTheDocument();
   });
 
   it("displays agent descriptions", () => {

--- a/lib/shire_web/live/agent_live/index.ex
+++ b/lib/shire_web/live/agent_live/index.ex
@@ -111,7 +111,7 @@ defmodule ShireWeb.AgentLive.Index do
            editing_agent: nil,
            catalog_agents: [],
            catalog_categories: [],
-           catalog_loading: false,
+           catalog_loading: true,
            catalog_task_ref: nil,
            catalog_selected_agent: nil
          )}


### PR DESCRIPTION
## Summary
- Default `catalog_loading` to `true` so the spinner shows immediately when the catalog dialog opens
- Prevents the "No agents in catalog" text from briefly flashing before data loads

## Test plan
- [ ] Open catalog browser — should show spinner, then content (no flash of empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)