### PR TITLE
Fix dangling bun processes on ungraceful shutdown in local mode

### DIFF
--- a/lib/shire/agent/agent_manager.ex
+++ b/lib/shire/agent/agent_manager.ex
@@ -157,6 +157,8 @@ defmodule Shire.Agent.AgentManager do
 
   @impl true
   def init(opts) do
+    Process.flag(:trap_exit, true)
+
     project_id = Keyword.fetch!(opts, :project_id)
     agent_id = Keyword.fetch!(opts, :agent_id)
     agent_name = Keyword.fetch!(opts, :agent_name)
@@ -606,6 +608,20 @@ defmodule Shire.Agent.AgentManager do
     {:noreply, state}
   end
 
+  # Handle EXIT from linked processes (forward_loop, Task.start_link).
+  # Since we trap_exit, these arrive as messages instead of killing us.
+  @impl true
+  def handle_info({:EXIT, _pid, :normal}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:EXIT, pid, reason}, state) do
+    Logger.warning(
+      "AgentManager #{state.agent_name} linked process #{inspect(pid)} exited: #{inspect(reason)}"
+    )
+
+    {:noreply, state}
+  end
+
   @impl true
   def handle_info(msg, state) do
     Logger.debug("AgentManager #{state.agent_name} unexpected message: #{inspect(msg)}")
@@ -613,9 +629,13 @@ defmodule Shire.Agent.AgentManager do
   end
 
   @impl true
-  def terminate(_reason, %{project_id: project_id, agent_id: agent_id} = _state) do
+  def terminate(_reason, %{project_id: project_id, agent_id: agent_id} = state) do
     kill_existing_runner(project_id, agent_id)
     :ok
+  rescue
+    e ->
+      Logger.warning("AgentManager #{state.agent_name} cleanup failed: #{Exception.message(e)}")
+      :ok
   end
 
   @impl true
@@ -768,13 +788,22 @@ defmodule Shire.Agent.AgentManager do
 
   defp kill_existing_runner(project_id, agent_id) do
     agent_dir = Workspace.agent_dir(project_id, agent_id)
+    pattern = "agent-runner.ts --agent-dir #{agent_dir}"
 
-    vm().cmd(
-      project_id,
-      "pkill",
-      ["-f", "agent-runner.ts --agent-dir #{agent_dir}"],
-      []
-    )
+    # SIGTERM first (graceful), then wait briefly for cleanup
+    vm().cmd(project_id, "pkill", ["-f", pattern], [])
+    Process.sleep(100)
+
+    # Check if any matching processes survived, then SIGKILL
+    case vm().cmd(project_id, "pgrep", ["-f", pattern], []) do
+      {:ok, output} ->
+        if String.trim(output) != "" do
+          vm().cmd(project_id, "pkill", ["-9", "-f", pattern], [])
+        end
+
+      _ ->
+        :ok
+    end
 
     :ok
   end

--- a/lib/shire/virtual_machine_local.ex
+++ b/lib/shire/virtual_machine_local.ex
@@ -275,6 +275,8 @@ defmodule Shire.VirtualMachineLocal do
       {:error, reason} -> Logger.error("Local VM setup failed: #{inspect(reason)}")
     end
 
+    cleanup_orphaned_runners(project_id)
+
     Logger.info("Local VM ready for project #{project_id} at #{root}")
     update_registry_status(project_id, :running)
 
@@ -285,6 +287,32 @@ defmodule Shire.VirtualMachineLocal do
     )
 
     {:ok, %{project_id: project_id, root: root}}
+  end
+
+  @doc """
+  Kills any orphaned agent-runner.ts processes whose --agent-dir falls under
+  this project's workspace root. Called on startup to clean up after ungraceful
+  shutdowns (e.g., SIGKILL, double Ctrl+C).
+  """
+  def cleanup_orphaned_runners(project_id) do
+    root = workspace_root(project_id)
+    pattern = "agent-runner.ts --agent-dir #{root}"
+
+    case System.cmd("pkill", ["-f", pattern], stderr_to_stdout: true) do
+      {_, 0} ->
+        Logger.info("Cleaned up orphaned agent-runner processes for project #{project_id}")
+
+      {_, 1} ->
+        # Exit code 1 = no matching processes found
+        :ok
+
+      {output, code} ->
+        Logger.warning(
+          "pkill orphan cleanup exited with code #{code} for project #{project_id}: #{output}"
+        )
+    end
+
+    :ok
   end
 
   # --- Private ---

--- a/test/shire/agent/agent_manager_test.exs
+++ b/test/shire/agent/agent_manager_test.exs
@@ -15,6 +15,7 @@ defmodule Shire.Agent.AgentManagerTest do
     stub(Shire.VirtualMachineMock, :workspace_root, fn _project_id -> "/workspace" end)
     stub(Shire.VirtualMachineMock, :touch_keepalive, fn _project_id -> :ok end)
     stub(Shire.VirtualMachineMock, :vm_status, fn _project_id -> :running end)
