### PR TITLE
Fix getPackageRoot detection for dev vs compiled binary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,9 @@ const DEFAULT_PORT = 8080;
  * When running as a compiled binary: assets sit alongside the binary.
  */
 function getPackageRoot(): string {
-  // Bun compiled binaries: execPath equals argv[0] (the binary itself)
-  const isBunCompiled = typeof Bun !== "undefined" && process.execPath === process.argv[0];
-  if (isBunCompiled) {
+  // In a compiled binary, argv[1] is undefined (no script path).
+  // When running from source, argv[1] is the script path (e.g., src/cli.ts).
+  if (!process.argv[1]) {
     return dirname(process.execPath);
   }
   return join(__dirname, "..");


### PR DESCRIPTION
## Summary

- Fix `getPackageRoot()` in `src/index.ts` — the previous check `process.execPath === process.argv[0]` is true for both compiled binaries and `bun run src/cli.ts`, causing dev mode to look for migrations in the wrong directory
- Use `!process.argv[1]` instead — compiled binaries have no script path argument, so `argv[1]` is undefined

## Test plan

- [x] `bun run dev` starts without migration error
- [x] Compiled binary (`bun build --compile`) still resolves paths correctly
- [x] All 424 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)