### PR TITLE
Fix sent inter-agent messages appearing in sender's chat history

### DIFF
--- a/src/runtime/coordinator.test.ts
+++ b/src/runtime/coordinator.test.ts
@@ -235,6 +235,38 @@ describe("routeMessage (inter-agent)", () => {
     expect((envelope.payload as Record<string, unknown>).text).toBe("hello from sender");
   });
 
+  it("does not persist inter-agent message in sender's message history", async () => {
+    const senderResult = await coordinator.createAgent({
+      name: "sender2",
+      recipeYaml: "name: sender2\n",
+    });
+    const receiverResult = await coordinator.createAgent({
+      name: "receiver2",
+      recipeYaml: "name: receiver2\n",
+    });
+    expect(senderResult.ok).toBe(true);
+    expect(receiverResult.ok).toBe(true);
+    if (!senderResult.ok || !receiverResult.ok) return;
+
+    bus.emit(`project:${projectId}:outbox`, {
+      type: "outbox_message",
+      payload: {
+        fromAgentId: senderResult.agentId,
+        fromAgentName: "sender2",
+        toAgentName: "receiver2",
+        text: "hi there",
+      },
+    });
+
+    // Sender should have no inter-agent messages in their history
+    const { messages: senderMessages } = agentsService.listMessages(
+      projectId,
+      senderResult.agentId,
+    );
+    const senderInterAgent = senderMessages.filter((m) => m.role === "inter_agent");
+    expect(senderInterAgent).toHaveLength(0);
+  });
+
   it("sends error to sender when target agent does not exist", async () => {
     const senderResult = await coordinator.createAgent({
       name: "lonely",

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -294,18 +294,6 @@ export class Coordinator {
     const filename = `${Date.now()}-${fromAgentName}.yaml`;
     const inboxPath = join(workspace.inboxDir(this.projectId, targetAgent.id), filename);
     writeFileSync(inboxPath, yaml.dump(envelope), "utf-8");
-
-    // Persist inter-agent message for sender too (activity log)
-    agentsService.createMessage({
-      projectId: this.projectId,
-      agentId: fromAgentId,
-      role: "inter_agent",
-      content: {
-        text,
-        fromAgent: fromAgentName,
-        toAgent: toAgentName,
-      },
-    });
   }
 
   private readRecipe(agentId: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- When an agent sent an inter-agent message, the coordinator persisted a copy with the sender's `agentId`, causing it to appear in the sender's own chat history as "Message from [self]"
- Removed the redundant sender-side `createMessage()` call in `coordinator.routeMessage()` — the receiver already creates its own DB record when processing the inbox via `processEnvelope()`
- Added test verifying sender has no inter-agent messages after sending

## Test plan
- [x] New test: sender's message history contains no inter-agent messages after sending
- [x] All 15 coordinator tests pass
- [x] All 112 backend tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes (no new warnings/errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)