### PR TITLE
Fix agent dashboard missing dark theme

### DIFF
--- a/src/frontend/components/AppLayout.tsx
+++ b/src/frontend/components/AppLayout.tsx
@@ -1,12 +1,9 @@
 import * as React from "react";
-import { ThemeProvider } from "./ThemeProvider";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider>
-      <main className="pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] sm:pl-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] lg:pl-[max(2rem,env(safe-area-inset-left))] lg:pr-[max(2rem,env(safe-area-inset-right))]">
-        <div className="mx-auto max-w-5xl">{children}</div>
-      </main>
-    </ThemeProvider>
+    <main className="pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] sm:pl-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] lg:pl-[max(2rem,env(safe-area-inset-left))] lg:pr-[max(2rem,env(safe-area-inset-right))]">
+      <div className="mx-auto max-w-5xl">{children}</div>
+    </main>
   );
 }

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { setNavigate } from "./lib/navigate";
 import { Toaster } from "sonner";
+import { ThemeProvider } from "./components/ThemeProvider";
 import "@fontsource-variable/dm-sans";
 import "./css/app.css";
 
@@ -40,23 +41,25 @@ function NavigateBridge() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Toaster position="bottom-right" richColors />
-      <BrowserRouter>
-        <NavigateBridge />
-        <Routes>
-          <Route path="/" element={<ProjectDashboard />} />
-          <Route path="/projects/:projectName" element={<AgentDashboard />} />
-          <Route path="/projects/:projectName/agents/:agentName" element={<AgentDashboard />} />
-          <Route
-            path="/projects/:projectName/agents/:agentName/settings"
-            element={<AgentSettings />}
-          />
-          <Route path="/projects/:projectName/details" element={<ProjectDetails />} />
-          <Route path="/projects/:projectName/settings" element={<Settings />} />
-          <Route path="/projects/:projectName/shared" element={<SharedDrivePage />} />
-          <Route path="/projects/:projectName/schedules" element={<Schedules />} />
-        </Routes>
-      </BrowserRouter>
+      <ThemeProvider>
+        <Toaster position="bottom-right" richColors />
+        <BrowserRouter>
+          <NavigateBridge />
+          <Routes>
+            <Route path="/" element={<ProjectDashboard />} />
+            <Route path="/projects/:projectName" element={<AgentDashboard />} />
+            <Route path="/projects/:projectName/agents/:agentName" element={<AgentDashboard />} />
+            <Route
+              path="/projects/:projectName/agents/:agentName/settings"
+              element={<AgentSettings />}
+            />
+            <Route path="/projects/:projectName/details" element={<ProjectDetails />} />
+            <Route path="/projects/:projectName/settings" element={<Settings />} />
+            <Route path="/projects/:projectName/shared" element={<SharedDrivePage />} />
+            <Route path="/projects/:projectName/schedules" element={<Schedules />} />
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/src/frontend/test/test-utils.tsx
+++ b/src/frontend/test/test-utils.tsx
@@ -5,14 +5,13 @@ import { MemoryRouter } from "react-router-dom";
 
 interface WrapperOptions {
   route?: string;
-  routePath?: string;
 }
 
 export function renderWithProviders(
   ui: React.ReactElement,
   options?: WrapperOptions & Omit<RenderOptions, "wrapper">,
 ) {
-  const { route = "/", routePath, ...renderOptions } = options ?? {};
+  const { route = "/", ...renderOptions } = options ?? {};
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
   });

--- a/src/runtime/agent-manager.test.ts
+++ b/src/runtime/agent-manager.test.ts
@@ -5,30 +5,12 @@ import * as agentsService from "../services/agents";
 import * as projects from "../services/projects";
 import * as workspace from "../services/workspace";
 import { bus, type BusEvent } from "../events";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import type { EventCallback } from "./harness/types";
-
 let testDir: string;
 let projectId: string;
 let agentId: string;
-
-// Capture the harness event callback so we can simulate harness events
-let harnessCallback: EventCallback | null = null;
-
-// Mock the harness module
-const mockHarness = {
-  start: async () => {},
-  sendMessage: async () => {},
-  interrupt: async () => {},
-  clearSession: async () => {},
-  stop: async () => {},
-  onEvent: (cb: EventCallback) => {
-    harnessCallback = cb;
-  },
-  isProcessing: () => false,
-};
 
 // We need to mock createHarness. Since AgentManager imports it,
 // we'll test event handling by collecting bus events.
