### PR TITLE
Add loading/error state handling to all queries and mutations

### DIFF
--- a/src/frontend/components/AgentShow.tsx
+++ b/src/frontend/components/AgentShow.tsx
@@ -22,7 +22,7 @@ import {
 import AppLayout from "./AppLayout";
 import { navigate } from "./lib/navigate";
 import AgentForm from "./AgentForm";
-import { ChevronLeft, MoreHorizontal, Pencil } from "lucide-react";
+import { ChevronLeft, MoreHorizontal, Pencil, Loader2 } from "lucide-react";
 import { type Agent, statusVariant, harnessLabel } from "./types";
 import {
   useProjectId,
@@ -90,7 +90,13 @@ export default function AgentShow() {
                 Restart Agent
               </Button>
             ) : (
-              <Button onClick={() => restartAgent.mutate(agentId!)}>Start Agent</Button>
+              <Button
+                onClick={() => restartAgent.mutate(agentId!)}
+                disabled={restartAgent.isPending}
+              >
+                {restartAgent.isPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+                Start Agent
+              </Button>
             )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -175,8 +181,11 @@ export default function AgentShow() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={() => restartAgent.mutate(agentId!)}>
-              Restart
+            <AlertDialogAction
+              onClick={() => restartAgent.mutate(agentId!)}
+              disabled={restartAgent.isPending}
+            >
+              {restartAgent.isPending ? "Restarting..." : "Restart"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -196,8 +205,9 @@ export default function AgentShow() {
             <AlertDialogAction
               className={buttonVariants({ variant: "destructive" })}
               onClick={() => deleteAgent.mutate(agentId!)}
+              disabled={deleteAgent.isPending}
             >
-              Delete
+              {deleteAgent.isPending ? "Deleting..." : "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/frontend/components/AgentSidebar.tsx
+++ b/src/frontend/components/AgentSidebar.tsx
@@ -17,7 +17,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./ui/alert-dialog";
-import { FileText, Settings, FolderOpen, Clock } from "lucide-react";
+import { FileText, Settings, FolderOpen, Clock, Loader2 } from "lucide-react";
 import ProjectSwitcher from "./ProjectSwitcher";
 import { navigate } from "./lib/navigate";
 import { type AgentOverview, type AgentStatus } from "./types";
@@ -46,7 +46,7 @@ export default function AgentSidebar({ onNewAgent, onBrowseCatalog }: AgentSideb
   const { agentName } = useParams<{ agentName: string }>();
   const { projectId, projectName } = useProjectId();
   const { data: projects = [] } = useProjects();
-  const { data: agents = [] } = useAgents(projectId);
+  const { data: agents = [], isLoading: agentsLoading } = useAgents(projectId);
   const deleteAgentMut = useDeleteAgent(projectId ?? "");
 
   const selectedAgentId = agentName ? (agents.find((a) => a.name === agentName)?.id ?? null) : null;
@@ -80,6 +80,11 @@ export default function AgentSidebar({ onNewAgent, onBrowseCatalog }: AgentSideb
       </div>
 
       <div className="flex-1 overflow-y-auto py-1">
+        {agentsLoading && (
+          <div className="flex items-center justify-center py-6">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          </div>
+        )}
         {agents.map((agent) => (
           <div key={agent.id} className="group flex items-center mx-1">
             <button
@@ -131,7 +136,7 @@ export default function AgentSidebar({ onNewAgent, onBrowseCatalog }: AgentSideb
             </DropdownMenu>
           </div>
         ))}
-        {agents.length === 0 && (
+        {!agentsLoading && agents.length === 0 && (
           <div className="px-3 py-6 text-center">
             <p className="text-sm text-muted-foreground mb-1">No agents yet</p>
             <p className="text-xs text-muted-foreground">
@@ -209,8 +214,9 @@ export default function AgentSidebar({ onNewAgent, onBrowseCatalog }: AgentSideb
             <AlertDialogAction
               className={buttonVariants({ variant: "destructive" })}
               onClick={handleDeleteConfirm}
+              disabled={deleteAgentMut.isPending}
             >
-              Delete
+              {deleteAgentMut.isPending ? "Deleting..." : "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -227,7 +227,7 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
       prev?.map((a) => (a.id === agent.id ? { ...a, busy: true } : a)),
     );
 
-  const { data: messagesData } = useMessages(projectId, agent.id);
+  const { data: messagesData, isLoading: messagesLoading } = useMessages(projectId, agent.id);
   const sendMessage = useSendMessage(projectId ?? "");
   const interruptAgent = useInterruptAgent(projectId ?? "");
   const restartAgent = useRestartAgent(projectId ?? "");
@@ -394,7 +394,12 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
             </span>
           </div>
         )}
-        {!hasMessages && (
+        {messagesLoading && (
+          <div className="flex items-center justify-center h-full">
+            <span className="text-sm text-muted-foreground animate-pulse">Loading messages...</span>
+          </div>
+        )}
+        {!messagesLoading && !hasMessages && (
           <div className="flex flex-col items-center justify-center h-full gap-4 max-w-sm mx-auto text-center">
             <p className="text-sm text-muted-foreground">
               Send a message to start working with this agent.
@@ -531,7 +536,9 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
                 <Square className="h-4 w-4 fill-current" />
               </Button>
             ) : (
-              <Button onClick={handleSend}>Send</Button>
+              <Button onClick={handleSend} disabled={sendMessage.isPending}>
+                Send
+              </Button>
             )}
           </div>
         </div>
@@ -541,8 +548,13 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
             <p className="text-sm text-muted-foreground">
               Agent is idle. It will restart automatically when the VM wakes up.
             </p>
-            <Button variant="outline" size="sm" onClick={() => restartAgent.mutate(agent.id)}>
-              Restart
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => restartAgent.mutate(agent.id)}
+              disabled={restartAgent.isPending}
+            >
+              {restartAgent.isPending ? "Restarting..." : "Restart"}
             </Button>
           </div>
         </div>

--- a/src/frontend/components/ErrorBoundary.tsx
+++ b/src/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "./ui/button";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Uncaught error:", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-8 text-center">
+          <h1 className="text-xl font-semibold">Something went wrong</h1>
+          <p className="text-sm text-muted-foreground max-w-md">
+            {this.state.error?.message || "An unexpected error occurred."}
+          </p>
+          <Button
+            variant="outline"
+            onClick={() => {
+              window.location.reload();
+            }}
+          >
+            Reload Page
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/frontend/components/ProjectDashboard.tsx
+++ b/src/frontend/components/ProjectDashboard.tsx
@@ -213,8 +213,9 @@ export default function ProjectDashboard() {
             <AlertDialogAction
               className={buttonVariants({ variant: "destructive" })}
               onClick={handleDelete}
+              disabled={deleteProject.isPending}
             >
-              Delete
+              {deleteProject.isPending ? "Deleting..." : "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/frontend/components/ProjectDetailsPage.tsx
+++ b/src/frontend/components/ProjectDetailsPage.tsx
@@ -3,14 +3,14 @@ import { Button } from "./ui/button";
 import { Textarea } from "./ui/textarea";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, Loader2 } from "lucide-react";
 import AppLayout from "./AppLayout";
 import { navigate } from "./lib/navigate";
 import { useProjectId, useProjectDoc, useRenameProject, useSaveProjectDoc } from "../lib/hooks";
 
 export default function ProjectDetailsPage() {
   const { projectId, projectName } = useProjectId();
-  const { data: projectDoc } = useProjectDoc(projectId);
+  const { data: projectDoc, isLoading: docLoading } = useProjectDoc(projectId);
   const renameProject = useRenameProject(projectId ?? "");
   const saveDoc = useSaveProjectDoc(projectId ?? "");
 
@@ -86,25 +86,31 @@ export default function ProjectDetailsPage() {
           </p>
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="project-doc">PROJECT.md</Label>
-          <p className="text-xs text-muted-foreground">
-            Shared project context visible to all agents. Agents check this before starting and
-            after completing tasks.
-          </p>
-          <Textarea
-            id="project-doc"
-            value={docValue}
-            onChange={(e) => setDocValue(e.target.value)}
-            className="min-h-[400px] font-mono text-sm"
-            placeholder="# Project&#10;&#10;Describe your project here..."
-          />
-          <div className="flex justify-end">
-            <Button onClick={handleSaveDoc} disabled={!docDirty || isSavingDoc}>
-              {isSavingDoc ? "Saving..." : "Save Document"}
-            </Button>
+        {docLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
-        </div>
+        ) : (
+          <div className="space-y-2">
+            <Label htmlFor="project-doc">PROJECT.md</Label>
+            <p className="text-xs text-muted-foreground">
+              Shared project context visible to all agents. Agents check this before starting and
+              after completing tasks.
+            </p>
+            <Textarea
+              id="project-doc"
+              value={docValue}
+              onChange={(e) => setDocValue(e.target.value)}
+              className="min-h-[400px] font-mono text-sm"
+              placeholder="# Project&#10;&#10;Describe your project here..."
+            />
+            <div className="flex justify-end">
+              <Button onClick={handleSaveDoc} disabled={!docDirty || isSavingDoc}>
+                {isSavingDoc ? "Saving..." : "Save Document"}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </AppLayout>
   );

--- a/src/frontend/components/SchedulesPage.tsx
+++ b/src/frontend/components/SchedulesPage.tsx
@@ -25,7 +25,7 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Textarea } from "./ui/textarea";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
-import { ChevronLeft, Plus, Play, Pencil, Trash2 } from "lucide-react";
+import { ChevronLeft, Plus, Play, Pencil, Trash2, Loader2 } from "lucide-react";
 import { navigate } from "./lib/navigate";
 import { type ScheduledTask } from "./types";
 import {
@@ -231,7 +231,7 @@ export default function SchedulesPage() {
   const queryClient = useQueryClient();
   const { projectId, projectName } = useProjectId();
 
-  const { data: tasks = [] } = useSchedules(projectId);
+  const { data: tasks = [], isLoading: schedulesLoading } = useSchedules(projectId);
   const { data: agentList = [] } = useAgents(projectId);
   const createScheduleMut = useCreateSchedule(projectId ?? "");
   const updateScheduleMut = useUpdateSchedule(projectId ?? "");
@@ -343,7 +343,11 @@ export default function SchedulesPage() {
           </Button>
         </div>
 
-        {typedTasks.length === 0 ? (
+        {schedulesLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : typedTasks.length === 0 ? (
           <div className="text-center py-12 text-muted-foreground">
             <p>No scheduled tasks yet.</p>
             <p className="text-sm mt-1">
@@ -644,8 +648,21 @@ export default function SchedulesPage() {
             <Button variant="outline" onClick={() => setFormOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={handleSubmit} disabled={!form.label || !form.agentId || !form.message}>
-              {editingId ? "Save Changes" : "Create Schedule"}
+            <Button
+              onClick={handleSubmit}
+              disabled={
+                !form.label ||
+                !form.agentId ||
+                !form.message ||
+                createScheduleMut.isPending ||
+                updateScheduleMut.isPending
+              }
+            >
+              {createScheduleMut.isPending || updateScheduleMut.isPending
+                ? "Saving..."
+                : editingId
+                  ? "Save Changes"
+                  : "Create Schedule"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -670,8 +687,9 @@ export default function SchedulesPage() {
             <AlertDialogAction
               className={buttonVariants({ variant: "destructive" })}
               onClick={handleDelete}
+              disabled={deleteScheduleMut.isPending}
             >
-              Delete
+              {deleteScheduleMut.isPending ? "Deleting..." : "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/frontend/components/SettingsPage.tsx
+++ b/src/frontend/components/SettingsPage.tsx
@@ -15,7 +15,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from "./ui/alert-dialog";
-import { ChevronLeft, Play, Trash2, Plus, X } from "lucide-react";
+import { ChevronLeft, Play, Trash2, Plus, X, Loader2 } from "lucide-react";
 import AppLayout from "./AppLayout";
 import ThemeSelector from "./ThemeSelector";
 import { navigate } from "./lib/navigate";
@@ -73,8 +73,8 @@ export default function SettingsPage() {
   const queryClient = useQueryClient();
   const { projectId, projectName } = useProjectId();
 
-  const { data: envData } = useEnv(projectId);
-  const { data: scripts = [] } = useScripts(projectId);
+  const { data: envData, isLoading: envLoading } = useEnv(projectId);
+  const { data: scripts = [], isLoading: scriptsLoading } = useScripts(projectId);
   const { data: activityData } = useActivity(projectId);
   const saveEnv = useSaveEnv(projectId ?? "");
   const saveScript = useSaveScript(projectId ?? "");
@@ -185,137 +185,151 @@ export default function SettingsPage() {
           </TabsList>
 
           <TabsContent value="environment" className="space-y-4 pt-4">
-            <div className="space-y-3">
-              <Label>Global Environment Variables</Label>
-              {envRows.length === 0 && (
-                <p className="text-sm text-muted-foreground py-2">
-                  No environment variables. Add variables to configure your agents.
-                </p>
-              )}
-              {envRows.map((row, index) => (
-                <div key={index} className="flex items-center gap-2">
-                  <Input
-                    value={row.key}
-                    onChange={(e) => updateEnvRow(index, "key", e.target.value)}
-                    placeholder="KEY"
-                    className="font-mono text-sm w-1/3"
-                    aria-label={`Variable ${index + 1} key`}
-                  />
-                  <span className="text-muted-foreground">=</span>
-                  <Input
-                    value={row.value}
-                    onChange={(e) => updateEnvRow(index, "value", e.target.value)}
-                    placeholder="value"
-                    className="font-mono text-sm flex-1 min-w-0"
-                    aria-label={`Variable ${index + 1} value`}
-                  />
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => removeEnvRow(index)}
-                    aria-label={`Remove variable ${index + 1}`}
-                  >
-                    <X className="h-4 w-4" />
+            {envLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <Label>Global Environment Variables</Label>
+                {envRows.length === 0 && (
+                  <p className="text-sm text-muted-foreground py-2">
+                    No environment variables. Add variables to configure your agents.
+                  </p>
+                )}
+                {envRows.map((row, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <Input
+                      value={row.key}
+                      onChange={(e) => updateEnvRow(index, "key", e.target.value)}
+                      placeholder="KEY"
+                      className="font-mono text-sm w-1/3"
+                      aria-label={`Variable ${index + 1} key`}
+                    />
+                    <span className="text-muted-foreground">=</span>
+                    <Input
+                      value={row.value}
+                      onChange={(e) => updateEnvRow(index, "value", e.target.value)}
+                      placeholder="value"
+                      className="font-mono text-sm flex-1 min-w-0"
+                      aria-label={`Variable ${index + 1} value`}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeEnvRow(index)}
+                      aria-label={`Remove variable ${index + 1}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+                <div className="flex items-center justify-between">
+                  <Button variant="outline" size="sm" onClick={addEnvRow}>
+                    <Plus className="h-4 w-4 mr-1" />
+                    Add Variable
+                  </Button>
+                  <Button onClick={handleSaveEnv} disabled={!envDirty || saveEnv.isPending}>
+                    {saveEnv.isPending ? "Saving..." : "Save Environment"}
                   </Button>
                 </div>
-              ))}
-              <div className="flex items-center justify-between">
-                <Button variant="outline" size="sm" onClick={addEnvRow}>
-                  <Plus className="h-4 w-4 mr-1" />
-                  Add Variable
-                </Button>
-                <Button onClick={handleSaveEnv} disabled={!envDirty}>
-                  Save Environment
-                </Button>
               </div>
-            </div>
+            )}
           </TabsContent>
 
           <TabsContent value="scripts" className="space-y-4 pt-4">
-            <div className="flex items-center gap-2">
-              <Input
-                value={newScriptName}
-                onChange={(e) => setNewScriptName(e.target.value)}
-                placeholder="script-name.sh"
-                className="max-w-xs"
-                onKeyDown={(e) => e.key === "Enter" && handleCreateScript()}
-              />
-              <Button variant="outline" size="sm" onClick={handleCreateScript}>
-                <Plus className="h-4 w-4 mr-1" />
-                New Script
-              </Button>
-            </div>
-
-            {scriptDrafts.length === 0 && (
-              <p className="text-sm text-muted-foreground py-4">
-                No global scripts. Create scripts to run setup commands on the VM.
-              </p>
-            )}
-
-            <div className="space-y-4">
-              {scriptDrafts.map((draft, index) => (
-                <div key={draft.originalName} className="border rounded-lg p-4 space-y-3">
-                  <div className="flex items-center gap-2">
-                    <Label className="shrink-0">Name</Label>
-                    <Input
-                      value={draft.name}
-                      onChange={(e) => updateScriptDraft(index, "name", e.target.value)}
-                      className="font-mono text-sm"
-                      aria-label={`Script ${index + 1} name`}
-                    />
-                    <div className="flex items-center gap-1 shrink-0">
-                      <Button
-                        size="sm"
-                        onClick={() => handleSaveScriptAt(index)}
-                        disabled={!draft.dirty}
-                      >
-                        Save
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => runScript.mutate(draft.originalName)}
-                        aria-label="Run script"
-                      >
-                        <Play className="h-4 w-4" />
-                      </Button>
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button variant="ghost" size="sm" aria-label="Delete script">
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>Delete Script</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              Are you sure you want to delete &quot;{draft.originalName}&quot;? This
-                              cannot be undone.
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction
-                              className={buttonVariants({ variant: "destructive" })}
-                              onClick={() => deleteScript.mutate(draft.originalName)}
-                            >
-                              Delete
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    </div>
-                  </div>
-                  <Textarea
-                    value={draft.content}
-                    onChange={(e) => updateScriptDraft(index, "content", e.target.value)}
-                    rows={8}
-                    className="font-mono text-sm"
-                    aria-label={`Script ${index + 1} content`}
+            {scriptsLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={newScriptName}
+                    onChange={(e) => setNewScriptName(e.target.value)}
+                    placeholder="script-name.sh"
+                    className="max-w-xs"
+                    onKeyDown={(e) => e.key === "Enter" && handleCreateScript()}
                   />
+                  <Button variant="outline" size="sm" onClick={handleCreateScript}>
+                    <Plus className="h-4 w-4 mr-1" />
+                    New Script
+                  </Button>
                 </div>
-              ))}
-            </div>
+
+                {scriptDrafts.length === 0 && (
+                  <p className="text-sm text-muted-foreground py-4">
+                    No global scripts. Create scripts to run setup commands on the VM.
+                  </p>
+                )}
+
+                <div className="space-y-4">
+                  {scriptDrafts.map((draft, index) => (
+                    <div key={draft.originalName} className="border rounded-lg p-4 space-y-3">
+                      <div className="flex items-center gap-2">
+                        <Label className="shrink-0">Name</Label>
+                        <Input
+                          value={draft.name}
+                          onChange={(e) => updateScriptDraft(index, "name", e.target.value)}
+                          className="font-mono text-sm"
+                          aria-label={`Script ${index + 1} name`}
+                        />
+                        <div className="flex items-center gap-1 shrink-0">
+                          <Button
+                            size="sm"
+                            onClick={() => handleSaveScriptAt(index)}
+                            disabled={!draft.dirty || saveScript.isPending}
+                          >
+                            {saveScript.isPending ? "Saving..." : "Save"}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => runScript.mutate(draft.originalName)}
+                            aria-label="Run script"
+                          >
+                            <Play className="h-4 w-4" />
+                          </Button>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button variant="ghost" size="sm" aria-label="Delete script">
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Delete Script</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  Are you sure you want to delete &quot;{draft.originalName}&quot;?
+                                  This cannot be undone.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction
+                                  className={buttonVariants({ variant: "destructive" })}
+                                  onClick={() => deleteScript.mutate(draft.originalName)}
+                                >
+                                  Delete
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </div>
+                      </div>
+                      <Textarea
+                        value={draft.content}
+                        onChange={(e) => updateScriptDraft(index, "content", e.target.value)}
+                        rows={8}
+                        className="font-mono text-sm"
+                        aria-label={`Script ${index + 1} content`}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
           </TabsContent>
 
           <TabsContent value="activity" className="pt-4">

--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -23,7 +23,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import AppLayout from "./AppLayout";
 import Markdown from "./Markdown";
-import { ChevronLeft, Folder, File, X, Download } from "lucide-react";
+import { ChevronLeft, Folder, File, X, Download, Loader2 } from "lucide-react";
 import { navigate as navigateTo } from "./lib/navigate";
 import {
   useProjectId,
@@ -206,7 +206,7 @@ export default function SharedDrive() {
   const { projectId, projectName } = useProjectId();
   const [currentPath, setCurrentPath] = React.useState("/");
 
-  const { data } = useSharedDrive(projectId, currentPath);
+  const { data, isLoading: filesLoading } = useSharedDrive(projectId, currentPath);
   const files = (data?.files ?? []) as SharedDriveFile[];
 
   const createDirectory = useCreateDirectory(projectId ?? "");
@@ -359,7 +359,13 @@ export default function SharedDrive() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {sortedFiles.length === 0 ? (
+                {filesLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={previewFile ? 2 : 3} className="text-center py-8">
+                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground mx-auto" />
+                    </TableCell>
+                  </TableRow>
+                ) : sortedFiles.length === 0 ? (
                   <TableRow>
                     <TableCell
                       colSpan={previewFile ? 2 : 3}

--- a/src/frontend/lib/hooks/shared-drive.ts
+++ b/src/frontend/lib/hooks/shared-drive.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
-import { unwrap, withErrorToast } from "./util";
+import { unwrap } from "./util";
 
 export function useSharedDrive(projectId: string | undefined, path: string) {
   return useQuery({
@@ -18,58 +18,44 @@ export function useSharedDrive(projectId: string | undefined, path: string) {
 
 export function useCreateDirectory(projectId: string) {
   const qc = useQueryClient();
-  return useMutation(
-    withErrorToast({
-      mutationFn: async ({ name, path }: { name: string; path: string }) =>
-        unwrap(
-          await api.projects[":id"]["shared-drive"].directory.$post({
-            param: { id: projectId },
-            json: { name, path },
-          }),
-        ),
-      onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
-    }),
-  );
+  return useMutation({
+    mutationFn: async ({ name, path }: { name: string; path: string }) =>
+      unwrap(
+        await api.projects[":id"]["shared-drive"].directory.$post({
+          param: { id: projectId },
+          json: { name, path },
+        }),
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
+  });
 }
 
 export function useDeleteSharedFile(projectId: string) {
   const qc = useQueryClient();
-  return useMutation(
-    withErrorToast({
-      mutationFn: async (path: string) =>
-        unwrap(
-          await api.projects[":id"]["shared-drive"].$delete({
-            param: { id: projectId },
-            query: { path },
-          }),
-        ),
-      onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
-    }),
-  );
+  return useMutation({
+    mutationFn: async (path: string) =>
+      unwrap(
+        await api.projects[":id"]["shared-drive"].$delete({
+          param: { id: projectId },
+          query: { path },
+        }),
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
+  });
 }
 
 export function useUploadFile(projectId: string) {
   const qc = useQueryClient();
-  return useMutation(
-    withErrorToast({
-      mutationFn: async ({
-        name,
-        content,
-        path,
-      }: {
-        name: string;
-        content: string;
-        path: string;
-      }) =>
-        unwrap(
-          await api.projects[":id"]["shared-drive"].upload.$post({
-            param: { id: projectId },
-            json: { name, content, path },
-          }),
-        ),
-      onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
-    }),
-  );
+  return useMutation({
+    mutationFn: async ({ name, content, path }: { name: string; content: string; path: string }) =>
+      unwrap(
+        await api.projects[":id"]["shared-drive"].upload.$post({
+          param: { id: projectId },
+          json: { name, content, path },
+        }),
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
+  });
 }
 
 export function usePreviewFile(projectId: string) {

--- a/src/frontend/lib/hooks/util.ts
+++ b/src/frontend/lib/hooks/util.ts
@@ -1,20 +1,5 @@
-import { useMutation } from "@tanstack/react-query";
-import { toast } from "sonner";
 import type { ClientResponse } from "hono/client";
 import type { SuccessStatusCode } from "hono/utils/http-status";
-
-/** Wraps a mutation with automatic error toasts */
-export function withErrorToast<TData, TVariables>(
-  opts: Parameters<typeof useMutation<TData, Error, TVariables>>[0],
-): Parameters<typeof useMutation<TData, Error, TVariables>>[0] {
-  return {
-    ...opts,
-    onError: (error, variables, onMutateResult, context) => {
-      toast.error(error.message || "Something went wrong");
-      opts.onError?.(error, variables, onMutateResult, context);
-    },
-  };
-}
 
 /**
  * Extracts the success response data type from a Hono ClientResponse union.

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -4,8 +4,9 @@ import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { setNavigate } from "./lib/navigate";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
 import { ThemeProvider } from "./components/ThemeProvider";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import "@fontsource-variable/dm-sans";
 import "./css/app.css";
 
@@ -26,6 +27,11 @@ const queryClient = new QueryClient({
       retry: 1,
       staleTime: 15_000,
     },
+    mutations: {
+      onError: (error: Error) => {
+        toast.error(error.message || "Something went wrong");
+      },
+    },
   },
 });
 
@@ -41,27 +47,29 @@ function NavigateBridge() {
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <Toaster position="bottom-right" richColors />
-        <BrowserRouter>
-          <NavigateBridge />
-          <Routes>
-            <Route path="/" element={<ProjectDashboard />} />
-            <Route path="/projects/:projectName" element={<AgentDashboard />} />
-            <Route path="/projects/:projectName/agents/:agentName" element={<AgentDashboard />} />
-            <Route
-              path="/projects/:projectName/agents/:agentName/settings"
-              element={<AgentSettings />}
-            />
-            <Route path="/projects/:projectName/details" element={<ProjectDetails />} />
-            <Route path="/projects/:projectName/settings" element={<Settings />} />
-            <Route path="/projects/:projectName/shared" element={<SharedDrivePage />} />
-            <Route path="/projects/:projectName/schedules" element={<Schedules />} />
-          </Routes>
-        </BrowserRouter>
-      </ThemeProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <Toaster position="bottom-right" richColors />
+          <BrowserRouter>
+            <NavigateBridge />
+            <Routes>
+              <Route path="/" element={<ProjectDashboard />} />
+              <Route path="/projects/:projectName" element={<AgentDashboard />} />
+              <Route path="/projects/:projectName/agents/:agentName" element={<AgentDashboard />} />
+              <Route
+                path="/projects/:projectName/agents/:agentName/settings"
+                element={<AgentSettings />}
+              />
+              <Route path="/projects/:projectName/details" element={<ProjectDetails />} />
+              <Route path="/projects/:projectName/settings" element={<Settings />} />
+              <Route path="/projects/:projectName/shared" element={<SharedDrivePage />} />
+              <Route path="/projects/:projectName/schedules" element={<Schedules />} />
+            </Routes>
+          </BrowserRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/frontend/test/ErrorBoundary.test.tsx
+++ b/src/frontend/test/ErrorBoundary.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBoundary } from "../components/ErrorBoundary";
+
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("Test explosion");
+  return <div>All good</div>;
+}
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("renders children when no error", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("All good")).toBeTruthy();
+  });
+
+  it("shows fallback UI when child throws", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+    expect(screen.getByText("Test explosion")).toBeTruthy();
+    expect(screen.getByText("Reload Page")).toBeTruthy();
+  });
+
+  it("calls window.location.reload when clicking Reload Page", () => {
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, reload: reloadMock },
+      writable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    fireEvent.click(screen.getByText("Reload Page"));
+    expect(reloadMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add global `onError` handler on `QueryClient` to show error toasts for all mutations — replaces the per-mutation `withErrorToast()` wrapper which only covered 3 of ~26 mutations
- Add loading spinners for queries missing them: AgentSidebar, ChatPanel, SharedDrive, SchedulesPage, SettingsPage, ProjectDetailsPage
- Add mutation pending states (disabled buttons, "Saving..."/"Deleting..." text) for destructive/important actions across 6 components
- Add `ErrorBoundary` component wrapping the app to catch render crashes with a user-friendly fallback
- Remove now-redundant `withErrorToast` utility

## Test plan
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] ESLint passes with 0 errors (`bun run lint`)
- [x] All 208 frontend tests pass (`bun run test:frontend`)
- [x] All 129 backend tests pass
- [x] New ErrorBoundary test (3 cases)
- [ ] Manual: stop backend, trigger mutations → verify error toasts appear
- [ ] Manual: throttle network in DevTools → verify loading spinners show

🤖 Generated with [Claude Code](https://claude.com/claude-code)