### PR TITLE
Migrate messages and activity logs to useInfiniteQuery

### DIFF
--- a/src/frontend/components/ActivityLog.tsx
+++ b/src/frontend/components/ActivityLog.tsx
@@ -6,7 +6,7 @@ import type { InterAgentMessage } from "./types";
 interface ActivityLogProps {
   messages: InterAgentMessage[];
   hasMore: boolean;
-  onLoadMore: (before: number) => void;
+  onLoadMore: () => void;
 }
 
 export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityLogProps) {
@@ -22,13 +22,6 @@ export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityL
       }
       return next;
     });
-  };
-
-  const handleLoadMore = () => {
-    const oldestId = messages[messages.length - 1]?.id;
-    if (oldestId) {
-      onLoadMore(oldestId);
-    }
   };
 
   if (messages.length === 0) {
@@ -82,7 +75,7 @@ export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityL
       })}
       {hasMore && (
         <div className="text-center pt-2">
-          <Button variant="outline" size="sm" onClick={handleLoadMore}>
+          <Button variant="outline" size="sm" onClick={onLoadMore}>
             Load more
           </Button>
         </div>

--- a/src/frontend/components/AgentChatView.tsx
+++ b/src/frontend/components/AgentChatView.tsx
@@ -91,7 +91,8 @@ export default function AgentChatView() {
   }
 
   // Mark messages as read when viewing an agent
-  const lastMessageId = messagesData?.messages?.at(-1)?.id;
+  // Page 0 = most recent page (no cursor); last element = newest message
+  const lastMessageId = messagesData?.pages?.[0]?.messages?.at(-1)?.id as number | undefined;
   const markReadRef = React.useRef(markRead);
   React.useEffect(() => {
     markReadRef.current = markRead;

--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -13,7 +13,6 @@ import {
   useSendMessage,
   useInterruptAgent,
   useRestartAgent,
-  useLoadMoreMessages,
 } from "../lib/hooks";
 
 export interface Attachment {
@@ -235,16 +234,25 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
       prev?.map((a) => (a.id === agent.id ? { ...a, busy: true } : a)),
     );
 
-  const { data: messagesData, isLoading: messagesLoading } = useMessages(projectId, agent.id);
+  const {
+    data: messagesData,
+    isLoading: messagesLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useMessages(projectId, agent.id);
   const sendMessage = useSendMessage(projectId ?? "");
   const interruptAgent = useInterruptAgent(projectId ?? "");
   const restartAgent = useRestartAgent(projectId ?? "");
-  const loadMore = useLoadMoreMessages(projectId ?? "");
 
-  const rawMessages = messagesData?.messages;
-  const messages = React.useMemo(() => transformMessages(rawMessages ?? []), [rawMessages]);
-  const hasMore = messagesData?.hasMore ?? false;
-  const loadingMore = loadMore.isPending;
+  const messages = React.useMemo(() => {
+    if (!messagesData) return [];
+    // Page 0 = newest (no cursor), page N = oldest. Reverse for chronological order.
+    const allRaw = [...messagesData.pages].reverse().flatMap((page) => page.messages);
+    return transformMessages(allRaw as Array<Record<string, unknown>>);
+  }, [messagesData]);
+  const hasMore = hasNextPage ?? false;
+  const loadingMore = isFetchingNextPage;
 
   const [input, setInput] = React.useState("");
   const [streamingText, setStreamingText] = React.useState("");
@@ -326,12 +334,9 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
     const container = scrollContainerRef.current;
     if (!container || !hasMore || loadingMore) return;
     if (container.scrollTop === 0 && messages.length > 0) {
-      const oldest = messages[0];
-      if (oldest.id != null) {
-        loadMore.mutate({ agentId: agent.id, before: oldest.id });
-      }
+      fetchNextPage();
     }
-  }, [hasMore, loadingMore, loadMore, messages, agent.id]);
+  }, [hasMore, loadingMore, fetchNextPage, messages.length]);
 
   const handleFileSelect = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;

--- a/src/frontend/components/SettingsPage.tsx
+++ b/src/frontend/components/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Button } from "./ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { ChevronLeft, Loader2 } from "lucide-react";
@@ -8,22 +9,26 @@ import ActivityLog from "./ActivityLog";
 import { useProjectId, useActivity } from "../lib/hooks";
 import { useSubscription } from "../lib/ws";
 import { useQueryClient } from "@tanstack/react-query";