@@ -37,8 +19,6 @@ beforeEach(() => {
   createTestDb();
   testDir = join(tmpdir(), `am_test_${Date.now()}_${Math.random().toString(36).slice(2)}`);
   process.env.SHIRE_PROJECTS_DIR = testDir;
-  harnessCallback = null;
-
   const project = projects.createProject(`test-project-${Date.now()}`);
   projectId = project.id;
   const agent = agentsService.createAgent(projectId, "test-agent");
@@ -269,8 +249,8 @@ describe("AgentManager", () => {
 
   describe("status transitions", () => {
     it("emits agent_status events on status change", () => {
-      const { events, unsub } = collectEvents(`project:${projectId}:agents`);
-      const mgr = createManager();
+      const { unsub } = collectEvents(`project:${projectId}:agents`);
+      createManager();
 
       // Creating the manager doesn't change status (starts idle, no event)
       // But if we could call setStatus we'd see events
@@ -283,14 +263,13 @@ describe("AgentManager", () => {
   describe("workspace setup", () => {
     it("creates agent directories on start", async () => {
       workspace.ensureProjectDirs(projectId);
-      const mgr = createManager();
+      createManager();
 
       // setupWorkspace is called during start(), which also tries to start the harness
       // For a unit test, we verify ensureAgentDirs creates the right structure
       workspace.ensureAgentDirs(projectId, agentId);
 
       const agentDir = workspace.agentDir(projectId, agentId);
-      const { existsSync } = require("fs");
       expect(existsSync(join(agentDir, "inbox"))).toBe(true);
       expect(existsSync(join(agentDir, "outbox"))).toBe(true);
       expect(existsSync(join(agentDir, "scripts"))).toBe(true);

--- a/src/runtime/coordinator.test.ts
+++ b/src/runtime/coordinator.test.ts
@@ -5,7 +5,7 @@ import * as agentsService from "../services/agents";
 import * as projects from "../services/projects";
 import * as workspace from "../services/workspace";
 import { bus } from "../events";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { rmSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, rmSync, readFileSync } from "fs";
+import { writeFileSync, rmSync, readFileSync } from "fs";
 import { join } from "path";
 import yaml from "js-yaml";
 import { bus } from "../events";

--- a/src/runtime/scheduler.ts
+++ b/src/runtime/scheduler.ts
@@ -103,7 +103,7 @@ export class Scheduler {
     });
 
     // Mark run
-    const updated = schedulesService.markRun(task.id);
+    schedulesService.markRun(task.id);
 
     // Disable one-time tasks
     if (task.scheduleType === "once") {

--- a/src/scripts/catalog-sync.test.ts
+++ b/src/scripts/catalog-sync.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import yaml from "js-yaml";
 
 // We test the pure functions from catalog-sync.
 // Since catalog-sync.ts is a script with top-level main() call,
@@ -21,7 +22,6 @@ function parseFrontmatter(content: string): {
   const parts = trimmed.split("---");
   if (parts.length >= 3 && parts[0] === "") {
     try {
-      const yaml = require("js-yaml");
       const frontmatter = yaml.load(parts[1]) as Record<string, unknown>;
       const body = parts.slice(2).join("---").trim();
       return { frontmatter: frontmatter ?? {}, body };

--- a/src/services/catalog.test.ts
+++ b/src/services/catalog.test.ts
@@ -80,7 +80,7 @@ afterAll(() => {
 // we test the underlying logic directly by importing and overriding.
 // For now, test the functions that don't depend on the path.
 
-import { searchAgents, type CatalogAgent } from "./catalog";
+import { type CatalogAgent } from "./catalog";
 
 // Build mock agents for search tests
 const mockAgents: CatalogAgent[] = [

--- a/src/services/projects.test.ts
+++ b/src/services/projects.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect } from "bun:test";
 import { useTestDb } from "../test/setup";
 import * as projects from "./projects";
 


### PR DESCRIPTION
## Summary
- Moved `ThemeProvider` from `AppLayout` to the top-level `App` component in `main.tsx`, so the dark theme class is applied on all routes including `AgentDashboard` (which bypasses `AppLayout` for its full-screen layout)
- Fixed pre-existing lint errors across 8 files (unused imports/vars, `require()` style imports)

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — 0 errors
- [x] `bun run test:all` — 121 backend + 205 frontend tests pass
- [ ] Manual: verify dark theme applies on agent dashboard page
- [ ] Manual: verify theme toggle in settings still works across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)