### PR TITLE
Fix shared drive Invalid path on subdirectory navigation

### DIFF
--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -405,7 +405,7 @@ export default function SharedDrive() {
                           <Button
                             variant="link"
                             className="flex items-center gap-2 text-foreground h-auto p-0"
-                            onClick={() => navigate("/" + file.path)}
+                            onClick={() => navigate(file.path)}
                           >
                             <Folder className="h-4 w-4 text-muted-foreground" />
                             {file.name}

--- a/src/routes/shared-drive.test.ts
+++ b/src/routes/shared-drive.test.ts
@@ -54,4 +54,12 @@ describe("safePath", () => {
     // A sibling directory that starts with the same prefix should be rejected
     expect(safePath(root, "../shared-evil/secret")).toBeNull();
   });
+
+  it("resolves double-slash paths (e.g. //docs from frontend)", () => {
+    expect(safePath(root, "//docs")).toBe(`${root}/docs`);
+  });
+
+  it("resolves triple-slash paths", () => {
+    expect(safePath(root, "///file.txt")).toBe(`${root}/file.txt`);
+  });
 });

--- a/src/routes/shared-drive.ts
+++ b/src/routes/shared-drive.ts
@@ -16,7 +16,7 @@ function resolveProjectId(nameOrId: string): string | null {
 
 export function safePath(sharedRoot: string, userPath: string): string | null {
   // Normalize: treat "/" or empty as the shared root itself
-  const normalized = userPath === "/" || userPath === "" ? "." : userPath.replace(/^\//, "");
+  const normalized = userPath === "/" || userPath === "" ? "." : userPath.replace(/^\/+/, "");
   const resolved = resolve(sharedRoot, normalized);
   // Guard against prefix collisions (e.g. /shared vs /shared-evil)
   if (resolved !== sharedRoot && !resolved.startsWith(sharedRoot + "/")) return null;


### PR DESCRIPTION
## Summary
- Fixed frontend prepending `/` to `file.path` (which already starts with `/`), creating double-slash paths like `//docs`
- Hardened backend `safePath` to strip all leading slashes (`/^\/+/` instead of `/^\//)`) so double-slash paths can't escape the shared root
- Added tests for double/triple slash path handling

## Test plan
- [x] `bun test` — 441 tests pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [ ] Manual: navigate into shared drive subdirectories, verify no "Invalid path" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)