+import type { InterAgentMessage } from "./types";
 
 export default function SettingsPage() {
   const queryClient = useQueryClient();
   const { projectId, projectName } = useProjectId();
 
-  const { data: activityData } = useActivity(projectId);
+  const { data: activityData, fetchNextPage, hasNextPage } = useActivity(projectId);
 
   useSubscription(projectId ? `project:${projectId}:schedules` : null, () => {
     queryClient.invalidateQueries({ queryKey: ["activity", projectId] });
   });
 
-  const messages = activityData?.messages ?? [];
-  const has_more_messages = activityData?.hasMore ?? false;
+  const messages = useMemo<InterAgentMessage[]>(
+    () => (activityData?.pages?.flatMap((page) => page.messages) ?? []) as InterAgentMessage[],
+    [activityData],
+  );
+  const has_more_messages = hasNextPage ?? false;
 
-  const handleLoadMoreMessages = (_before: number) => {
-    queryClient.invalidateQueries({ queryKey: ["activity", projectId] });
+  const handleLoadMoreMessages = () => {
+    fetchNextPage();
   };
 
   if (!projectId) {

--- a/src/frontend/lib/hooks/activity.ts
+++ b/src/frontend/lib/hooks/activity.ts
@@ -1,12 +1,21 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { api } from "../api";
 import { unwrap } from "./util";
 
 export function useActivity(projectId: string | undefined) {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ["activity", projectId],
-    queryFn: async () =>
-      unwrap(await api.projects[":id"].activity.$get({ param: { id: projectId! }, query: {} })),
+    queryFn: async ({ pageParam }) => {
+      const query: Record<string, string> = {};
+      if (pageParam != null) query.before = String(pageParam);
+      return unwrap(await api.projects[":id"].activity.$get({ param: { id: projectId! }, query }));
+    },
     enabled: !!projectId,
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.hasMore || lastPage.messages.length === 0) return undefined;
+      // Activity is displayed newest-first; oldest message in page is the cursor
+      return lastPage.messages[lastPage.messages.length - 1].id as number;
+    },
   });
 }

--- a/src/frontend/lib/hooks/messages.ts
+++ b/src/frontend/lib/hooks/messages.ts
@@ -1,30 +1,27 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { unwrap } from "./util";
 
 export function useMessages(projectId: string | undefined, agentId: string | undefined) {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ["messages", projectId, agentId],
-    queryFn: async () =>
-      unwrap(
+    queryFn: async ({ pageParam }) => {
+      const query: Record<string, string> = {};
+      if (pageParam != null) query.before = String(pageParam);
+      return unwrap(
         await api.projects[":id"].agents[":aid"].messages.$get({
           param: { id: projectId!, aid: agentId! },
-          query: {},
+          query,
         }),
-      ),
+      );
+    },
     enabled: !!projectId && !!agentId,
-  });
-}
-
-export function useLoadMoreMessages(projectId: string) {
-  return useMutation({
-    mutationFn: async ({ agentId, before }: { agentId: string; before: number }) =>
-      unwrap(
-        await api.projects[":id"].agents[":aid"].messages.$get({
-          param: { id: projectId, aid: agentId },
-          query: { before: String(before) },
-        }),
-      ),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.hasMore || lastPage.messages.length === 0) return undefined;
+      // Oldest message in the page is the cursor for the next (older) page
+      return lastPage.messages[0].id as number;
+    },
   });
 }
 

--- a/src/frontend/test/ActivityLog.test.tsx
+++ b/src/frontend/test/ActivityLog.test.tsx
@@ -39,11 +39,11 @@ describe("ActivityLog", () => {
     expect(screen.queryByText("Load more")).not.toBeInTheDocument();
   });
 
