### PR TITLE
Replace all sync fs operations with async equivalents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { ProjectManager } from "./runtime/project-manager";
 import { Scheduler } from "./runtime/scheduler";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { existsSync, readFileSync } from "fs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
@@ -62,7 +61,7 @@ async function main() {
       if (DEV) {
         return proxyToVite(req, url);
       }
-      return serveStatic(url);
+      return await serveStatic(url);
     },
     websocket: {
       message(ws, message) {
@@ -101,23 +100,24 @@ async function proxyToVite(req: Request, url: URL): Promise<Response> {
 }
 
 // Production: serve pre-built frontend static files
-function serveStatic(url: URL): Response {
+async function serveStatic(url: URL): Promise<Response> {
   let filePath = join(FRONTEND_DIST, url.pathname);
 
   // SPA fallback: serve index.html for non-file routes
-  if (!existsSync(filePath) || !filePath.includes(".")) {
+  const file = Bun.file(filePath);
+  if (!(await file.exists()) || !filePath.includes(".")) {
     filePath = join(FRONTEND_DIST, "index.html");
   }
 
-  if (!existsSync(filePath)) {
+  const indexFile = Bun.file(filePath);
+  if (!(await indexFile.exists())) {
     return new Response("Not Found", { status: 404 });
   }
 
-  const file = readFileSync(filePath);
   const ext = filePath.split(".").pop() ?? "";
   const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
 
-  return new Response(file, {
+  return new Response(indexFile, {
     headers: { "Content-Type": contentType },
   });
 }

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -24,12 +24,12 @@ export const agentRoutes = new Hono<AppEnv>()
       return c.json({ id: result.agentId }, 201);
     },
   )
-  .get("/projects/:id/agents/:aid", (c) => {
+  .get("/projects/:id/agents/:aid", async (c) => {
     const pm = c.get("projectManager");
     const coordinator = pm.getCoordinator(c.req.param("id"));
     if (!coordinator) return c.json({ error: "Project not found" }, 404);
 
-    const detail = coordinator.getAgentDetail(c.req.param("aid"));
+    const detail = await coordinator.getAgentDetail(c.req.param("aid"));
     if (!detail) return c.json({ error: "Agent not found" }, 404);
     return c.json(detail);
   })

--- a/src/routes/attachments.ts
+++ b/src/routes/attachments.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { readFileSync, existsSync } from "fs";
+import { readFile, access } from "fs/promises";
 import { basename } from "path";
 import * as workspace from "../services/workspace";
 import * as projectsService from "../services/projects";
@@ -7,7 +7,7 @@ import type { AppEnv } from "../types";
 
 export const attachmentRoutes = new Hono<AppEnv>().get(
   "/projects/:id/agents/:aid/attachments/:attId/:filename",
-  (c) => {
+  async (c) => {
     const projectIdParam = c.req.param("id");
     const agentId = c.req.param("aid");
     const attId = c.req.param("attId");
@@ -23,12 +23,14 @@ export const attachmentRoutes = new Hono<AppEnv>().get(
 
     const filePath = workspace.attachmentPath(projectId, agentId, attId, filename);
 
-    if (!existsSync(filePath)) {
+    try {
+      await access(filePath);
+    } catch {
       return c.json({ error: "Attachment not found" }, 404);
     }
 
     try {
-      const data = readFileSync(filePath);
+      const data = await readFile(filePath);
       return new Response(data, {
         headers: {
           "Content-Disposition": `attachment; filename="${basename(filename)}"`,

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -8,16 +8,16 @@ export const catalogRoutes = new Hono<AppEnv>()
   .get(
     "/catalog/agents",
     zValidator("query", z.object({ category: z.string().optional() })),
-    (c) => {
+    async (c) => {
       const { category } = c.req.valid("query");
-      return c.json(catalog.listAgents(category ?? undefined));
+      return c.json(await catalog.listAgents(category ?? undefined));
     },
   )
-  .get("/catalog/agents/:name", (c) => {
-    const agent = catalog.getAgent(c.req.param("name"));
+  .get("/catalog/agents/:name", async (c) => {
+    const agent = await catalog.getAgent(c.req.param("name"));
     if (!agent) return c.json({ error: "Agent not found" }, 404);
     return c.json(agent);
   })
-  .get("/catalog/categories", (c) => {
-    return c.json(catalog.listCategories());
+  .get("/catalog/categories", async (c) => {
+    return c.json(await catalog.listCategories());
   });

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -15,15 +15,15 @@ function resolveProjectId(nameOrId: string): string | null {
 const contentSchema = z.object({ content: z.string() });
 
 export const settingsRoutes = new Hono<AppEnv>()
-  .get("/projects/:id/settings/project-doc", (c) => {
+  .get("/projects/:id/settings/project-doc", async (c) => {
     const projectId = resolveProjectId(c.req.param("id"));
     if (!projectId) return c.json({ error: "Project not found" }, 404);
-    return c.json({ content: settings.readProjectDoc(projectId) });
+    return c.json({ content: await settings.readProjectDoc(projectId) });
   })
-  .put("/projects/:id/settings/project-doc", zValidator("json", contentSchema), (c) => {
+  .put("/projects/:id/settings/project-doc", zValidator("json", contentSchema), async (c) => {
     const projectId = resolveProjectId(c.req.param("id"));
     if (!projectId) return c.json({ error: "Project not found" }, 404);
     const { content } = c.req.valid("json");
-    settings.writeProjectDoc(projectId, content);
+    await settings.writeProjectDoc(projectId, content);
     return c.json({ ok: true });
   });

--- a/src/routes/shared-drive.ts
+++ b/src/routes/shared-drive.ts
@@ -1,15 +1,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import {
-  readdirSync,
-  statSync,
-  readFileSync,
-  mkdirSync,
-  unlinkSync,
-  rmSync,
-  writeFileSync,
-} from "fs";
+import { readdir, stat, readFile, mkdir, unlink, rm, writeFile } from "fs/promises";
 import { join, resolve, basename } from "path";
 import * as workspace from "../services/workspace";
 import * as projectsService from "../services/projects";
@@ -34,7 +26,7 @@ const pathQuery = z.object({ path: z.string().optional() });
 const requiredPathQuery = z.object({ path: z.string() });
 
 export const sharedDriveRoutes = new Hono<AppEnv>()
-  .get("/projects/:id/shared-drive", zValidator("query", pathQuery), (c) => {
+  .get("/projects/:id/shared-drive", zValidator("query", pathQuery), async (c) => {
     const projectId = resolveProjectId(c.req.param("id"));
     if (!projectId) return c.json({ error: "Project not found" }, 404);
 
@@ -44,18 +36,20 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
     if (!fullPath) return c.json({ error: "Invalid path" }, 400);
 
     try {
-      mkdirSync(sharedRoot, { recursive: true });
-      const entries = readdirSync(fullPath, { withFileTypes: true });
-      const files = entries.map((entry) => {
-        const entryPath = join(fullPath, entry.name);
-        const stat = statSync(entryPath);
-        return {
-          name: entry.name,
-          path: join(path, entry.name),
-          type: entry.isDirectory() ? ("directory" as const) : ("file" as const),
-          size: stat.size,
-        };
-      });
+      await mkdir(sharedRoot, { recursive: true });
+      const entries = await readdir(fullPath, { withFileTypes: true });
+      const files = await Promise.all(
+        entries.map(async (entry) => {
+          const entryPath = join(fullPath, entry.name);
+          const s = await stat(entryPath);
+          return {
+            name: entry.name,
+            path: join(path, entry.name),
+            type: entry.isDirectory() ? ("directory" as const) : ("file" as const),
+            size: s.size,
+          };
+        }),
+      );
       return c.json({ files, currentPath: path });
     } catch {
       return c.json({
@@ -69,7 +63,7 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
       });
     }
   })
-  .get("/projects/:id/shared-drive/preview", zValidator("query", requiredPathQuery), (c) => {
+  .get("/projects/:id/shared-drive/preview", zValidator("query", requiredPathQuery), async (c) => {
     const projectId = resolveProjectId(c.req.param("id"));
     if (!projectId) return c.json({ error: "Project not found" }, 404);
 
@@ -80,17 +74,17 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
     if (!fullPath) return c.json({ error: "Invalid path" }, 400);
 
     try {
-      const stat = statSync(fullPath);
-      if (stat.size > 1024 * 1024) {
+      const s = await stat(fullPath);
+      if (s.size > 1024 * 1024) {
         return c.json({ error: "File too large for preview" }, 413);
       }
-      const content = readFileSync(fullPath, "utf-8");
-      return c.json({ content, filename: basename(fullPath), size: stat.size });
+      const content = await readFile(fullPath, "utf-8");
+      return c.json({ content, filename: basename(fullPath), size: s.size });
     } catch {
       return c.json({ error: "File not found" }, 404);
     }
   })
-  .get("/projects/:id/shared-drive/download", zValidator("query", requiredPathQuery), (c) => {
+  .get("/projects/:id/shared-drive/download", zValidator("query", requiredPathQuery), async (c) => {
     const projectId = resolveProjectId(c.req.param("id"));
     if (!projectId) return c.json({ error: "Project not found" }, 404);
 
@@ -101,7 +95,7 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
     if (!fullPath) return c.json({ error: "Invalid path" }, 400);
 
     try {
-      const data = readFileSync(fullPath);
+      const data = await readFile(fullPath);
       const filename = basename(fullPath);
       return new Response(data, {
         headers: {
@@ -116,7 +110,7 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
   .post(
     "/projects/:id/shared-drive/directory",
     zValidator("json", z.object({ name: z.string(), path: z.string().optional() })),
-    (c) => {
+    async (c) => {
       const projectId = resolveProjectId(c.req.param("id"));
       if (!projectId) return c.json({ error: "Project not found" }, 404);
 
@@ -125,7 +119,7 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
       const fullPath = safePath(sharedRoot, join(parentPath ?? "/", name));
       if (!fullPath) return c.json({ error: "Invalid path" }, 400);
 
-      mkdirSync(fullPath, { recursive: true });
+      await mkdir(fullPath, { recursive: true });
       return c.json({ ok: true }, 201);
     },
   )
@@ -135,7 +129,7 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
       "json",
       z.object({ name: z.string(), content: z.string(), path: z.string().optional() }),
     ),
-    (c) => {
+    async (c) => {
       const projectId = resolveProjectId(c.req.param("id"));
       if (!projectId) return c.json({ error: "Project not found" }, 404);
 
@@ -145,11 +139,11 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
       if (!fullPath) return c.json({ error: "Invalid path" }, 400);
 
       const decoded = Buffer.from(content, "base64");
-      writeFileSync(fullPath, decoded);
+      await writeFile(fullPath, decoded);
       return c.json({ ok: true }, 201);
     },
   )
-  .delete("/projects/:id/shared-drive", zValidator("query", requiredPathQuery), (c) => {
+  .delete("/projects/:id/shared-drive", zValidator("query", requiredPathQuery), async (c) => {
     const projectId = resolveProjectId(c.req.param("id"));
     if (!projectId) return c.json({ error: "Project not found" }, 404);
 
@@ -160,11 +154,11 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
     if (!fullPath) return c.json({ error: "Invalid path" }, 400);
 
     try {
-      const stat = statSync(fullPath);
-      if (stat.isDirectory()) {
-        rmSync(fullPath, { recursive: true, force: true });
+      const s = await stat(fullPath);
+      if (s.isDirectory()) {
+        await rm(fullPath, { recursive: true, force: true });
       } else {
-        unlinkSync(fullPath);
+        await unlink(fullPath);
       }
       return c.json({ ok: true });
     } catch {

--- a/src/runtime/agent-manager.test.ts
+++ b/src/runtime/agent-manager.test.ts
@@ -258,12 +258,12 @@ describe("AgentManager", () => {
 
   describe("workspace setup", () => {
     it("creates agent directories on start", async () => {
-      workspace.ensureProjectDirs(projectId);
+      await workspace.ensureProjectDirs(projectId);
       createManager();
 
       // setupWorkspace is called during start(), which also tries to start the harness
       // For a unit test, we verify ensureAgentDirs creates the right structure
-      workspace.ensureAgentDirs(projectId, agentId);
+      await workspace.ensureAgentDirs(projectId, agentId);
 
       const agentDir = workspace.agentDir(projectId, agentId);
       expect(existsSync(join(agentDir, "inbox"))).toBe(true);

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -1,6 +1,5 @@
 import { watch, type FSWatcher } from "fs";
-import { readFile, readdir, rename, unlink, writeFile, mkdir, stat } from "fs/promises";
-import { readFileSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { readFile, readdir, rename, unlink, writeFile, mkdir, stat, rm } from "fs/promises";
 import { join } from "path";
 import yaml from "js-yaml";
 import { safeYamlLoad } from "../utils/yaml";
@@ -282,7 +281,7 @@ export class AgentManager {
   // --- Harness setup ---
 
   private async startHarness(): Promise<void> {
-    const recipe = this.readRecipe();
+    const recipe = await this.readRecipe();
     const harnessType = (recipe?.harness as HarnessType) ?? "claude_code";
     const model = (recipe?.model as string) ?? "claude-sonnet-4-6";
     const systemPrompt = (recipe?.system_prompt as string) ?? "";
@@ -767,26 +766,26 @@ export class AgentManager {
   // --- Workspace setup ---
 
   private async setupWorkspace(): Promise<void> {
-    workspace.ensureAgentDirs(this.projectId, this.agentId);
+    await workspace.ensureAgentDirs(this.projectId, this.agentId);
     const agentDir = workspace.agentDir(this.projectId, this.agentId);
-    mkdirSync(join(agentDir, ".claude", "skills"), { recursive: true });
+    await mkdir(join(agentDir, ".claude", "skills"), { recursive: true });
 
-    const recipe = this.readRecipe();
+    const recipe = await this.readRecipe();
     if (recipe?.skills && Array.isArray(recipe.skills)) {
-      this.deploySkills(recipe);
+      await this.deploySkills(recipe);
     }
   }
 
-  private readRecipe(): Record<string, unknown> | null {
+  private async readRecipe(): Promise<Record<string, unknown> | null> {
     try {
-      const content = readFileSync(workspace.recipePath(this.projectId, this.agentId), "utf-8");
+      const content = await readFile(workspace.recipePath(this.projectId, this.agentId), "utf-8");
       return safeYamlLoad(content) as Record<string, unknown>;
     } catch {
       return null;
     }
   }
 
-  private deploySkills(recipe: Record<string, unknown>): void {
+  private async deploySkills(recipe: Record<string, unknown>): Promise<void> {
     const skills = recipe.skills as Array<Record<string, unknown>>;
     const harnessType = (recipe.harness as string) ?? "claude_code";
     const agentDir = workspace.agentDir(this.projectId, this.agentId);
@@ -795,19 +794,15 @@ export class AgentManager {
         ? join(agentDir, ".claude", "skills")
         : join(agentDir, ".pi", "agent", "skills");
 
-    try {
-      rmSync(skillBase, { recursive: true, force: true });
-    } catch {
-      /* ok */
-    }
+    await rm(skillBase, { recursive: true, force: true }).catch(() => {});
 
     for (const skill of skills) {
       const skillDir = join(skillBase, skill.name as string);
-      mkdirSync(skillDir, { recursive: true });
+      await mkdir(skillDir, { recursive: true });
       const skillMd = `---\nname: ${skill.name}\ndescription: ${skill.description}\n---\n\n${skill.content}\n`;
-      writeFileSync(join(skillDir, "SKILL.md"), skillMd, "utf-8");
+      await writeFile(join(skillDir, "SKILL.md"), skillMd, "utf-8");
       for (const ref of (skill.references as Array<Record<string, string>>) ?? []) {
-        writeFileSync(join(skillDir, ref.name), ref.content, "utf-8");
+        await writeFile(join(skillDir, ref.name), ref.content, "utf-8");
       }
     }
   }

--- a/src/runtime/coordinator.test.ts
+++ b/src/runtime/coordinator.test.ts
@@ -153,8 +153,8 @@ describe("listAgentStatuses", () => {
 });
 
 describe("getAgentDetail", () => {
-  it("returns null for nonexistent agent", () => {
-    expect(coordinator.getAgentDetail("nonexistent")).toBeNull();
+  it("returns null for nonexistent agent", async () => {
+    expect(await coordinator.getAgentDetail("nonexistent")).toBeNull();
   });
 
   it("returns agent detail with recipe fields", async () => {
@@ -165,7 +165,7 @@ describe("getAgentDetail", () => {
     });
     if (!result.ok) return;
 
-    const detail = coordinator.getAgentDetail(result.agentId);
+    const detail = await coordinator.getAgentDetail(result.agentId);
     expect(detail).not.toBeNull();
     expect(detail!.name).toBe("detail-agent");
     expect(detail!.description).toBe("A test");
@@ -210,6 +210,10 @@ describe("routeMessage (inter-agent)", () => {
     expect(receiverResult.ok).toBe(true);
     if (!senderResult.ok || !receiverResult.ok) return;
 
+    // Stop the receiver so its inbox watcher doesn't consume the file
+    const receiverProc = coordinator.getAgent(receiverResult.agentId);
+    await receiverProc?.stop();
+
     // Trigger the outbox event that the coordinator listens on
     bus.emit(`project:${projectId}:outbox`, {
       type: "outbox_message",
@@ -220,6 +224,9 @@ describe("routeMessage (inter-agent)", () => {
         text: "hello from sender",
       },
     });
+
+    // Wait for async routeMessage to complete
+    await new Promise((r) => setTimeout(r, 200));
 
     // Check that a YAML file was written to receiver's inbox
     const inboxDir = workspace.inboxDir(projectId, receiverResult.agentId);
@@ -258,6 +265,9 @@ describe("routeMessage (inter-agent)", () => {
       },
     });
 
+    // Wait for async routeMessage to complete
+    await new Promise((r) => setTimeout(r, 200));
+
     // Sender should have no inter-agent messages in their history
     const { messages: senderMessages } = agentsService.listMessages(
       projectId,
@@ -275,6 +285,10 @@ describe("routeMessage (inter-agent)", () => {
     expect(senderResult.ok).toBe(true);
     if (!senderResult.ok) return;
 
+    // Stop the sender so its inbox watcher doesn't consume the error file
+    const senderProc = coordinator.getAgent(senderResult.agentId);
+    await senderProc?.stop();
+
     bus.emit(`project:${projectId}:outbox`, {
       type: "outbox_message",
       payload: {
@@ -284,6 +298,9 @@ describe("routeMessage (inter-agent)", () => {
         text: "hello?",
       },
     });
+
+    // Wait for async routeMessage to complete
+    await new Promise((r) => setTimeout(r, 200));
 
     const inboxDir = workspace.inboxDir(projectId, senderResult.agentId);
     const errorFile = readdirSync(inboxDir).find((f) => f.endsWith("-error.yaml"));

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, rmSync, readFileSync } from "fs";
+import { writeFile, rm, readFile } from "fs/promises";
 import { join } from "path";
 import yaml from "js-yaml";
 import { safeYamlLoad } from "../utils/yaml";
@@ -26,7 +26,9 @@ export class Coordinator {
           toAgentName: string;
           text: string;
         };
-        this.routeMessage(p.fromAgentId, p.fromAgentName, p.toAgentName, p.text);
+        this.routeMessage(p.fromAgentId, p.fromAgentName, p.toAgentName, p.text).catch((err) =>
+          console.error("routeMessage error:", err),
+        );
       }
     });
 
@@ -37,7 +39,9 @@ export class Coordinator {
         const agent = agentsService.getAgentByName(projectId, p.name);
         if (agent) {
           const proc = this.agents.get(agent.id);
-          if (proc) proc.restart();
+          if (proc) {
+            proc.restart().catch((err) => console.error("spawn_agent restart error:", err));
+          }
         }
       }
     });
@@ -46,14 +50,14 @@ export class Coordinator {
   async deployAndScan(): Promise<void> {
     if (this.deployed) return;
 
-    workspace.ensureProjectDirs(this.projectId);
+    await workspace.ensureProjectDirs(this.projectId);
 
     const dbAgents = agentsService.listAgents(this.projectId);
     for (const agent of dbAgents) {
       await this.startAgentManager(agent.id, agent.name);
     }
 
-    this.writePeersYaml();
+    await this.writePeersYaml();
     this.deployed = true;
   }
 
@@ -79,12 +83,12 @@ export class Coordinator {
     const agent = agentsService.createAgent(this.projectId, params.name);
 
     // Write recipe.yaml
-    workspace.ensureAgentDirs(this.projectId, agent.id);
-    writeFileSync(workspace.recipePath(this.projectId, agent.id), params.recipeYaml, "utf-8");
+    await workspace.ensureAgentDirs(this.projectId, agent.id);
+    await writeFile(workspace.recipePath(this.projectId, agent.id), params.recipeYaml, "utf-8");
 
     // Start process
     await this.startAgentManager(agent.id, agent.name);
-    this.writePeersYaml();
+    await this.writePeersYaml();
 
     bus.emit(`project:${this.projectId}:agents`, {
       type: "agent_created",
@@ -109,13 +113,13 @@ export class Coordinator {
     }
 
     // Write updated recipe
-    writeFileSync(workspace.recipePath(this.projectId, agentId), params.recipeYaml, "utf-8");
+    await writeFile(workspace.recipePath(this.projectId, agentId), params.recipeYaml, "utf-8");
 
     // Restart the agent
     const proc = this.agents.get(agentId);
     if (proc) await proc.restart();
 
-    this.writePeersYaml();
+    await this.writePeersYaml();
 
     bus.emit(`project:${this.projectId}:agents`, {
       type: "agent_updated",
@@ -135,15 +139,11 @@ export class Coordinator {
 
     // Delete workspace
     const agentDir = workspace.agentDir(this.projectId, agentId);
-    try {
-      rmSync(agentDir, { recursive: true, force: true });
-    } catch {
-      // ok
-    }
+    await rm(agentDir, { recursive: true, force: true }).catch(() => {});
 
     // Delete DB record (cascades messages)
     agentsService.deleteAgent(agentId);
-    this.writePeersYaml();
+    await this.writePeersYaml();
 
     bus.emit(`project:${this.projectId}:agents`, {
       type: "agent_deleted",
@@ -200,11 +200,11 @@ export class Coordinator {
     return result.sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  getAgentDetail(agentId: string): Record<string, unknown> | null {
+  async getAgentDetail(agentId: string): Promise<Record<string, unknown> | null> {
     const proc = this.agents.get(agentId);
     if (!proc) return null;
 
-    const recipe = this.readRecipe(agentId);
+    const recipe = await this.readRecipe(agentId);
     return {
       id: agentId,
       name: proc.agentName,
@@ -247,12 +247,12 @@ export class Coordinator {
     await proc.start();
   }
 
-  private routeMessage(
+  private async routeMessage(
     fromAgentId: string,
     fromAgentName: string,
     toAgentName: string,
     text: string,
-  ): void {
+  ): Promise<void> {
     const targetAgent = agentsService.getAgentByName(this.projectId, toAgentName);
     if (!targetAgent) {
       console.warn(`Inter-agent message from ${fromAgentName} to unknown agent ${toAgentName}`);
@@ -269,11 +269,7 @@ export class Coordinator {
         };
         const filename = `${Date.now()}-error.yaml`;
         const inboxPath = join(workspace.inboxDir(this.projectId, fromAgentId), filename);
-        try {
-          writeFileSync(inboxPath, yaml.dump(errorEnvelope), "utf-8");
-        } catch {
-          // ok
-        }
+        await writeFile(inboxPath, yaml.dump(errorEnvelope), "utf-8").catch(() => {});
       }
       return;
     }
@@ -293,22 +289,22 @@ export class Coordinator {
     };
     const filename = `${Date.now()}-${fromAgentName}.yaml`;
     const inboxPath = join(workspace.inboxDir(this.projectId, targetAgent.id), filename);
-    writeFileSync(inboxPath, yaml.dump(envelope), "utf-8");
+    await writeFile(inboxPath, yaml.dump(envelope), "utf-8");
   }
 
-  private readRecipe(agentId: string): Record<string, unknown> | null {
+  private async readRecipe(agentId: string): Promise<Record<string, unknown> | null> {
     try {
-      const content = readFileSync(workspace.recipePath(this.projectId, agentId), "utf-8");
+      const content = await readFile(workspace.recipePath(this.projectId, agentId), "utf-8");
       return safeYamlLoad(content) as Record<string, unknown>;
     } catch {
       return null;
     }
   }
 
-  private writePeersYaml(): void {
+  private async writePeersYaml(): Promise<void> {
     const peers: Array<Record<string, string>> = [];
     for (const [id, proc] of this.agents) {
-      const recipe = this.readRecipe(id);
+      const recipe = await this.readRecipe(id);
       peers.push({
         id,
         name: proc.agentName,
@@ -317,6 +313,6 @@ export class Coordinator {
     }
 
     const peersPath = workspace.peersPath(this.projectId);
-    writeFileSync(peersPath, yaml.dump(peers), "utf-8");
+    await writeFile(peersPath, yaml.dump(peers), "utf-8");
   }
 }

--- a/src/runtime/project-manager.ts
+++ b/src/runtime/project-manager.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "fs";
+import { rm } from "fs/promises";
 import { bus } from "../events";
 import { Coordinator } from "./coordinator";
 import * as projectsService from "../services/projects";
@@ -48,11 +48,7 @@ export class ProjectManager {
     this.statuses.delete(id);
 
     // Remove workspace
-    try {
-      rmSync(workspace.root(id), { recursive: true, force: true });
-    } catch {
-      // ok
-    }
+    await rm(workspace.root(id), { recursive: true, force: true }).catch(() => {});
 
     projectsService.deleteProject(id);
 

--- a/src/scripts/catalog-sync.ts
+++ b/src/scripts/catalog-sync.ts
@@ -5,7 +5,7 @@
  * Usage:
  *   bun run src/scripts/catalog-sync.ts [--repo URL] [--clear]
  */
-import { mkdirSync, rmSync, readdirSync, statSync, readFileSync, writeFileSync } from "fs";
+import { mkdir, rm, readdir, stat, readFile, writeFile } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { tmpdir } from "os";
@@ -103,7 +103,7 @@ async function main() {
 
   if (clear) {
     console.log("Clearing existing catalog...");
-    rmSync(CATALOG_DIR, { recursive: true, force: true });
+    await rm(CATALOG_DIR, { recursive: true, force: true });
   }
 
   const tmpDir = join(tmpdir(), `catalog_sync_${Date.now()}`);
@@ -117,40 +117,41 @@ async function main() {
     }
 
     // Find category dirs (dirs containing .md files, excluding skip list)
-    const entries = readdirSync(tmpDir);
-    const categories = entries.filter((entry) => {
-      if (SKIP_DIRS.has(entry)) return false;
+    const entries = await readdir(tmpDir);
+    const categories: string[] = [];
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry)) continue;
       const path = join(tmpDir, entry);
-      if (!statSync(path).isDirectory()) return false;
-      return readdirSync(path).some((f) => f.endsWith(".md"));
-    });
+      if (!(await stat(path)).isDirectory()) continue;
+      const contents = await readdir(path);
+      if (contents.some((f) => f.endsWith(".md"))) categories.push(entry);
+    }
 
     let agentsCount = 0;
 
     for (const category of categories) {
       const categoryPath = join(tmpDir, category);
       const outDir = join(CATALOG_DIR, "agents", category);
-      mkdirSync(outDir, { recursive: true });
+      await mkdir(outDir, { recursive: true });
 
-      const mdFiles = readdirSync(categoryPath).filter(
-        (f) => f.endsWith(".md") && f !== "README.md",
-      );
+      const allFiles = await readdir(categoryPath);
+      const mdFiles = allFiles.filter((f) => f.endsWith(".md") && f !== "README.md");
 
       for (const file of mdFiles) {
-        const content = readFileSync(join(categoryPath, file), "utf-8");
+        const content = await readFile(join(categoryPath, file), "utf-8");
         const { frontmatter, body } = parseFrontmatter(content);
 
         if (frontmatter.name) {
           const agentYaml = buildAgentYaml(frontmatter, body, category);
           const yamlContent = encodeAgentYaml(agentYaml);
-          writeFileSync(join(outDir, `${agentYaml.name}.yaml`), yamlContent);
+          await writeFile(join(outDir, `${agentYaml.name}.yaml`), yamlContent);
           agentsCount++;
         }
       }
     }
 
     // Write categories.yaml
-    mkdirSync(CATALOG_DIR, { recursive: true });
+    await mkdir(CATALOG_DIR, { recursive: true });
     const categoryMaps = categories.map((cat) => ({
       id: cat,
       name: cat
@@ -166,11 +167,11 @@ async function main() {
         .map((c) => `- id: ${c.id}\n  name: "${c.name}"\n  description: "${c.description}"`)
         .join("\n") + "\n";
 
-    writeFileSync(join(CATALOG_DIR, "categories.yaml"), categoriesYaml);
+    await writeFile(join(CATALOG_DIR, "categories.yaml"), categoriesYaml);
 
     console.log(`Synced ${agentsCount} agents across ${categories.length} categories`);
   } finally {
-    rmSync(tmpDir, { recursive: true, force: true });
+    await rm(tmpDir, { recursive: true, force: true });
   }
 }
 

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, existsSync } from "fs";
+import { readFile, readdir, access } from "fs/promises";
 import { join, basename, dirname } from "path";
 import { fileURLToPath } from "url";
 import { safeYamlLoad } from "../utils/yaml";
@@ -27,28 +27,39 @@ function catalogDir(): string {
   return join(__dirname, "..", "..", "catalog");
 }
 
-export function listCategories(): CatalogCategory[] {
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listCategories(): Promise<CatalogCategory[]> {
   const path = join(catalogDir(), "categories.yaml");
-  if (!existsSync(path)) return [];
-  const content = readFileSync(path, "utf-8");
+  if (!(await fileExists(path))) return [];
+  const content = await readFile(path, "utf-8");
   const data = safeYamlLoad(content) as CatalogCategory[];
   return data ?? [];
 }
 
-export function listAgents(category?: string): CatalogAgent[] {
+export async function listAgents(category?: string): Promise<CatalogAgent[]> {
   const agentsDir = join(catalogDir(), "agents");
-  if (!existsSync(agentsDir)) return [];
+  if (!(await fileExists(agentsDir))) return [];
 
   const result: CatalogAgent[] = [];
-  const categories = readdirSync(agentsDir, { withFileTypes: true }).filter((d) => d.isDirectory());
+  const entries = await readdir(agentsDir, { withFileTypes: true });
+  const categories = entries.filter((d) => d.isDirectory());
 
   for (const cat of categories) {
     if (category && cat.name !== category) continue;
     const catDir = join(agentsDir, cat.name);
-    const files = readdirSync(catDir).filter((f) => f.endsWith(".yaml"));
+    const allFiles = await readdir(catDir);
+    const files = allFiles.filter((f) => f.endsWith(".yaml"));
 
     for (const file of files) {
-      const content = readFileSync(join(catDir, file), "utf-8");
+      const content = await readFile(join(catDir, file), "utf-8");
       const data = safeYamlLoad(content) as Record<string, unknown>;
       if (!data) continue;
 
@@ -69,14 +80,14 @@ export function listAgents(category?: string): CatalogAgent[] {
   return result;
 }
 
-export function getAgent(name: string): CatalogAgent | null {
-  const allAgents = listAgents();
+export async function getAgent(name: string): Promise<CatalogAgent | null> {
+  const allAgents = await listAgents();
   return allAgents.find((a) => a.name === name) ?? null;
 }
 
-export function searchAgents(query: string): CatalogAgent[] {
+export async function searchAgents(query: string): Promise<CatalogAgent[]> {
   const q = query.toLowerCase();
-  return listAgents().filter(
+  return (await listAgents()).filter(
     (a) =>
       a.displayName.toLowerCase().includes(q) ||
       a.description.toLowerCase().includes(q) ||

--- a/src/services/workspace-settings.test.ts
+++ b/src/services/workspace-settings.test.ts
@@ -8,10 +8,10 @@ import * as workspace from "./workspace";
 const PROJECT_ID = "ws-test-project";
 let testDir: string;
 
-beforeEach(() => {
+beforeEach(async () => {
   testDir = join(tmpdir(), `ws_settings_${Date.now()}_${Math.random().toString(36).slice(2)}`);
   process.env.SHIRE_PROJECTS_DIR = testDir;
-  workspace.ensureProjectDirs(PROJECT_ID);
+  await workspace.ensureProjectDirs(PROJECT_ID);
 });
 
 afterEach(() => {
@@ -20,19 +20,19 @@ afterEach(() => {
 
 describe("workspace settings", () => {
   describe("readProjectDoc", () => {
-    it("returns content when PROJECT.md exists", () => {
+    it("returns content when PROJECT.md exists", async () => {
       writeFileSync(workspace.projectDocPath(PROJECT_ID), "# My Project\n");
-      expect(settings.readProjectDoc(PROJECT_ID)).toBe("# My Project\n");
+      expect(await settings.readProjectDoc(PROJECT_ID)).toBe("# My Project\n");
     });
 
-    it("returns empty string when PROJECT.md does not exist", () => {
-      expect(settings.readProjectDoc(PROJECT_ID)).toBe("");
+    it("returns empty string when PROJECT.md does not exist", async () => {
+      expect(await settings.readProjectDoc(PROJECT_ID)).toBe("");
     });
   });
 
   describe("writeProjectDoc", () => {
-    it("writes content to PROJECT.md", () => {
-      settings.writeProjectDoc(PROJECT_ID, "# Updated");
+    it("writes content to PROJECT.md", async () => {
+      await settings.writeProjectDoc(PROJECT_ID, "# Updated");
       expect(readFileSync(workspace.projectDocPath(PROJECT_ID), "utf-8")).toBe("# Updated");
     });
   });

--- a/src/services/workspace-settings.ts
+++ b/src/services/workspace-settings.ts
@@ -1,14 +1,14 @@
-import { readFileSync, writeFileSync } from "fs";
+import { readFile, writeFile } from "fs/promises";
 import * as workspace from "./workspace";
 
-export function readProjectDoc(projectId: string): string {
+export async function readProjectDoc(projectId: string): Promise<string> {
   try {
-    return readFileSync(workspace.projectDocPath(projectId), "utf-8");
+    return await readFile(workspace.projectDocPath(projectId), "utf-8");
   } catch {
     return "";
   }
 }
 
-export function writeProjectDoc(projectId: string, content: string): void {
-  writeFileSync(workspace.projectDocPath(projectId), content, "utf-8");
+export async function writeProjectDoc(projectId: string, content: string): Promise<void> {
+  await writeFile(workspace.projectDocPath(projectId), content, "utf-8");
 }

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import { homedir } from "os";
-import { mkdirSync } from "fs";
+import { mkdir } from "fs/promises";
 
 export function projectsDir(): string {
   return process.env.SHIRE_PROJECTS_DIR || join(homedir(), ".shire", "projects");
@@ -71,20 +71,22 @@ export function recipePath(projectId: string, agentId: string): string {
   return join(agentDir(projectId, agentId), "recipe.yaml");
 }
 
-export function ensureProjectDirs(projectId: string): void {
-  mkdirSync(root(projectId), { recursive: true });
-  mkdirSync(sharedDir(projectId), { recursive: true });
-  mkdirSync(runnerDir(projectId), { recursive: true });
+export async function ensureProjectDirs(projectId: string): Promise<void> {
+  await Promise.all([
+    mkdir(root(projectId), { recursive: true }),
+    mkdir(sharedDir(projectId), { recursive: true }),
+    mkdir(runnerDir(projectId), { recursive: true }),
+  ]);
 }
 
-export function ensureAgentDirs(projectId: string, agentId: string): void {
-  mkdirSync(agentDir(projectId, agentId), { recursive: true });
-  mkdirSync(inboxDir(projectId, agentId), { recursive: true });
-  mkdirSync(outboxDir(projectId, agentId), { recursive: true });
-  mkdirSync(scriptsDir(projectId, agentId), { recursive: true });
-  mkdirSync(documentsDir(projectId, agentId), { recursive: true });
-  mkdirSync(attachmentsDir(projectId, agentId), { recursive: true });
-  mkdirSync(join(attachmentsDir(projectId, agentId), "outbox"), {
-    recursive: true,
-  });
+export async function ensureAgentDirs(projectId: string, agentId: string): Promise<void> {
+  await Promise.all([
+    mkdir(agentDir(projectId, agentId), { recursive: true }),
+    mkdir(inboxDir(projectId, agentId), { recursive: true }),
+    mkdir(outboxDir(projectId, agentId), { recursive: true }),
+    mkdir(scriptsDir(projectId, agentId), { recursive: true }),
+    mkdir(documentsDir(projectId, agentId), { recursive: true }),
+    mkdir(attachmentsDir(projectId, agentId), { recursive: true }),
+    mkdir(join(attachmentsDir(projectId, agentId), "outbox"), { recursive: true }),
+  ]);
 }


### PR DESCRIPTION
## Summary
- Convert all synchronous filesystem operations (`readFileSync`, `writeFileSync`, `mkdirSync`, `rmSync`, `existsSync`, etc.) to `fs/promises` async equivalents across 13 source files
- Prevents event loop blocking during filesystem I/O in HTTP route handlers and runtime agent management
- Uses `Bun.file()` API for production static file serving in `index.ts`
- Fixes pre-existing floating promise in `spawn_agent` event handler

## Files changed (16)
**Services:** `workspace.ts`, `workspace-settings.ts`, `catalog.ts`
**Runtime:** `agent-manager.ts`, `coordinator.ts`, `project-manager.ts`
**Routes:** `settings.ts`, `catalog.ts`, `agents.ts`, `shared-drive.ts`, `attachments.ts`
**Other:** `index.ts`, `catalog-sync.ts`
**Tests:** `workspace-settings.test.ts`, `coordinator.test.ts`, `agent-manager.test.ts`

**Excluded:** `db/index.ts` (sync singleton, runs once at startup)

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun test` — 125 backend tests pass
- [x] `bun run test:frontend` — 198 frontend tests pass
- [x] `bun run lint` — no errors
- [x] Code review via subagent — no critical issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)