### PR TITLE
Fix YAML parsing crash on non-printable characters

### DIFF
--- a/catalog/agents/engineering/mobile-app-builder.yaml
+++ b/catalog/agents/engineering/mobile-app-builder.yaml
@@ -348,7 +348,7 @@ system_prompt: |
   });
   ```
   
-  ## = Your Workflow Process
+  ## = Your Workflow Process
   
   ### Step 1: Platform Strategy and Setup
   ```bash
@@ -445,7 +445,7 @@ system_prompt: |
   - **Think user experience**: "Added haptic feedback and smooth animations that feel natural on each platform"
   - **Consider constraints**: "Built offline-first architecture to handle poor network conditions gracefully"
   
-  ## = Learning & Memory
+  ## = Learning & Memory
   
   Remember and build expertise in:
   - **Platform-specific patterns** that create native-feeling user experiences

--- a/catalog/agents/engineering/rapid-prototyper.yaml
+++ b/catalog/agents/engineering/rapid-prototyper.yaml
@@ -323,7 +323,7 @@ system_prompt: |
   }
   ```
   
-  ## = Your Workflow Process
+  ## = Your Workflow Process
   
   ### Step 1: Rapid Requirements and Hypothesis Definition (Day 1 Morning)
   ```bash
@@ -368,7 +368,7 @@ system_prompt: |
   **Feature Set**: [3-5 features maximum for initial validation]
   **Technical Stack**: [Rapid development tools chosen]
   
-  ## =à Technical Implementation
+  ## =à Technical Implementation
   
   ### Development Stack
   **Frontend**: [Next.js 14 with TypeScript and Tailwind CSS]
@@ -414,7 +414,7 @@ system_prompt: |
   - **Think iteration**: "Added A/B testing to validate which CTA converts better"
   - **Measure everything**: "Set up analytics to track user engagement and identify friction points"
   
-  ## = Learning & Memory
+  ## = Learning & Memory
   
   Remember and build expertise in:
   - **Rapid development tools** that minimize setup time and maximize speed

--- a/catalog/agents/marketing/app-store-optimizer.yaml
+++ b/catalog/agents/marketing/app-store-optimizer.yaml
@@ -171,7 +171,7 @@ system_prompt: |
   - Regional performance analysis
   ```
   
-  ## = Your Workflow Process
+  ## = Your Workflow Process
   
   ### Step 1: Market Research and Analysis
   ```bash
@@ -273,7 +273,7 @@ system_prompt: |
   - **Think competitively**: "Identified keyword gap that competitors missed, gaining top 5 ranking in 3 weeks"
   - **Measure everything**: "A/B tested 5 icon variations, with version C delivering 23% higher conversion rate"
   
