### PR TITLE
Fix activity log missing from/to agent labels

### DIFF
--- a/src/frontend/components/ActivityLog.tsx
+++ b/src/frontend/components/ActivityLog.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Button } from "./ui/button";
-import { Clock } from "lucide-react";
+import { Clock, Info } from "lucide-react";
 import { Spinner } from "./ui/spinner";
 import type { InterAgentMessage } from "./types";
 
@@ -76,7 +76,14 @@ export default function ActivityLog({
                 {msg.trigger === "scheduled_task" ? (
                   <>
                     <Clock className="inline h-3 w-3 mr-1" />
-                    <span className="font-medium text-foreground">{msg.taskLabel}</span>
+                    <span className="font-medium text-foreground">
+                      {msg.taskLabel ?? "Scheduled task"}
+                    </span>
+                  </>
+                ) : msg.role === "system" || (!msg.fromAgent && !msg.toAgent) ? (
+                  <>
+                    <Info className="inline h-3 w-3 mr-1" />
+                    <span className="font-medium text-foreground">System</span>
                   </>
                 ) : (
                   <>

--- a/src/frontend/components/types.ts
+++ b/src/frontend/components/types.ts
@@ -73,6 +73,7 @@ export interface InterAgentMessage {
   toAgent: string;
   text: string;
   ts: string;
+  role?: string;
   trigger?: string;
   taskLabel?: string;
 }

--- a/src/frontend/test/ActivityLog.test.tsx
+++ b/src/frontend/test/ActivityLog.test.tsx
@@ -137,6 +137,32 @@ describe("ActivityLog", () => {
     if (origCH) Object.defineProperty(HTMLDivElement.prototype, "clientHeight", origCH);
   });
 
+  it("renders system messages without from/to arrow", () => {
+    const systemMessages: InterAgentMessage[] = [
+      {
+        id: 10,
+        fromAgent: "",
+        toAgent: "",
+        text: "Session cleared",
+        ts: "2026-03-17T10:00:00Z",
+        role: "system",
+      },
+      {
+        id: 11,
+        fromAgent: "",
+        toAgent: "",
+        text: "Error: something went wrong",
+        ts: "2026-03-17T10:01:00Z",
+        role: "system",
+      },
+    ];
+    render(<ActivityLog {...defaultProps} messages={systemMessages} />);
+    expect(screen.getByText("Session cleared")).toBeInTheDocument();
+    expect(screen.getByText("Error: something went wrong")).toBeInTheDocument();
+    // Should show "System" label, not empty arrows
+    expect(screen.getAllByText("System")).toHaveLength(2);
+  });
+
   it("truncates long messages and shows expand toggle", async () => {
     const longText = "A".repeat(250);
     const longMessages: InterAgentMessage[] = [

--- a/src/routes/messages.test.ts
+++ b/src/routes/messages.test.ts
@@ -66,7 +66,7 @@ describe("GET /api/projects/:id/activity", () => {
       projectId,
       agentId,
       role: "inter_agent",
-      content: { text: "Hello from Alice", from_agent: "Alice", to_agent: "Bob" },
+      content: { text: "Hello from Alice", fromAgent: "Alice", toAgent: "Bob" },
     });
 
     const res = await request("GET", `/api/projects/${projectId}/activity`);
@@ -79,12 +79,27 @@ describe("GET /api/projects/:id/activity", () => {
     expect(msg.text).toBe("Hello from Alice");
     expect(msg.fromAgent).toBe("Alice");
     expect(msg.toAgent).toBe("Bob");
+    expect(msg.role).toBe("inter_agent");
     expect(msg.ts).toBeDefined();
     expect(msg.id).toBeDefined();
     // Raw DB fields should not leak through
     expect(msg.content).toBeUndefined();
-    expect(msg.role).toBeUndefined();
     expect(msg.createdAt).toBeUndefined();
+  });
+
+  it("supports legacy snake_case field names for backwards compatibility", async () => {
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "inter_agent",
+      content: { text: "Legacy msg", from_agent: "Alice", to_agent: "Bob" },
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/activity`);
+    const data = (await res.json()) as { messages: Record<string, unknown>[] };
+    const msg = data.messages[0];
+    expect(msg.fromAgent).toBe("Alice");
+    expect(msg.toAgent).toBe("Bob");
   });
 
   it("includes trigger and taskLabel for scheduled task messages", async () => {
@@ -108,12 +123,28 @@ describe("GET /api/projects/:id/activity", () => {
     expect(msg.taskLabel).toBe("daily-check");
   });
 
+  it("includes role for system messages", async () => {
+    agentsService.createMessage({
+      projectId,
+      agentId,
+      role: "system",
+      content: { text: "Session cleared" },
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/activity`);
+    const data = (await res.json()) as { messages: Record<string, unknown>[] };
+    const msg = data.messages[0];
+    expect(msg.role).toBe("system");
+    expect(msg.fromAgent).toBe("");
+    expect(msg.toAgent).toBe("");
+  });
+
   it("omits trigger and taskLabel when not present", async () => {
     agentsService.createMessage({
       projectId,
       agentId,
       role: "inter_agent",
-      content: { text: "plain msg", from_agent: "A", to_agent: "B" },
+      content: { text: "plain msg", fromAgent: "A", toAgent: "B" },
     });
 
     const res = await request("GET", `/api/projects/${projectId}/activity`);
@@ -129,7 +160,7 @@ describe("GET /api/projects/:id/activity", () => {
         projectId,
         agentId,
         role: "inter_agent",
-        content: { text: `msg-${i}`, from_agent: "A", to_agent: "B" },
+        content: { text: `msg-${i}`, fromAgent: "A", toAgent: "B" },
       });
     }
 
@@ -162,7 +193,7 @@ describe("GET /api/projects/:id/activity", () => {
       projectId,
       agentId,
       role: "inter_agent",
-      content: { from_agent: "A", to_agent: "B" },
+      content: { fromAgent: "A", toAgent: "B" },
     });
 
     const res = await request("GET", `/api/projects/${projectId}/activity`);

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -47,12 +47,15 @@ export const messageRoutes = new Hono<AppEnv>()
       const { content } = row;
       return {
         id: row.id,
+        role: row.role,
         text: String(content.text ?? ""),
-        fromAgent: String(content.from_agent ?? ""),
-        toAgent: String(content.to_agent ?? ""),
+        fromAgent: String(content.fromAgent ?? content.from_agent ?? ""),
+        toAgent: String(content.toAgent ?? content.to_agent ?? ""),
         ts: row.createdAt,
         ...(content.trigger ? { trigger: String(content.trigger) } : {}),
-        ...(content.task_label ? { taskLabel: String(content.task_label) } : {}),
+        ...(content.taskLabel != null || content.task_label != null
+          ? { taskLabel: String(content.taskLabel ?? content.task_label) }
+          : {}),
       };
     });
 


### PR DESCRIPTION
## Summary
- **Fixed camelCase/snake_case mismatch**: Messages stored with `fromAgent`/`toAgent` but API read `from_agent`/`to_agent`, causing empty labels in the activity log
- **Added system message rendering**: Error and session-cleared messages now show an info icon with "System" label instead of a broken `→` arrow
- **Backwards compatibility**: API supports both camelCase and snake_case field names for existing data

## Test plan
- [x] All 442 tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Manual: start dev server, send inter-agent messages, verify from/to labels display
- [ ] Manual: trigger a system event (clear session, agent error), verify "System" label appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)