### PR TITLE
Fix broken attachment and shared drive URLs

### DIFF
--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -65,7 +65,7 @@ const AttachmentDisplay = React.memo(function AttachmentDisplay({
   return (
     <div className="flex flex-wrap gap-2 mt-2">
       {attachments.map((att) => {
-        const url = `/projects/${projectName}/agents/${agentId}/attachments/${att.id}/${att.filename}`;
+        const url = `/api/projects/${projectName}/agents/${agentId}/attachments/${att.id}/${att.filename}`;
         const isImage = att.content_type.startsWith("image/");
 
         return isImage ? (

--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -142,7 +142,7 @@ function PreviewContent({
   error: string | null;
 }) {
   const type = getPreviewType(file.name);
-  const previewUrl = `/projects/${projectName}/shared/preview?path=${encodeURIComponent(file.path)}`;
+  const previewUrl = `/api/projects/${projectName}/shared-drive/preview?path=${encodeURIComponent(file.path)}`;
 
   if (error) {
     return <p className="text-sm text-destructive p-4">{error}</p>;
@@ -417,7 +417,7 @@ export default function SharedDrive() {
                             {file.type === "file" && (
                               <Button variant="ghost" size="sm" asChild>
                                 <a
-                                  href={`/projects/${projectName}/shared/download?path=${encodeURIComponent(file.path)}`}
+                                  href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(file.path)}`}
                                   download
                                 >
                                   Download

--- a/src/frontend/test/ChatPanel.test.tsx
+++ b/src/frontend/test/ChatPanel.test.tsx
@@ -399,7 +399,7 @@ describe("ChatPanel", () => {
     const link = screen.getByText("report.pdf").closest("a");
     expect(link).toHaveAttribute(
       "href",
-      "/projects/test-project/agents/a1/attachments/abc123/report.pdf",
+      "/api/projects/test-project/agents/a1/attachments/abc123/report.pdf",
     );
   });
 
@@ -418,7 +418,7 @@ describe("ChatPanel", () => {
     const img = screen.getByAltText("screenshot.png");
     expect(img).toHaveAttribute(
       "src",
-      "/projects/test-project/agents/a1/attachments/img001/screenshot.png",
+      "/api/projects/test-project/agents/a1/attachments/img001/screenshot.png",
     );
   });
 

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -209,7 +209,10 @@ describe("SharedDrive", () => {
 
       const img = screen.getByRole("img", { name: "photo.png" });
       expect(img).toBeInTheDocument();
-      expect(img).toHaveAttribute("src", "/projects/test-project/shared/preview?path=photo.png");
+      expect(img).toHaveAttribute(
+        "src",
+        "/api/projects/test-project/shared-drive/preview?path=photo.png",
+      );
     });
 
     it("shows unsupported message for unknown file types", async () => {
@@ -249,7 +252,10 @@ describe("SharedDrive", () => {
 
       const iframe = screen.getByTitle("doc.pdf");
       expect(iframe).toBeInTheDocument();
-      expect(iframe).toHaveAttribute("src", "/projects/test-project/shared/preview?path=doc.pdf");
+      expect(iframe).toHaveAttribute(
+        "src",
+        "/api/projects/test-project/shared-drive/preview?path=doc.pdf",
+      );
     });
 
     it("hides actions column when preview is open", async () => {


### PR DESCRIPTION
## Summary
- Add missing `/api` prefix to attachment URLs in `ChatPanel.tsx`, fixing broken image previews and download links
- Fix shared drive preview/download URLs in `SharedDrive.tsx`: add `/api` prefix and correct path segment (`shared` → `shared-drive`)
- Update test expectations in both `ChatPanel.test.tsx` and `SharedDrive.test.tsx`

## Test plan
- [x] All 200 frontend tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] Manual: verify attachment image previews render in chat
- [ ] Manual: verify shared drive file download/preview works

🤖 Generated with [Claude Code](https://claude.com/claude-code)