+    stub(Shire.VirtualMachineMock, :cmd, fn _project, _cmd, _args, _opts -> {:ok, ""} end)
 
     {:ok, project} = Projects.create_project("test-project-#{System.unique_integer([:positive])}")
     {:ok, agent} = Agents.create_agent_with_vm(project.id, "test-agent", "version: 1\n", @vm)
@@ -742,6 +743,43 @@ defmodule Shire.Agent.AgentManagerTest do
       Process.sleep(50)
       state_after_second = AgentManager.get_state(pid)
       assert state_after_second.last_keepalive_touch == first_touch
+    end
+  end
+
+  describe "terminate/2 cleanup" do
+    test "terminate calls kill_existing_runner via pkill", ctx do
+      Mox.set_mox_global()
+      test_pid = self()
+
+      stub(Shire.VirtualMachineMock, :cmd, fn _project, cmd, args, _opts ->
+        send(test_pid, {:cmd_called, cmd, args})
+        {:ok, ""}
+      end)
+
+      {:ok, _pid} = start_manager(ctx)
+
+      # Stop the supervised process — triggers terminate/2
+      stop_supervised!(AgentManager)
+
+      assert_receive {:cmd_called, "pkill", args}, 1_000
+      assert Enum.any?(args, &String.contains?(&1, "agent-runner.ts"))
+    end
+
+    test "traps exits so terminate is called during shutdown", ctx do
+      {:ok, pid} = start_manager(ctx)
+
+      # Verify the process traps exits
+      assert {:trap_exit, true} = Process.info(pid, :trap_exit)
+    end
+
+    test "handles EXIT from linked processes without crashing", ctx do
+      {:ok, pid} = start_manager(ctx)
+
+      # Simulate an EXIT from a linked process (e.g., the forward_loop process)
+      send(pid, {:EXIT, self(), :normal})
+
+      # Should still be alive
+      assert Process.alive?(pid)
     end
   end
 

--- a/test/shire/virtual_machine_local_test.exs
+++ b/test/shire/virtual_machine_local_test.exs
@@ -213,6 +213,46 @@ defmodule Shire.VirtualMachineLocalTest do
     end
   end
 
+  describe "cleanup_orphaned_runners/1" do
+    test "kills orphaned agent-runner processes matching workspace root", %{
+      project_id: project_id,
+      root: root
+    } do
+      File.mkdir_p!(root)
+
+      # Start a dummy long-running process that looks like an agent-runner
+      agent_dir = Path.join(root, "agents/test-agent")
+      File.mkdir_p!(agent_dir)
+      marker = Path.join(root, "cleanup_test_marker")
+
+      # Spawn a process that simulates agent-runner.ts with matching --agent-dir
+      port =
+        Port.open(
+          {:spawn, "sh -c 'echo running > #{marker}; sleep 60'"},
+          [:binary, :exit_status]
+        )
+
+      port_info = Port.info(port)
+      os_pid = Keyword.get(port_info, :os_pid)
+
+      # Verify the process is running
+      assert {_, 0} = System.cmd("kill", ["-0", "#{os_pid}"], stderr_to_stdout: true)
+
+      # Call cleanup — it should kill processes matching the workspace root
+      Local.cleanup_orphaned_runners(project_id)
+
+      # The dummy process won't match the pkill pattern (it's `sh -c sleep`),
+      # so this test mainly verifies cleanup_orphaned_runners doesn't crash.
+      # Integration testing of actual pkill matching requires real agent-runner.ts.
+      Port.close(port)
+    end
+
+    test "does not crash when no orphaned processes exist", %{project_id: project_id, root: root} do
+      File.mkdir_p!(root)
+      assert :ok = Local.cleanup_orphaned_runners(project_id)
+    end
+  end
+
   describe "vm_status/1 and touch_keepalive/1" do
     test "touch_keepalive returns :ok", %{project_id: pid} do
       assert :ok = Local.touch_keepalive(pid)


### PR DESCRIPTION
## Summary
- **AgentManager traps exits** so `terminate/2` reliably runs during OTP shutdown, ensuring bun processes are killed on Ctrl+C
- **Improved kill_existing_runner** sends SIGTERM first, waits 100ms, then SIGKILL if the process survives
- **VirtualMachineLocal startup sweep** kills any orphaned `agent-runner.ts` processes from a previous server instance (handles SIGKILL, double Ctrl+C)
- **Defensive terminate/2** rescues errors during cleanup to prevent cascading failures

## Test plan
- [x] New tests for trap_exit verification, terminate cleanup, and EXIT message handling
- [x] New tests for `cleanup_orphaned_runners` smoke testing
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] All 68 affected tests pass (agent_manager + virtual_machine_local)
- [ ] Manual: start server, create agents, `kill -9` the server, verify orphaned bun processes exist, restart server, verify they're cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)