-  ## = Learning & Memory
+  ## = Learning & Memory
   
   Remember and build expertise in:
   - **Keyword research techniques** that identify high-opportunity, low-competition terms

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -3,6 +3,7 @@ import { readFile, readdir, rename, unlink, writeFile, mkdir, stat } from "fs/pr
 import { readFileSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import yaml from "js-yaml";
+import { safeYamlLoad } from "../utils/yaml";
 import { bus } from "../events";
 import * as agentsService from "../services/agents";
 import * as workspace from "../services/workspace";
@@ -513,7 +514,7 @@ export class AgentManager {
     try {
       const path = join(inboxDir, filename);
       const raw = await readFile(path, "utf-8");
-      const envelope = yaml.load(raw) as MessageEnvelope;
+      const envelope = safeYamlLoad(raw) as MessageEnvelope;
       if (envelope.type === "interrupt") {
         await this.harness?.interrupt();
         await unlink(path);
@@ -543,7 +544,7 @@ export class AgentManager {
         const s = await stat(path);
         if (s.size === 0) continue;
         const raw = await readFile(path, "utf-8");
-        const envelope = yaml.load(raw) as MessageEnvelope;
+        const envelope = safeYamlLoad(raw) as MessageEnvelope;
         await this.processEnvelope(envelope);
         await unlink(path);
         processed++;
@@ -637,7 +638,7 @@ export class AgentManager {
       let msg: OutboxMessage;
       try {
         const raw = await readFile(path, "utf-8");
-        msg = yaml.load(raw) as OutboxMessage;
+        msg = safeYamlLoad(raw) as OutboxMessage;
       } catch (err) {
         await this.writeSystemInbox(`Your outbox message "${file}" could not be parsed: ${err}`);
         await unlink(path);
@@ -750,7 +751,7 @@ export class AgentManager {
     const peersPath = workspace.peersPath(this.projectId);
     try {
       const raw = await readFile(peersPath, "utf-8");
-      const entries = yaml.load(raw) as PeerEntry[] | null;
+      const entries = safeYamlLoad(raw) as PeerEntry[] | null;
       this.peersNameToId.clear();
       this.peersIdToName.clear();
       if (Array.isArray(entries)) {
@@ -784,7 +785,7 @@ export class AgentManager {
   private readRecipe(): Record<string, unknown> | null {
     try {
       const content = readFileSync(workspace.recipePath(this.projectId, this.agentId), "utf-8");
-      return yaml.load(content) as Record<string, unknown>;
+      return safeYamlLoad(content) as Record<string, unknown>;
     } catch {
       return null;
     }

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, rmSync, readFileSync } from "fs";
 import { join } from "path";
 import yaml from "js-yaml";
+import { safeYamlLoad } from "../utils/yaml";
 import { bus } from "../events";
 import { AgentManager, type AgentStatus } from "./agent-manager";
 import * as agentsService from "../services/agents";
@@ -101,7 +102,7 @@ export class Coordinator {
     if (!agent) return { ok: false, error: "Agent not found" };
 
     // Parse new recipe to check for name change
-    const recipe = yaml.load(params.recipeYaml) as Record<string, unknown>;
+    const recipe = safeYamlLoad(params.recipeYaml) as Record<string, unknown>;
     const newName = recipe?.name as string | undefined;
     if (newName && newName !== agent.name) {
       agentsService.renameAgent(agentId, newName);
@@ -310,7 +311,7 @@ export class Coordinator {
   private readRecipe(agentId: string): Record<string, unknown> | null {
     try {
       const content = readFileSync(workspace.recipePath(this.projectId, agentId), "utf-8");
-      return yaml.load(content) as Record<string, unknown>;
+      return safeYamlLoad(content) as Record<string, unknown>;
     } catch {
       return null;
     }

--- a/src/scripts/catalog-sync.test.ts
+++ b/src/scripts/catalog-sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import yaml from "js-yaml";
+import { safeYamlLoad } from "../utils/yaml";
 
 // We test the pure functions from catalog-sync.
 // Since catalog-sync.ts is a script with top-level main() call,
@@ -22,7 +22,7 @@ function parseFrontmatter(content: string): {
   const parts = trimmed.split("---");
   if (parts.length >= 3 && parts[0] === "") {
     try {
-      const frontmatter = yaml.load(parts[1]) as Record<string, unknown>;
+      const frontmatter = safeYamlLoad(parts[1]) as Record<string, unknown>;
       const body = parts.slice(2).join("---").trim();
       return { frontmatter: frontmatter ?? {}, body };
     } catch {

--- a/src/scripts/catalog-sync.ts
+++ b/src/scripts/catalog-sync.ts
@@ -9,7 +9,7 @@ import { mkdirSync, rmSync, readdirSync, statSync, readFileSync, writeFileSync }
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { tmpdir } from "os";
-import yaml from "js-yaml";
+import { safeYamlLoad } from "../utils/yaml";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_REPO = "https://github.com/msitarzewski/agency-agents";
@@ -46,7 +46,7 @@ function parseFrontmatter(content: string): { frontmatter: Record<string, unknow
   const parts = trimmed.split("---");
   if (parts.length >= 3 && parts[0] === "") {
     try {
-      const frontmatter = yaml.load(parts[1]) as Record<string, unknown>;
+      const frontmatter = safeYamlLoad(parts[1]) as Record<string, unknown>;
       const body = parts.slice(2).join("---").trim();
       return { frontmatter: frontmatter ?? {}, body };
     } catch {

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, existsSync } from "fs";
 import { join, basename, dirname } from "path";
 import { fileURLToPath } from "url";
-import yaml from "js-yaml";
+import { safeYamlLoad } from "../utils/yaml";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -31,7 +31,7 @@ export function listCategories(): CatalogCategory[] {
   const path = join(catalogDir(), "categories.yaml");
   if (!existsSync(path)) return [];
   const content = readFileSync(path, "utf-8");
-  const data = yaml.load(content) as CatalogCategory[];
+  const data = safeYamlLoad(content) as CatalogCategory[];
   return data ?? [];
 }
 
@@ -49,7 +49,7 @@ export function listAgents(category?: string): CatalogAgent[] {
 
     for (const file of files) {
       const content = readFileSync(join(catDir, file), "utf-8");
-      const data = yaml.load(content) as Record<string, unknown>;
+      const data = safeYamlLoad(content) as Record<string, unknown>;
       if (!data) continue;
 
       result.push({

--- a/src/utils/yaml.test.ts
+++ b/src/utils/yaml.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeYaml, safeYamlLoad } from "./yaml";
+
+describe("sanitizeYaml", () => {
+  test("strips C0 control characters except tab, newline, carriage return", () => {
+    const input = "hello\x00\x04\x07\x08\x0B\x0C\x0E\x1Fworld";
+    expect(sanitizeYaml(input)).toBe("helloworld");
+  });
+
+  test("strips DEL character", () => {
+    expect(sanitizeYaml("a\x7Fb")).toBe("ab");
+  });
+
+  test("preserves tab, newline, carriage return", () => {
+    const input = "line1\n\tindented\r\nline2";
+    expect(sanitizeYaml(input)).toBe(input);
+  });
+
+  test("preserves valid UTF-8 including emoji and accented chars", () => {
+    const input = "name: 📱 café résumé";
+    expect(sanitizeYaml(input)).toBe(input);
+  });
+
+  test("strips C1 control characters (x80-x9F, except NEL x85)", () => {
+    expect(sanitizeYaml("a\x80b")).toBe("ab");
+    expect(sanitizeYaml("a\x84b")).toBe("ab");
+    expect(sanitizeYaml("a\x86b")).toBe("ab");
+    expect(sanitizeYaml("a\x9Fb")).toBe("ab");
+    expect(sanitizeYaml("a\x85b")).toBe("a\x85b");
+  });
+
+  test("strips Unicode non-characters uFFFE and uFFFF", () => {
+    expect(sanitizeYaml("a\uFFFEb")).toBe("ab");
+    expect(sanitizeYaml("a\uFFFFb")).toBe("ab");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(sanitizeYaml("")).toBe("");
+  });
+});
+
+describe("safeYamlLoad", () => {
+  test("parses valid YAML", () => {
+    const result = safeYamlLoad<{ name: string }>("name: test");
+    expect(result).toEqual({ name: "test" });
+  });
+
+  test("parses YAML containing non-printable characters without throwing", () => {
+    const yaml = "name: test\ndescription: |\n  ## =\x04 Workflow\n  Some content";
+    const result = safeYamlLoad<{ name: string; description: string }>(yaml);
+    expect(result.name).toBe("test");
+    expect(result.description).toContain("## = Workflow");
+  });
+
+  test("handles multiline block scalars with embedded control chars", () => {
+    const yaml = [
+      "system_prompt: |",
+      "  Hello\x00 world",
+      "  ## =\x04 Section",
+      "  Normal text",
+    ].join("\n");
+    const result = safeYamlLoad<{ system_prompt: string }>(yaml);
+    expect(result.system_prompt).toContain("Hello world");
+    expect(result.system_prompt).toContain("## = Section");
+  });
+});

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,0 +1,14 @@
+import yaml from "js-yaml";
+
+/**
+ * Strip characters that js-yaml rejects as non-printable (C0, C1, DEL, BOM non-chars).
+ * Preserves tab (\x09), newline (\x0A), carriage return (\x0D), and NEL (\x85).
+ */
+export function sanitizeYaml(input: string): string {
+  return input.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]/g, "");
+}
+
+/** Parse YAML after stripping non-printable characters. */
+export function safeYamlLoad<T>(content: string): T {
+  return yaml.load(sanitizeYaml(content)) as T;
+}


### PR DESCRIPTION
## Summary
- Catalog YAML files (3 files) contained corrupted emoji sequences with C0/C1 control characters that caused `js-yaml` to throw `YAMLException: the stream contains non-printable characters`
- Added `safeYamlLoad` utility (`src/utils/yaml.ts`) that strips non-printable characters before parsing, matching js-yaml's own rejection set
- Replaced all `yaml.load()` calls across `catalog.ts`, `coordinator.ts`, `agent-manager.ts`, and `catalog-sync.ts` with `safeYamlLoad`
- Cleaned the 3 affected catalog YAML files directly

## Test plan
- [x] New unit tests for `sanitizeYaml` and `safeYamlLoad` (10 tests, all passing)
- [x] Covers C0 controls, C1 controls, DEL, Unicode non-characters, and preservation of valid chars
- [x] All backend tests pass (93 tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)