### PR TITLE
Fix false unreads on server restart

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -171,14 +171,20 @@ defmodule Shire.Agent.AgentManager do
     }
 
     if skip_sprite do
-      {:ok, state}
+      {:ok, state, {:continue, :init_last_read}}
     else
       {:ok, state, {:continue, :bootstrap}}
     end
   end
 
   @impl true
+  def handle_continue(:init_last_read, state) do
+    {:noreply, init_last_read(state)}
+  end
+
+  @impl true
   def handle_continue(:bootstrap, state) do
+    state = init_last_read(state)
     state = transition_status(state, :bootstrapping)
 
     Task.start_link(fn ->
@@ -630,6 +636,16 @@ defmodule Shire.Agent.AgentManager do
   end
 
   # --- Private ---
+
+  defp init_last_read(state) do
+    case Shire.Agents.latest_message_id(state.agent_id) do
+      nil -> state
+      id -> %{state | last_read_message_id: id}
+    end
+  rescue
+    DBConnection.OwnershipError -> state
+    DBConnection.ConnectionError -> state
+  end
 
   defp transition_status(state, status) do
     state = %{state | status: status}

--- a/lib/shire/agents.ex
+++ b/lib/shire/agents.ex
@@ -251,5 +251,17 @@ defmodule Shire.Agents do
     end
   end
 
+  @doc """
+  Returns the ID of the latest "agent" role message for the given agent,
+  or nil if no such message exists.
+  """
+  def latest_message_id(agent_id) do
+    from(m in Message,
+      where: m.agent_id == ^agent_id and m.role == "agent",
+      select: max(m.id)
+    )
+    |> Repo.one()
+  end
+
   defp vm, do: Application.get_env(:shire, :vm, Shire.VirtualMachineSprite)
 end

--- a/test/shire/agents_test.exs
+++ b/test/shire/agents_test.exs
@@ -338,6 +338,43 @@ defmodule Shire.AgentsTest do
       assert Map.get(counts, agent.id) == 1
     end
 
+    test "latest_message_id/1 returns nil when no messages exist", %{agent: agent} do
+      assert Agents.latest_message_id(agent.id) == nil
+    end
+
+    test "latest_message_id/1 returns the latest agent-role message id", %{
+      project: project,
+      agent: agent
+    } do
+      {:ok, _} =
+        Agents.create_message(%{
+          project_id: project.id,
+          agent_id: agent.id,
+          role: "user",
+          content: %{"text" => "hello"}
+        })
+
+      {:ok, m1} =
+        Agents.create_message(%{
+          project_id: project.id,
+          agent_id: agent.id,
+          role: "agent",
+          content: %{"text" => "first"}
+        })
+
+      assert Agents.latest_message_id(agent.id) == m1.id
+
+      {:ok, m2} =
+        Agents.create_message(%{
+          project_id: project.id,
+          agent_id: agent.id,
+          role: "agent",
+          content: %{"text" => "second"}
+        })
+
+      assert Agents.latest_message_id(agent.id) == m2.id
+    end
+
     test "delete_agent_with_vm/3 deletes agent and its messages", %{project: project} do
       {:ok, del_agent} =
         Agents.create_agent_with_vm(project.id, "delete-test", "version: 1\n", @vm)


### PR DESCRIPTION
## Summary
- Add `Agents.latest_message_id/1` to query the latest agent-role message ID
- Initialize `last_read_message_id` from DB during `AgentManager` startup (in `handle_continue`) instead of defaulting to `nil`
- Gracefully handles DB unavailability (rescues connection errors, falls back to `nil`)

Previously, every server restart caused all existing messages to appear as unread because `last_read_message_id` started at `nil` (treated as `0`).

## Test plan
- [x] Added tests for `latest_message_id/1` (nil case + incremental case)
- [x] All 361 existing tests pass
- [x] Compile clean with `--warnings-as-errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)