### PR TITLE
Standardize backend port to 3000

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Shire is an AI agent orchestration platform. Users create projects, add agents (
 
 ```bash
 # Development
-bun run dev                # Backend server on :4000
+bun run dev                # Backend server on :3000
 bun run dev:frontend       # Vite dev server on :5173
 
 # Testing

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ mix setup        # Install deps, create SQLite DB, build assets
 mix phx.server   # Start the server
 ```
 
-Visit [localhost:4000](http://localhost:4000) to open the dashboard.
+Visit [localhost:3000](http://localhost:3000) to open the dashboard.
 
 By default, Shire uses **SQLite** for storage and **local mode** for agent execution. Agents run as local processes on your machine — no VMs, no SSH, no tokens. All data is stored at `~/.shire/`.
 
@@ -166,7 +166,7 @@ Full reference. Create a `.env` file in the project root — it's automatically 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | `4000` | HTTP server port |
+| `PORT` | `3000` | HTTP server port |
 | `PHX_HOST` | `example.com` | Hostname for URL generation (production) |
 | `SECRET_KEY_BASE` | — | Phoenix session secret. Generate with `mix phx.gen.secret` |
 | `SHIRE_DB` | `sqlite` | Database engine: `sqlite` or `postgres` (compile-time) |

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -16,9 +16,9 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/api": "http://localhost:4000",
+      "/api": "http://localhost:3000",
       "/ws": {
-        target: "ws://localhost:4000",
+        target: "ws://localhost:3000",
         ws: true,
       },
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,7 @@ export interface AppContext {
 export function createApp(ctx: AppContext) {
   const allowedOrigins = process.env.ALLOWED_ORIGINS
     ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim())
-    : ["http://localhost:5173", "http://localhost:4000"];
+    : ["http://localhost:5173", "http://localhost:3000"];
 
   const app = new Hono<AppEnv>()
     .use("*", cors({ origin: allowedOrigins }))


### PR DESCRIPTION
## Summary
- The backend (`src/index.ts`) defaults to port 3000, but the Vite dev proxy, CORS config, README, and CLAUDE.md all referenced port 4000
- Updated all references to consistently use port 3000, fixing the frontend dev proxy connection failure

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Backend tests pass (181 tests)
- [x] Frontend tests pass (200 tests)
- [ ] Start dev server with `bun run dev` and confirm it logs port 3000
- [ ] Start frontend with `bun run dev:frontend` and confirm API proxy works

🤖 Generated with [Claude Code](https://claude.com/claude-code)