### PR TITLE
Unify processing/agent_busy event types

### DIFF
--- a/src/frontend/pages/AgentDashboard.tsx
+++ b/src/frontend/pages/AgentDashboard.tsx
@@ -95,10 +95,13 @@ export default function AgentDashboardPage() {
           }
           break;
         }
-        case "processing": {
-          const active = (event.payload as Record<string, unknown>)?.active as boolean;
-          if (selectedAgentId) {
-            updateAgent(queryClient, projectId!, selectedAgentId, { busy: active });
+        case "agent_busy": {
+          const p = event.payload as Record<string, unknown>;
+          const agentId = p.agentId as string;
+          if (agentId) {
+            updateAgent(queryClient, projectId!, agentId, { busy: p.active as boolean });
+          } else {
+            console.warn("[AgentDashboard] agent_busy event missing agentId", event);
           }
           break;
         }

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -131,9 +131,8 @@ export class AgentManager {
       this.startWatchers();
       this.setStatus("active");
 
-      // Process any existing inbox messages
-      const count = await this.processInbox();
-      if (count > 0) this.broadcastAgent({ type: "processing", payload: { active: false } });
+      // Process any existing inbox messages (no subscriber at cold boot, skip broadcast)
+      await this.processInbox();
     } catch (err) {
       console.error(`Bootstrap failed for ${this.agentName}:`, err);
       this.setStatus("idle");
@@ -222,7 +221,7 @@ export class AgentManager {
     // Send directly to harness (no inbox file needed for direct messages)
     const prefix = from === "system" ? "[System] " : "";
     this.busy = true;
-    this.broadcastAgent({ type: "processing", payload: { active: true } });
+    this.broadcastAgent({ type: "agent_busy", payload: { agentId: this.agentId, active: true } });
     this.broadcastAgents({ type: "agent_busy", payload: { agentId: this.agentId, active: true } });
 
     // Fire-and-forget: start harness processing in the background
@@ -234,7 +233,10 @@ export class AgentManager {
       })
       .finally(() => {
         this.busy = false;
-        this.broadcastAgent({ type: "processing", payload: { active: false } });
+        this.broadcastAgent({
+          type: "agent_busy",
+          payload: { agentId: this.agentId, active: false },
+        });
         this.broadcastAgents({
           type: "agent_busy",
           payload: { agentId: this.agentId, active: false },
@@ -459,7 +461,7 @@ export class AgentManager {
         return;
       }
       this.busy = true;
-      this.broadcastAgent({ type: "processing", payload: { active: true } });
+      this.broadcastAgent({ type: "agent_busy", payload: { agentId: this.agentId, active: true } });
       this.broadcastAgents({
         type: "agent_busy",
         payload: { agentId: this.agentId, active: true },
@@ -471,7 +473,10 @@ export class AgentManager {
         } while (count > 0);
       } finally {
         this.busy = false;
-        this.broadcastAgent({ type: "processing", payload: { active: false } });
+        this.broadcastAgent({
+          type: "agent_busy",
+          payload: { agentId: this.agentId, active: false },
+        });
         this.broadcastAgents({
           type: "agent_busy",
           payload: { agentId: this.agentId, active: false },


### PR DESCRIPTION
## Summary
- Renamed all `"processing"` events on the per-agent WebSocket channel to `"agent_busy"` to match the project-wide channel
- Added `agentId` to per-agent channel payloads for consistency
- Removed stray `active: false` broadcast during cold boot (no subscriber exists)
- Added warning log for malformed `agent_busy` events missing `agentId`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (0 errors, 2 pre-existing warnings)
- [x] `bun run test:all` passes (326 tests)
- [ ] Manual: send a message to an agent, verify busy spinner appears in sidebar and chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)