### PR TITLE
Fix zero-height spinner flash on project pages

### DIFF
--- a/src/frontend/providers/ProjectLayoutProvider.tsx
+++ b/src/frontend/providers/ProjectLayoutProvider.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext } from "react";
+import { createContext, Suspense, useContext } from "react";
 import { Outlet } from "react-router-dom";
+import { Spinner } from "../components/ui/spinner";
 
 export interface ProjectLayoutContextValue {
   projectId: string | undefined;
@@ -26,7 +27,15 @@ interface ProjectLayoutProviderProps {
 export function ProjectLayoutProvider({ value }: ProjectLayoutProviderProps) {
   return (
     <ProjectLayoutContext.Provider value={value}>
-      <Outlet />
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center flex-1">
+            <Spinner size="lg" className="text-muted-foreground" />
+          </div>
+        }
+      >
+        <Outlet />
+      </Suspense>
     </ProjectLayoutContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Added a `Suspense` boundary around `<Outlet />` inside `ProjectLayoutProvider` so lazy route children (AgentChatView, AgentSettings, etc.) show a properly sized spinner in the content area instead of replacing the entire page layout
- Prevents the sidebar from disappearing during lazy chunk loading

## Test plan
- [ ] Navigate to a project page — sidebar should remain visible while content loads
- [ ] Hard refresh on a project route — no zero-height spinner flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)