### PR TITLE
Fix settings page crash on activity log

### DIFF
--- a/src/frontend/components/SettingsPage.tsx
+++ b/src/frontend/components/SettingsPage.tsx
@@ -19,7 +19,7 @@ export default function SettingsPage() {
     queryClient.invalidateQueries({ queryKey: ["activity", projectId] });
   });
 
-  const messages = (activityData?.messages ?? []) as never[];
+  const messages = activityData?.messages ?? [];
   const has_more_messages = activityData?.hasMore ?? false;
 
   const handleLoadMoreMessages = (_before: number) => {

--- a/src/frontend/test/SettingsPage.test.tsx
+++ b/src/frontend/test/SettingsPage.test.tsx
@@ -3,8 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import SettingsPage from "../components/SettingsPage";
 import { renderWithProviders } from "./test-utils";
+import type { InterAgentMessage } from "../components/types";
 
-let mockMessages: never[] = [];
+let mockMessages: InterAgentMessage[] = [];
 let mockHasMore = false;
 
 vi.mock("../lib/hooks", async () => {
@@ -23,9 +24,9 @@ vi.mock("../lib/ws", () => ({
   useSubscription: vi.fn(),
 }));
 
-const activityMessages = [
+const activityMessages: InterAgentMessage[] = [
   { id: 1, fromAgent: "Alice", toAgent: "Bob", text: "Hello!", ts: "2026-03-17T10:00:00Z" },
-] as never[];
+];
 
 beforeEach(() => {
   mockMessages = [];

--- a/src/routes/messages.test.ts
+++ b/src/routes/messages.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createTestDb } from "../test/setup";
+import { createApp } from "../server";
+import { ProjectManager } from "../runtime/project-manager";
+import { Scheduler } from "../runtime/scheduler";
+import * as agentsService from "../services/agents";
+import { rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let app: ReturnType<typeof createApp>;
+let testDir: string;
+let projectId: string;
+let agentId: string;
+
+beforeEach(async () => {
+  createTestDb();
+  testDir = join(
+    tmpdir(),
+    `messages_route_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+  );
+  process.env.SHIRE_PROJECTS_DIR = testDir;
+
+  mock.module("../runtime/harness", () => ({
+    createHarness: () => ({
+      start: async () => {},
+      sendMessage: async () => {},
+      interrupt: async () => {},
+      clearSession: async () => {},
+      stop: async () => {},
+      onEvent: () => {},
+      isProcessing: () => false,
+      getSessionId: () => null,
+    }),
+  }));
+
+  const projectManager = new ProjectManager();
+  const scheduler = new Scheduler(projectManager);
+  app = createApp({ projectManager, scheduler });
+
+  const createRes = await request("POST", "/api/projects", { name: "test-project" });
+  const projectData = (await createRes.json()) as Record<string, string>;
+  projectId = projectData.id;
+
+  const agentRes = await request("POST", `/api/projects/${projectId}/agents`, {
+    name: "test-agent",
+    description: "Test",
+  });
+  const agentData = (await agentRes.json()) as Record<string, string>;
+  agentId = agentData.id;
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+async function request(method: string, path: string, body?: unknown) {
+  const opts: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (body) opts.body = JSON.stringify(body);
+  return app.request(path, opts);
+}
+
+describe("GET /api/projects/:id/activity", () => {
+  it("transforms inter_agent messages to flat shape", async () => {
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "inter_agent",
+      content: { text: "Hello from Alice", from_agent: "Alice", to_agent: "Bob" },
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/activity`);
+    expect(res.status).toBe(200);
+
+    const data = (await res.json()) as { messages: Record<string, unknown>[]; hasMore: boolean };
+    expect(data.messages).toHaveLength(1);
+
+    const msg = data.messages[0];
+    expect(msg.text).toBe("Hello from Alice");
+    expect(msg.fromAgent).toBe("Alice");
+    expect(msg.toAgent).toBe("Bob");
+    expect(msg.ts).toBeDefined();
+    expect(msg.id).toBeDefined();
+    // Raw DB fields should not leak through
+    expect(msg.content).toBeUndefined();
+    expect(msg.role).toBeUndefined();
+    expect(msg.createdAt).toBeUndefined();
+  });
+
+  it("includes trigger and taskLabel for scheduled task messages", async () => {
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "system",
+      content: {
+        text: "Scheduled run",
+        trigger: "scheduled_task",
+        task_label: "daily-check",
+        from_agent: "",
+        to_agent: "test-agent",
+      },
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/activity`);
+    const data = (await res.json()) as { messages: Record<string, unknown>[] };
+    const msg = data.messages[0];
+    expect(msg.trigger).toBe("scheduled_task");
+    expect(msg.taskLabel).toBe("daily-check");
+  });
+
+  it("omits trigger and taskLabel when not present", async () => {
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "inter_agent",
+      content: { text: "plain msg", from_agent: "A", to_agent: "B" },
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/activity`);
+    const data = (await res.json()) as { messages: Record<string, unknown>[] };
+    const msg = data.messages[0];
+    expect(msg.trigger).toBeUndefined();
+    expect(msg.taskLabel).toBeUndefined();
+  });
+
+  it("supports pagination with transformed data", async () => {
+    for (let i = 1; i <= 3; i++) {
+      agentsService.createMessage({
+        projectId,
+        agentId,
+        role: "inter_agent",
+        content: { text: `msg-${i}`, from_agent: "A", to_agent: "B" },
+      });
+    }
+
+    const res1 = await request("GET", `/api/projects/${projectId}/activity?limit=2`);
+    const page1 = (await res1.json()) as {
+      messages: { id: number; text: string }[];
+      hasMore: boolean;
+    };
+    expect(page1.messages).toHaveLength(2);
+    expect(page1.hasMore).toBe(true);
+    // Messages are newest-first
+    expect(page1.messages[0].text).toBe("msg-3");
+
+    const oldestId = page1.messages[page1.messages.length - 1].id;
+    const res2 = await request(
+      "GET",
+      `/api/projects/${projectId}/activity?before=${oldestId}&limit=2`,
+    );
+    const page2 = (await res2.json()) as {
+      messages: { id: number; text: string }[];
+      hasMore: boolean;
+    };
+    expect(page2.messages).toHaveLength(1);
+    expect(page2.hasMore).toBe(false);
+    expect(page2.messages[0].text).toBe("msg-1");
+  });
+
+  it("defaults text to empty string when content.text is missing", async () => {
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "inter_agent",
+      content: { from_agent: "A", to_agent: "B" },
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/activity`);
+    const data = (await res.json()) as { messages: { text: string }[] };
+    expect(data.messages[0].text).toBe("");
+  });
+});

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -43,5 +43,18 @@ export const messageRoutes = new Hono<AppEnv>()
       limit: limit ? Math.min(parseInt(limit, 10), MAX_PAGE_SIZE) : undefined,
     });
 
-    return c.json(result);
+    const messages = result.messages.map((row) => {
+      const content = row.content as Record<string, unknown>;
+      return {
+        id: row.id,
+        text: (content.text as string) ?? "",
+        fromAgent: (content.from_agent as string) ?? "",
+        toAgent: (content.to_agent as string) ?? "",
+        ts: row.createdAt,
+        ...(content.trigger ? { trigger: content.trigger as string } : {}),
+        ...(content.task_label ? { taskLabel: content.task_label as string } : {}),
+      };
+    });
+
+    return c.json({ messages, hasMore: result.hasMore });
   });


### PR DESCRIPTION
## Summary

- Fix "Cannot read properties of undefined (reading 'length')" crash on the settings page
- The `/api/projects/:id/activity` endpoint returned raw DB rows with nested `content` JSON, but the frontend `InterAgentMessage` type expected flat fields (`text`, `fromAgent`, `toAgent`, `ts`)
- Transform rows in the API route to match the expected shape, remove unsafe `as never[]` cast in SettingsPage

## Test plan

- [x] New backend route tests for activity endpoint transformation (5 cases: shape, trigger/taskLabel, omission, pagination, missing fields)
- [x] Frontend SettingsPage and ActivityLog tests pass
- [x] Full test suite passes (186 backend + 198 frontend)
- [x] TypeScript typecheck and ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)