### PR TITLE
Convert activity log to scroll-based infinite loading

### DIFF
--- a/src/frontend/components/ActivityLog.tsx
+++ b/src/frontend/components/ActivityLog.tsx
@@ -1,16 +1,23 @@
 import * as React from "react";
 import { Button } from "./ui/button";
-import { Clock } from "lucide-react";
+import { Clock, Loader2 } from "lucide-react";
 import type { InterAgentMessage } from "./types";
 
 interface ActivityLogProps {
   messages: InterAgentMessage[];
   hasMore: boolean;
+  loadingMore: boolean;
   onLoadMore: () => void;
 }
 
-export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityLogProps) {
+export default function ActivityLog({
+  messages,
+  hasMore,
+  loadingMore,
+  onLoadMore,
+}: ActivityLogProps) {
   const [expandedIds, setExpandedIds] = React.useState<Set<number>>(new Set());
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
 
   const toggleExpand = (id: number) => {
     setExpandedIds((prev) => {
@@ -24,6 +31,24 @@ export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityL
     });
   };
 
+  const handleScroll = React.useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !hasMore || loadingMore) return;
+    const nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100;
+    if (nearBottom && messages.length > 0) {
+      onLoadMore();
+    }
+  }, [hasMore, loadingMore, messages.length, onLoadMore]);
+
+  // Auto-load next page when content doesn't overflow the scroll container
+  React.useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !hasMore || loadingMore || messages.length === 0) return;
+    if (container.scrollHeight <= container.clientHeight) {
+      onLoadMore();
+    }
+  }, [hasMore, loadingMore, messages.length, onLoadMore]);
+
   if (messages.length === 0) {
     return (
       <div className="text-center text-muted-foreground py-12">
@@ -33,7 +58,11 @@ export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityL
   }
 
   return (
-    <div className="space-y-2">
+    <div
+      ref={scrollContainerRef}
+      onScroll={handleScroll}
+      className="space-y-2 overflow-y-auto max-h-[calc(100vh-16rem)]"
+    >
       {messages.map((msg) => {
         const isExpanded = expandedIds.has(msg.id);
         const isLong = msg.text.length > 200;
@@ -51,7 +80,7 @@ export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityL
                 ) : (
                   <>
                     <span className="font-medium text-foreground">{msg.fromAgent}</span>
-                    {" \u2192 "}
+                    {" → "}
                     <span className="font-medium text-foreground">{msg.toAgent}</span>
                   </>
                 )}
@@ -73,11 +102,9 @@ export default function ActivityLog({ messages, hasMore, onLoadMore }: ActivityL
           </div>
         );
       })}
