### PR TITLE
Add project status tracking (starting/running/error)

### DIFF
--- a/src/frontend/components/ProjectDashboard.tsx
+++ b/src/frontend/components/ProjectDashboard.tsx
@@ -35,16 +35,12 @@ import { useProjects, useCreateProject, useDeleteProject, useRestartProject } fr
 import { useSubscription } from "../lib/ws";
 import { useQueryClient } from "@tanstack/react-query";
 
-function projectStatusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+function projectStatusVariant(status: string): "default" | "secondary" | "destructive" {
   switch (status) {
     case "running":
       return "default";
     case "starting":
-    case "stopped":
       return "secondary";
-    case "idle":
-      return "outline";
-    case "unreachable":
     case "error":
       return "destructive";
     default:
@@ -134,7 +130,7 @@ export default function ProjectDashboard() {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          {project.status !== "running" && (
+                          {project.status === "error" && (
                             <DropdownMenuItem
                               disabled={restartingId === project.id}
                               onClick={() => {

--- a/src/frontend/components/types.ts
+++ b/src/frontend/components/types.ts
@@ -1,7 +1,7 @@
 export interface Project {
   id: string;
   name: string;
-  status: "starting" | "running" | "idle" | "unreachable" | "stopped" | "error";
+  status: "starting" | "running" | "error";
 }
 
 export type HarnessType = "pi" | "claude_code";

--- a/src/frontend/lib/ws.ts
+++ b/src/frontend/lib/ws.ts
@@ -136,11 +136,14 @@ export function useSubscriptions(topics: Array<string | null>, handler: EventHan
     handlerRef.current = handler;
   });
 
+  const topicsKey = topics.join(",");
+
   useEffect(() => {
     const wsClient = getClient();
     const unsubs: Array<() => void> = [];
+    const currentTopics = topicsKey.split(",");
 
-    for (const topic of topics) {
+    for (const topic of currentTopics) {
       if (!topic) continue;
       unsubs.push(
         wsClient.subscribe(topic, (event) => {
@@ -152,7 +155,7 @@ export function useSubscriptions(topics: Array<string | null>, handler: EventHan
     return () => {
       for (const unsub of unsubs) unsub();
     };
-  }, [topics.join(",")]);
+  }, [topicsKey]);
 }
 
 /**

--- a/src/frontend/test/ProjectDashboard.test.tsx
+++ b/src/frontend/test/ProjectDashboard.test.tsx
@@ -67,21 +67,17 @@ describe("ProjectDashboard", () => {
     expect(screen.getByText("error")).toBeInTheDocument();
   });
 
-  it("shows idle and unreachable status badges", () => {
-    mockProjects = [
-      { id: "p9", name: "idle-project", status: "idle" },
-      { id: "p10", name: "unreachable-project", status: "unreachable" },
-    ];
+  it("shows starting status badge", () => {
+    mockProjects = [{ id: "p9", name: "starting-project", status: "starting" }];
     renderWithProviders(<ProjectDashboard />);
-    expect(screen.getByText("idle")).toBeInTheDocument();
-    expect(screen.getByText("unreachable")).toBeInTheDocument();
+    expect(screen.getByText("starting")).toBeInTheDocument();
   });
 
-  it("shows Restart option in menu for unreachable projects", async () => {
-    mockProjects = [{ id: "p11", name: "unreachable-proj", status: "unreachable" }];
+  it("does not show Restart option for starting projects", async () => {
+    mockProjects = [{ id: "p10", name: "starting-proj", status: "starting" }];
     renderWithProviders(<ProjectDashboard />);
     await userEvent.click(screen.getByRole("button", { name: /actions/ }));
-    expect(screen.getByText("Restart")).toBeInTheDocument();
+    expect(screen.queryByText("Restart")).not.toBeInTheDocument();
   });
 
   it("does not show Restart option for running projects (explicit)", async () => {
@@ -145,15 +141,8 @@ describe("ProjectDashboard", () => {
     expect(deleteMutate).toHaveBeenCalledWith("p1");
   });
 
-  it("shows Restart option in menu for stopped projects", async () => {
-    mockProjects = [{ id: "p5", name: "stopped-proj", status: "stopped" }];
-    renderWithProviders(<ProjectDashboard />);
-    await userEvent.click(screen.getByRole("button", { name: /actions/ }));
-    expect(screen.getByText("Restart")).toBeInTheDocument();
-  });
-
   it("shows Restart option in menu for error projects", async () => {
-    mockProjects = [{ id: "p6", name: "error-proj", status: "error" }];
+    mockProjects = [{ id: "p5", name: "errored-proj", status: "error" }];
     renderWithProviders(<ProjectDashboard />);
     await userEvent.click(screen.getByRole("button", { name: /actions/ }));
     expect(screen.getByText("Restart")).toBeInTheDocument();
@@ -167,7 +156,7 @@ describe("ProjectDashboard", () => {
   });
 
   it("calls restartProject.mutate when clicking Restart in menu", async () => {
-    mockProjects = [{ id: "p7", name: "restart-me", status: "stopped" }];
+    mockProjects = [{ id: "p7", name: "restart-me", status: "error" }];
     renderWithProviders(<ProjectDashboard />);
 
     await userEvent.click(screen.getByRole("button", { name: /actions/ }));
@@ -176,7 +165,7 @@ describe("ProjectDashboard", () => {
   });
 
   it("shows Restarting... text while restart is in progress", async () => {
-    mockProjects = [{ id: "p8", name: "restarting-proj", status: "stopped" }];
+    mockProjects = [{ id: "p8", name: "restarting-proj", status: "error" }];
     renderWithProviders(<ProjectDashboard />);
 
     await userEvent.click(screen.getByRole("button", { name: /actions/ }));

--- a/src/routes/projects.test.ts
+++ b/src/routes/projects.test.ts
@@ -43,12 +43,13 @@ describe("POST /api/projects", () => {
     expect(res.status).toBe(422);
   });
 
-  it("lists created project", async () => {
+  it("lists created project with running status", async () => {
     await request("POST", "/api/projects", { name: "listed" });
     const res = await request("GET", "/api/projects");
     const data = (await res.json()) as Array<Record<string, unknown>>;
     expect(data.length).toBe(1);
     expect(data[0].name).toBe("listed");
+    expect(data[0].status).toBe("running");
   });
 });
 

--- a/src/runtime/project-manager.ts
+++ b/src/runtime/project-manager.ts
@@ -4,8 +4,11 @@ import { Coordinator } from "./coordinator";
 import * as projectsService from "../services/projects";
 import * as workspace from "../services/workspace";
 
+export type ProjectStatus = "starting" | "running" | "error";
+
 export class ProjectManager {
   private coordinators = new Map<string, Coordinator>();
+  private statuses = new Map<string, ProjectStatus>();
 
   async boot(): Promise<void> {
     const projects = projectsService.listProjects();
@@ -42,6 +45,7 @@ export class ProjectManager {
       coordinator.stopAll();
       this.coordinators.delete(id);
     }
+    this.statuses.delete(id);
 
     // Remove workspace
     try {
@@ -67,14 +71,14 @@ export class ProjectManager {
       this.coordinators.delete(id);
     }
 
-    await this.bootProject(id);
+    const ok = await this.bootProject(id);
 
     bus.emit("projects:lobby", {
       type: "project_restarted",
       payload: { id },
     });
 
-    return true;
+    return ok;
   }
 
   renameProject(id: string, name: string): ReturnType<typeof projectsService.renameProject> {
@@ -95,21 +99,30 @@ export class ProjectManager {
   listProjects(): Array<{
     id: string;
     name: string;
-    status: "running" | "stopped";
+    status: ProjectStatus;
   }> {
     const projects = projectsService.listProjects();
     return projects.map((p) => ({
       id: p.id,
       name: p.name,
-      status: this.coordinators.has(p.id) ? ("running" as const) : ("stopped" as const),
+      status: this.statuses.get(p.id) ?? "starting",
     }));
   }
 
   // --- Private ---
 
-  private async bootProject(projectId: string): Promise<void> {
-    const coordinator = new Coordinator(projectId);
-    this.coordinators.set(projectId, coordinator);
-    await coordinator.deployAndScan();
+  private async bootProject(projectId: string): Promise<boolean> {
+    this.statuses.set(projectId, "starting");
+    try {
+      const coordinator = new Coordinator(projectId);
+      this.coordinators.set(projectId, coordinator);
+      await coordinator.deployAndScan();
+      this.statuses.set(projectId, "running");
+      return true;
+    } catch (err) {
+      this.statuses.set(projectId, "error");
+      console.error(`ProjectManager: failed to boot project ${projectId}:`, err);
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Replace binary `running`/`stopped` project status with a proper state machine tracking `starting`, `running`, and `error` states in `ProjectManager`
- Narrow frontend `Project.status` type to match the three valid states
- Show Restart button only for projects in `error` state (not during `starting`)
- Fix pre-existing eslint warnings in `useSubscriptions` hook

## Test plan
- [x] Backend tests pass (`bun test`) — 128 tests
- [x] Frontend tests pass (`bun run test:frontend`) — 207 tests
- [x] TypeScript compiles cleanly (`bun run typecheck`)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [ ] Manual: create a project, verify it shows "starting" briefly then "running"
- [ ] Manual: kill a coordinator process, verify project shows "error" with Restart option

🤖 Generated with [Claude Code](https://claude.com/claude-code)