### PR TITLE
Fix shared drive preview download URL

### DIFF
--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -450,7 +450,7 @@ export default function SharedDrive() {
                 <div className="flex items-center gap-1">
                   <Button variant="ghost" size="sm" asChild>
                     <a
-                      href={`/projects/${projectName}/shared/download?path=${encodeURIComponent(previewFile.path)}`}
+                      href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(previewFile.path)}`}
                       download
                     >
                       <Download className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Fix the download button in the shared drive preview panel header — it still had the old `/projects/.../shared/download` path instead of `/api/projects/.../shared-drive/download`
- This was a missed instance from #161

## Test plan
- [x] SharedDrive tests pass (20/20)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] Manual: open shared drive, click a file to preview, click the download icon in the preview header

🤖 Generated with [Claude Code](https://claude.com/claude-code)