### PR TITLE
Fix API 405 errors and HMR in Bun fullstack dev mode

### DIFF
--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -91,3 +91,7 @@ createRoot(document.getElementById("root")!).render(
     <App />
   </StrictMode>,
 );
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,20 +71,24 @@ export async function startServer(opts: StartOptions = {}) {
       port,
       development: true,
       routes: {
+        "/api/*": {
+          GET: (req: Request) => app.fetch(req),
+          POST: (req: Request) => app.fetch(req),
+          PUT: (req: Request) => app.fetch(req),
+          PATCH: (req: Request) => app.fetch(req),
+          DELETE: (req: Request) => app.fetch(req),
+          OPTIONS: (req: Request) => app.fetch(req),
+          HEAD: (req: Request) => app.fetch(req),
+        },
         "/": homepage.default,
         "/*": homepage.default,
       },
       async fetch(req, server) {
-        const url = new URL(req.url);
-
+        // WebSocket upgrades (e.g. /ws) — must be in fetch since routes can't do upgrades
         if (req.headers.get("upgrade") === "websocket") {
           const upgraded = server.upgrade(req, { data: {} });
           if (upgraded) return undefined;
           return new Response("WebSocket upgrade failed", { status: 400 });
-        }
-
-        if (url.pathname.startsWith("/api")) {
-          return app.fetch(req);
         }
 
         // Fallback


### PR DESCRIPTION
## Summary
- Add explicit `/api/*` route handlers for all HTTP methods (GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD) in Bun's `routes` config so they take priority over the `"/*"` HTML catch-all
- Add `import.meta.hot.accept()` in `main.tsx` to enable HMR without full page reloads

Bun's fullstack `routes: { "/*": homepage }` was intercepting all requests — including `/api/*` — before the `fetch` handler, causing 405 on POST and returning HTML on GET for API routes.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] All 439 tests pass
- [x] `POST /api/projects` returns 201
- [x] `OPTIONS /api/projects` returns 204 (CORS preflight)
- [x] WebSocket `/ws` connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)