-      {hasMore && (
-        <div className="text-center pt-2">
-          <Button variant="outline" size="sm" onClick={onLoadMore}>
-            Load more
-          </Button>
+      {loadingMore && (
+        <div className="flex justify-center py-2">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
       )}
     </div>

--- a/src/frontend/components/SettingsPage.tsx
+++ b/src/frontend/components/SettingsPage.tsx
@@ -15,7 +15,12 @@ export default function SettingsPage() {
   const queryClient = useQueryClient();
   const { projectId, projectName } = useProjectId();
 
-  const { data: activityData, fetchNextPage, hasNextPage } = useActivity(projectId);
+  const {
+    data: activityData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useActivity(projectId);
 
   useSubscription(projectId ? `project:${projectId}:schedules` : null, () => {
     queryClient.invalidateQueries({ queryKey: ["activity", projectId] });
@@ -26,10 +31,6 @@ export default function SettingsPage() {
     [activityData],
   );
   const has_more_messages = hasNextPage ?? false;
-
-  const handleLoadMoreMessages = () => {
-    fetchNextPage();
-  };
 
   if (!projectId) {
     return (
@@ -64,7 +65,8 @@ export default function SettingsPage() {
             <ActivityLog
               messages={messages}
               hasMore={has_more_messages}
-              onLoadMore={handleLoadMoreMessages}
+              loadingMore={isFetchingNextPage}
+              onLoadMore={fetchNextPage}
             />
           </TabsContent>
 

--- a/src/frontend/test/ActivityLog.test.tsx
+++ b/src/frontend/test/ActivityLog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import ActivityLog from "../components/ActivityLog";
@@ -15,34 +15,117 @@ const messages: InterAgentMessage[] = [
   },
 ];
 
+const defaultProps = {
+  messages,
+  hasMore: false,
+  loadingMore: false,
+  onLoadMore: vi.fn(),
+};
+
 describe("ActivityLog", () => {
   it("renders empty state when no messages", () => {
-    render(<ActivityLog messages={[]} hasMore={false} onLoadMore={vi.fn()} />);
+    render(<ActivityLog {...defaultProps} messages={[]} />);
     expect(screen.getByText(/No inter-agent messages yet/)).toBeInTheDocument();
   });
 
   it("renders messages with sender and recipient", () => {
-    render(<ActivityLog messages={messages} hasMore={false} onLoadMore={vi.fn()} />);
+    render(<ActivityLog {...defaultProps} />);
     expect(screen.getAllByText("Alice")).toHaveLength(2); // sender in msg1, recipient in msg2
     expect(screen.getAllByText("Bob")).toHaveLength(2); // recipient in msg1, sender in msg2
     expect(screen.getByText("Hello Bob!")).toBeInTheDocument();
     expect(screen.getByText("Hi Alice, how are you?")).toBeInTheDocument();
   });
 
-  it("shows Load more button when hasMore is true", () => {
-    render(<ActivityLog messages={messages} hasMore={true} onLoadMore={vi.fn()} />);
-    expect(screen.getByText("Load more")).toBeInTheDocument();
+  it("shows loading spinner when loadingMore is true", () => {
+    const { container } = render(
+      <ActivityLog {...defaultProps} hasMore={true} loadingMore={true} />,
+    );
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
-  it("does not show Load more when hasMore is false", () => {
-    render(<ActivityLog messages={messages} hasMore={false} onLoadMore={vi.fn()} />);
-    expect(screen.queryByText("Load more")).not.toBeInTheDocument();
+  it("does not show loading spinner when not loading more", () => {
+    const { container } = render(
+      <ActivityLog {...defaultProps} hasMore={true} loadingMore={false} />,
+    );
+    expect(container.querySelector(".animate-spin")).not.toBeInTheDocument();
   });
 
-  it("calls onLoadMore on Load more click", async () => {
+  it("calls onLoadMore when scrolled near bottom with hasMore", () => {
     const onLoadMore = vi.fn();
-    render(<ActivityLog messages={messages} hasMore={true} onLoadMore={onLoadMore} />);
-    await userEvent.click(screen.getByText("Load more"));
+    // Mock Element.prototype so the scroll container has overflow from the start
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, "scrollHeight");
+    const originalClientHeight = Object.getOwnPropertyDescriptor(Element.prototype, "clientHeight");
+    Object.defineProperty(Element.prototype, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(Element.prototype, "clientHeight", { value: 400, configurable: true });
+
+    const { container } = render(
+      <ActivityLog {...defaultProps} hasMore={true} onLoadMore={onLoadMore} />,
+    );
+    const scrollContainer = container.firstElementChild as HTMLElement;
+
+    // useEffect saw overflow, so onLoadMore should NOT have been called yet
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    Object.defineProperty(scrollContainer, "scrollTop", { value: 550, configurable: true });
+    fireEvent.scroll(scrollContainer);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    // Restore
+    if (originalScrollHeight)
+      Object.defineProperty(Element.prototype, "scrollHeight", originalScrollHeight);
+    if (originalClientHeight)
+      Object.defineProperty(Element.prototype, "clientHeight", originalClientHeight);
+  });
+
+  it("does not call onLoadMore when not near bottom", () => {
+    const onLoadMore = vi.fn();
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, "scrollHeight");
+    const originalClientHeight = Object.getOwnPropertyDescriptor(Element.prototype, "clientHeight");
+    Object.defineProperty(Element.prototype, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(Element.prototype, "clientHeight", { value: 400, configurable: true });
+
+    const { container } = render(
+      <ActivityLog {...defaultProps} hasMore={true} onLoadMore={onLoadMore} />,
+    );
+    const scrollContainer = container.firstElementChild as HTMLElement;
+
+    Object.defineProperty(scrollContainer, "scrollTop", { value: 100, configurable: true });
+    fireEvent.scroll(scrollContainer);
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    if (originalScrollHeight)
+      Object.defineProperty(Element.prototype, "scrollHeight", originalScrollHeight);
+    if (originalClientHeight)
+      Object.defineProperty(Element.prototype, "clientHeight", originalClientHeight);
+  });
+
+  it("does not call onLoadMore when already loading", () => {
+    const onLoadMore = vi.fn();
+    const { container } = render(
+      <ActivityLog {...defaultProps} hasMore={true} loadingMore={true} onLoadMore={onLoadMore} />,
+    );
+    const scrollContainer = container.firstElementChild as HTMLElement;
+
+    Object.defineProperty(scrollContainer, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, "scrollTop", { value: 550, configurable: true });
+
+    fireEvent.scroll(scrollContainer);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("auto-loads next page when content does not overflow", () => {
+    const onLoadMore = vi.fn();
+    const { container } = render(
+      <ActivityLog {...defaultProps} hasMore={true} onLoadMore={onLoadMore} />,
+    );
+    const scrollContainer = container.firstElementChild as HTMLElement;
+
+    // Simulate content fitting within the viewport (no overflow)
+    Object.defineProperty(scrollContainer, "scrollHeight", { value: 300, configurable: true });
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 400, configurable: true });
+
+    // The useEffect fires on render — onLoadMore should have been called
     expect(onLoadMore).toHaveBeenCalled();
   });
 
@@ -51,7 +134,7 @@ describe("ActivityLog", () => {
     const longMessages: InterAgentMessage[] = [
       { id: 1, fromAgent: "Alice", toAgent: "Bob", text: longText, ts: "2026-03-17T10:00:00Z" },
     ];
-    render(<ActivityLog messages={longMessages} hasMore={false} onLoadMore={vi.fn()} />);
+    render(<ActivityLog {...defaultProps} messages={longMessages} />);
     expect(screen.getByText("Show more")).toBeInTheDocument();
     expect(screen.getByText(/\.\.\.$/)).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- Replaced broken "Load more" button with automatic scroll-based infinite loading in the activity log
- Added auto-load behavior when content doesn't overflow the scroll container (prevents dead-end states for short activity histories)
- Cleaned up unnecessary wrapper function in SettingsPage, passing `fetchNextPage` directly
- Added comprehensive tests for scroll detection, loading states, and auto-load edge case

## Test plan
- [x] All 402 tests pass (199 backend + 203 frontend)
- [x] TypeScript compiles with no errors
- [x] ESLint passes with no warnings
- [ ] Manual: open Settings > Activity tab with a project that has >50 activity messages, verify scrolling loads older entries
- [ ] Manual: verify spinner appears while loading and disappears after

🤖 Generated with [Claude Code](https://claude.com/claude-code)