### PR TITLE
Add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Shire is an open platform for deploying, orchestrating, and collaborating with A
 
 ![Shire Dashboard](docs/screenshot.png)
 
+## See it in action
+
+<video src="https://github.com/victor36max/shire/releases/download/assets/demo-web.mp4" controls width="100%"></video>
+
 ---
 
 ## Why Shire?


### PR DESCRIPTION
## Summary
- Add "See it in action" section to README with an embedded demo video
- Video hosted on GitHub releases to avoid bloating the repo

## Test plan
- [ ] Verify video renders on the GitHub README page

🤖 Generated with [Claude Code](https://claude.com/claude-code)