### PR TITLE
Fix unread count not clearing when switching agents

### DIFF
--- a/src/frontend/lib/hooks/messages.ts
+++ b/src/frontend/lib/hooks/messages.ts
@@ -62,6 +62,18 @@ export function useInterruptAgent(projectId: string) {
   });
 }
 
+export function useMarkRead(projectId: string) {
+  return useMutation({
+    mutationFn: async ({ agentId, messageId }: { agentId: string; messageId: number }) =>
+      unwrap(
+        await api.projects[":id"].agents[":aid"]["mark-read"].$post({
+          param: { id: projectId, aid: agentId },
+          json: { messageId },
+        }),
+      ),
+  });
+}
+
 export function useClearSession(projectId: string) {
   return useMutation({
     mutationFn: async (agentId: string) =>

--- a/src/frontend/pages/AgentDashboard.tsx
+++ b/src/frontend/pages/AgentDashboard.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useState, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { useResolveProjectId, useAgents } from "../lib/hooks";
+import { useResolveProjectId, useAgents, useMessages, useMarkRead } from "../lib/hooks";
 import { useSubscription } from "../lib/ws";
 import type { WsEvent } from "../lib/ws";
 import AgentDashboardComponent from "../components/AgentDashboard";
@@ -29,6 +29,9 @@ export default function AgentDashboardPage() {
   const selectedAgent = agentName ? agentList.find((a) => a.name === agentName) : agentList[0];
   const selectedAgentId = selectedAgent?.id;
 
+  const { data: messagesData } = useMessages(projectId, selectedAgentId);
+  const markRead = useMarkRead(projectId ?? "");
+
   // --- Streaming state ---
   const [streamingText, setStreamingText] = useState("");
 
@@ -49,10 +52,11 @@ export default function AgentDashboardPage() {
       case "new_message_notification":
         if (agentId === selectedAgentId) {
           queryClient.invalidateQueries({ queryKey: ["messages", projectId, selectedAgentId] });
+        } else {
+          const cached = queryClient.getQueryData<AgentData>(["agents", projectId]);
+          const current = cached?.find((a) => a.id === agentId)?.unreadCount ?? 0;
+          updateAgent(queryClient, projectId!, agentId, { unreadCount: current + 1 });
         }
-        updateAgent(queryClient, projectId!, agentId, {
-          unreadCount: (agentList.find((a) => a.id === agentId)?.unreadCount ?? 0) + 1,
-        });
         break;
       case "agent_created":
       case "agent_deleted":
@@ -126,6 +130,18 @@ export default function AgentDashboardPage() {
     prevAgentIdRef.current = selectedAgentId;
     if (streamingText !== "") setStreamingText("");
   }
+
+  // Mark messages as read when viewing an agent
+  const lastMessageId = messagesData?.messages?.at(-1)?.id;
+  const markReadRef = React.useRef(markRead);
+  React.useEffect(() => {
+    markReadRef.current = markRead;
+  });
+  React.useEffect(() => {
+    if (!projectId || !selectedAgentId || !lastMessageId) return;
+    markReadRef.current.mutate({ agentId: selectedAgentId, messageId: lastMessageId });
+    updateAgent(queryClient, projectId, selectedAgentId, { unreadCount: 0 });
+  }, [projectId, selectedAgentId, lastMessageId, queryClient]);
 
   if (!projectId) return <div className="p-8">Loading...</div>;
 

--- a/src/routes/agents.test.ts
+++ b/src/routes/agents.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createTestDb } from "../test/setup";
+import { createApp } from "../server";
+import { ProjectManager } from "../runtime/project-manager";
+import { Scheduler } from "../runtime/scheduler";
+import * as agentsService from "../services/agents";
+import { rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let app: ReturnType<typeof createApp>;
+let testDir: string;
+let projectId: string;
+let agentId: string;
+
+beforeEach(async () => {
+  createTestDb();
+  testDir = join(
+    tmpdir(),
+    `agents_route_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+  );
+  process.env.SHIRE_PROJECTS_DIR = testDir;
+
+  // Mock the harness so agents don't actually start LLM sessions
+  mock.module("../runtime/harness", () => ({
+    createHarness: () => ({
+      start: async () => {},
+      sendMessage: async () => {},
+      interrupt: async () => {},
+      clearSession: async () => {},
+      stop: async () => {},
+      onEvent: () => {},
+      isProcessing: () => false,
+    }),
+  }));
+
+  const projectManager = new ProjectManager();
+  const scheduler = new Scheduler(projectManager);
+  app = createApp({ projectManager, scheduler });
+
+  // Create a project
+  const createRes = await request("POST", "/api/projects", { name: "test-project" });
+  const projectData = (await createRes.json()) as Record<string, string>;
+  projectId = projectData.id;
+
+  // Create an agent
+  const agentRes = await request("POST", `/api/projects/${projectId}/agents`, {
+    name: "test-agent",
+    recipeYaml: "name: test-agent\ndescription: Test\n",
+  });
+  const agentData = (await agentRes.json()) as Record<string, string>;
+  agentId = agentData.id;
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+async function request(method: string, path: string, body?: unknown) {
+  const opts: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (body) opts.body = JSON.stringify(body);
+  return app.request(path, opts);
+}
+
+describe("POST /api/projects/:id/agents/:aid/mark-read", () => {
+  it("marks messages as read and reduces unread count", async () => {
+    // Create some agent messages to generate unread count
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "agent",
+      content: { text: "hello" },
+    });
+    const m2 = agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "agent",
+      content: { text: "world" },
+    });
+
+    // Verify there are unread messages
+    const listRes = await request("GET", `/api/projects/${projectId}/agents`);
+    const agents = (await listRes.json()) as Array<Record<string, unknown>>;
+    const agent = agents.find((a) => a.id === agentId);
+    expect(agent?.unreadCount).toBeGreaterThan(0);
+
+    // Mark read up to the latest message
+    const res = await request("POST", `/api/projects/${projectId}/agents/${agentId}/mark-read`, {
+      messageId: m2.id,
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Record<string, unknown>;
+    expect(data.ok).toBe(true);
+
+    // Verify unread count is now 0
+    const listRes2 = await request("GET", `/api/projects/${projectId}/agents`);
+    const agents2 = (await listRes2.json()) as Array<Record<string, unknown>>;
+    const agent2 = agents2.find((a) => a.id === agentId);
+    expect(agent2?.unreadCount).toBe(0);
+  });
+
+  it("partially marks read, leaving newer messages unread", async () => {
+    const m1 = agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "agent",
+      content: { text: "first" },
+    });
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "agent",
+      content: { text: "second" },
+    });
+
+    // Mark only up to the first message
+    const res = await request("POST", `/api/projects/${projectId}/agents/${agentId}/mark-read`, {
+      messageId: m1.id,
+    });
+    expect(res.status).toBe(200);
+
+    // Second message should still be unread
+    const listRes = await request("GET", `/api/projects/${projectId}/agents`);
+    const agents = (await listRes.json()) as Array<Record<string, unknown>>;
+    const agent = agents.find((a) => a.id === agentId);
+    expect(agent?.unreadCount).toBe(1);
+  });
+
+  it("returns 404 for unknown agent", async () => {
+    const res = await request("POST", `/api/projects/${projectId}/agents/nonexistent/mark-read`, {
+      messageId: 1,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for unknown project", async () => {
+    const res = await request("POST", `/api/projects/nonexistent/agents/${agentId}/mark-read`, {
+      messageId: 1,
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -100,6 +100,22 @@ export const agentRoutes = new Hono<AppEnv>()
     if (!ok) return c.json({ error: "Agent not active" }, 422);
     return c.json({ ok: true });
   })
+  .post(
+    "/projects/:id/agents/:aid/mark-read",
+    zValidator("json", z.object({ messageId: z.number() })),
+    (c) => {
+      const pm = c.get("projectManager");
+      const coordinator = pm.getCoordinator(c.req.param("id"));
+      if (!coordinator) return c.json({ error: "Project not found" }, 404);
+
+      const agent = coordinator.getAgent(c.req.param("aid"));
+      if (!agent) return c.json({ error: "Agent not found" }, 404);
+
+      const { messageId } = c.req.valid("json");
+      agent.markRead(messageId);
+      return c.json({ ok: true });
+    },
+  )
   .post("/projects/:id/agents/:aid/clear", async (c) => {
     const pm = c.get("projectManager");
     const coordinator = pm.getCoordinator(c.req.param("id"));


### PR DESCRIPTION
## Summary

- Add `POST /projects/:id/agents/:aid/mark-read` endpoint that calls `agent.markRead(messageId)` to advance the read cursor
- Add `useMarkRead` hook and call it from `AgentDashboard` when switching agents or when new messages load
- Skip incrementing unread count for the currently-viewed agent (previously, even the selected agent's badge would increase)
- Read unread count from TanStack Query cache instead of stale render closure to avoid double-counting during rapid message delivery

## Test plan

- [x] Backend route test: mark-read reduces unread count to 0, partial mark-read leaves newer messages unread, 404 for unknown agent/project
- [x] All 126 backend tests pass
- [x] All 205 frontend tests pass
- [x] TypeScript strict mode passes
- [x] ESLint clean (no new warnings)
- [ ] Manual: switch between agents, verify badge clears; receive message while viewing agent, verify no badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)