### PR TITLE
Remove unused zustand dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,6 @@
         "tw-animate-css": "^1.4.0",
         "yaml": "^2.8.2",
         "zod": "^4.3.6",
-        "zustand": "^5.0.0",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.1",
@@ -1810,8 +1809,6 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
-
-    "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "yaml": "^2.8.2",
-    "zod": "^4.3.6",
-    "zustand": "^5.0.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.1",


### PR DESCRIPTION
## Summary
- Removed `zustand` from `package.json` — it was never imported or used anywhere in the codebase
- TanStack Query and React built-in state cover all state management needs

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Backend tests pass
- [x] Frontend tests pass (22 files, 200 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)