-  it("calls onLoadMore with before id on Load more click", async () => {
+  it("calls onLoadMore on Load more click", async () => {
     const onLoadMore = vi.fn();
     render(<ActivityLog messages={messages} hasMore={true} onLoadMore={onLoadMore} />);
     await userEvent.click(screen.getByText("Load more"));
-    expect(onLoadMore).toHaveBeenCalledWith(2);
+    expect(onLoadMore).toHaveBeenCalled();
   });
 
   it("truncates long messages and shows expand toggle", async () => {

--- a/src/frontend/test/AgentDashboard.test.tsx
+++ b/src/frontend/test/AgentDashboard.test.tsx
@@ -55,11 +55,19 @@ vi.mock("../lib/hooks", async () => {
     }),
     useDeleteAgent: () => ({ mutate: vi.fn(), isPending: false }),
     useClearSession: () => ({ mutate: vi.fn(), isPending: false }),
-    useMessages: () => ({ data: { messages: [], hasMore: false }, isLoading: false }),
+    useMessages: () => ({
+      data: {
+        pages: [{ messages: [], hasMore: false }],
+        pageParams: [undefined],
+      },
+      isLoading: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    }),
     useSendMessage: () => ({ mutate: vi.fn(), isPending: false }),
     useInterruptAgent: () => ({ mutate: vi.fn(), isPending: false }),
     useRestartAgent: () => ({ mutate: vi.fn(), isPending: false }),
-    useLoadMoreMessages: () => ({ mutate: vi.fn(), isPending: false }),
     useMarkRead: () => ({ mutate: vi.fn(), isPending: false }),
   };
 });

--- a/src/frontend/test/ChatPanel.test.tsx
+++ b/src/frontend/test/ChatPanel.test.tsx
@@ -21,7 +21,7 @@ const createdAgent: AgentOverview = {
 const sendMutate = vi.fn();
 const interruptMutate = vi.fn();
 const restartMutate = vi.fn();
-const loadMoreMutate = vi.fn();
+const fetchNextPageMock = vi.fn();
 
 let mockMessages: Array<Record<string, unknown>> = [];
 let mockHasMore = false;
@@ -32,13 +32,18 @@ vi.mock("../lib/hooks", async () => {
     ...actual,
     useProjectId: () => ({ projectId: "p1", projectName: "test-project" }),
     useMessages: () => ({
-      data: { messages: mockMessages, hasMore: mockHasMore },
+      data: {
+        pages: [{ messages: mockMessages, hasMore: mockHasMore }],
+        pageParams: [undefined],
+      },
       isLoading: false,
+      fetchNextPage: fetchNextPageMock,
+      hasNextPage: mockHasMore,
+      isFetchingNextPage: false,
     }),
     useSendMessage: () => ({ mutate: sendMutate, isPending: false }),
     useInterruptAgent: () => ({ mutate: interruptMutate, isPending: false }),
     useRestartAgent: () => ({ mutate: restartMutate, isPending: false }),
-    useLoadMoreMessages: () => ({ mutate: loadMoreMutate, isPending: false }),
   };
 });
 
@@ -77,7 +82,7 @@ describe("ChatPanel", () => {
     sendMutate.mockClear();
     interruptMutate.mockClear();
     restartMutate.mockClear();
-    loadMoreMutate.mockClear();
+    fetchNextPageMock.mockClear();
   });
 
   it("renders empty state when no messages", () => {
@@ -186,7 +191,7 @@ describe("ChatPanel", () => {
     expect(screen.getByText("done")).toBeInTheDocument();
   });
 
-  it("sends load-more with before param when scrolled to top", () => {
+  it("fetches next page when scrolled to top", () => {
     mockMessages = messages.map(apiMessage);
     mockHasMore = true;
     const { container } = renderWithProviders(<ChatPanel agent={activeAgent} />);
@@ -195,10 +200,10 @@ describe("ChatPanel", () => {
     Object.defineProperty(scrollContainer, "scrollTop", { value: 0, writable: true });
     fireEvent.scroll(scrollContainer);
 
-    expect(loadMoreMutate).toHaveBeenCalledWith({ agentId: "a1", before: 1 });
+    expect(fetchNextPageMock).toHaveBeenCalled();
   });
 
-  it("does not send load-more when no messages", () => {
+  it("does not fetch next page when no messages", () => {
     mockHasMore = true;
     const { container } = renderWithProviders(<ChatPanel agent={activeAgent} />);
 
@@ -206,7 +211,7 @@ describe("ChatPanel", () => {
     Object.defineProperty(scrollContainer, "scrollTop", { value: 0, writable: true });
     fireEvent.scroll(scrollContainer);
 
-    expect(loadMoreMutate).not.toHaveBeenCalled();
+    expect(fetchNextPageMock).not.toHaveBeenCalled();
   });
 
   it("renders streaming text from props", () => {

--- a/src/frontend/test/SettingsPage.test.tsx
+++ b/src/frontend/test/SettingsPage.test.tsx
@@ -14,8 +14,13 @@ vi.mock("../lib/hooks", async () => {
     ...actual,
     useProjectId: () => ({ projectId: "p1", projectName: "test-project" }),
     useActivity: () => ({
-      data: { messages: mockMessages, hasMore: mockHasMore },
-      isLoading: false,
+      data: {
+        pages: [{ messages: mockMessages, hasMore: mockHasMore }],
+        pageParams: [undefined],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: mockHasMore,
+      isFetchingNextPage: false,
     }),
   };
 });


### PR DESCRIPTION
## Summary
- Replace `useQuery` + `useMutation` pagination with `useInfiniteQuery` for both messages and activity hooks
- Delete `useLoadMoreMessages` hook — cursor tracking is now handled automatically by TanStack Query
- Fix broken "Load more" in activity logs (was just invalidating the query instead of fetching older pages)

## Changes
- **Hooks**: `useMessages` and `useActivity` rewritten to `useInfiniteQuery` with cursor-based `getNextPageParam`
- **ChatPanel**: Flattens infinite query pages (reversed for chronological order), uses `fetchNextPage()` on scroll-to-top
- **AgentChatView**: Updated `lastMessageId` extraction from pages
- **SettingsPage**: Flattens activity pages, uses `fetchNextPage()` for load-more
- **ActivityLog**: Simplified `onLoadMore` prop to `() => void` (cursor managed by infinite query)

## Test plan
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bun run test:frontend` — 200/200 tests pass
- [x] `bun run lint` — clean
- [ ] Manual: open chat, scroll to top → older messages load, scroll position preserved
- [ ] Manual: Settings > Activity Log, click "Load more" → older entries appear
- [ ] Manual: send a message → appears at bottom, WebSocket updates work

🤖 Generated with [Claude Code](https://claude.com/claude-code)