### PR TITLE
Fix catalog always stuck in loading state

### DIFF
--- a/assets/react-components/AgentDashboard.tsx
+++ b/assets/react-components/AgentDashboard.tsx
@@ -87,7 +87,7 @@ export default function AgentDashboard({
   }, [catalogSelectedAgent]);
 
   const handleBrowseCatalog = () => {
-    if (catalogAgents.length === 0 && !catalogLoading) {
+    if (catalogAgents.length === 0) {
       pushEvent("load-catalog", {});
     }
     setCatalogOpen(true);

--- a/assets/test/AgentDashboard.test.tsx
+++ b/assets/test/AgentDashboard.test.tsx
@@ -104,6 +104,22 @@ describe("AgentDashboard", () => {
     expect(pushEvent).toHaveBeenCalledWith("load-catalog", {});
   });
 
+  it("fires load-catalog event even when catalogLoading is already true", async () => {
+    const pushEvent = vi.fn();
+    render(
+      <AgentDashboard
+        {...defaultProps}
+        agents={agents}
+        selectedAgent={null}
+        pushEvent={pushEvent}
+        catalogLoading={true}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Browse Catalog"));
+    expect(pushEvent).toHaveBeenCalledWith("load-catalog", {});
+  });
+
   it("does not fire load-catalog when catalog agents already loaded", async () => {
     const pushEvent = vi.fn();
     const catalogAgents: CatalogAgentSummary[] = [


### PR DESCRIPTION
## Summary
- Removed the `!catalogLoading` guard from `handleBrowseCatalog` that prevented the `load-catalog` event from firing when `catalog_loading` defaults to `true` on mount
- This deadlock was introduced in #114 where `catalog_loading` was changed to default `true` to prevent a "no agents" text flash, but inadvertently blocked the lazy-load trigger

## Test plan
- [x] Added test: fires `load-catalog` event even when `catalogLoading` is already `true`
- [x] Existing test still passes: does not fire when agents already loaded
- [x] All 17 AgentDashboard tests pass
- [x] TypeScript, ESLint, Prettier all pass
- [ ] Manual: open catalog dialog — should show spinner briefly then agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)