### PR TITLE
Fix DM Sans font not loading

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "shire",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.85",
-        "@fontsource-variable/dm-sans": "^5.2.8",
         "@hono/zod-validator": "^0.7.6",
         "@mariozechner/pi-ai": "^0.63.1",
         "@mariozechner/pi-coding-agent": "^0.63.1",
@@ -244,8 +243,6 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
-
-    "@fontsource-variable/dm-sans": ["@fontsource-variable/dm-sans@5.2.8", "", {}, "sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g=="],
 
     "@google/genai": ["@google/genai@1.46.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-ewPMN5JkKfgU5/kdco9ZhXBHDPhVqZpMQqIFQhwsHLf8kyZfx1cNpw1pHo1eV6PGEW7EhIBFi3aYZraFndAXqg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.85",
-    "@fontsource-variable/dm-sans": "^5.2.8",
     "@hono/zod-validator": "^0.7.6",
     "@mariozechner/pi-ai": "^0.63.1",
     "@mariozechner/pi-coding-agent": "^0.63.1",

--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -12,7 +12,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-sans: "DM Sans Variable", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Shire</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="./css/app.css" />
   </head>
   <body class="bg-background text-foreground antialiased">

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -8,8 +8,6 @@ import { ThemeProvider } from "./components/ThemeProvider";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { useConnectionToast } from "./lib/useConnectionToast";
 import { Spinner } from "./components/ui/spinner";
-import "@fontsource-variable/dm-sans";
-
 import ProjectLayout from "./components/ProjectLayout";
 
 const ProjectDashboard = lazy(() => import("./pages/ProjectDashboard"));


### PR DESCRIPTION
## Summary
- Bun's CSS minifier strips quotes from `format('woff2-variations')`, producing the invalid keyword `format(woff2-variations)` which browsers silently reject — so DM Sans never loaded
- Switched from `@fontsource-variable/dm-sans` to Google Fonts CDN, which bypasses Bun's CSS processing
- Removed `@fontsource-variable/dm-sans` dependency

## Test plan
- [ ] Run `bun run dev` and verify DM Sans renders in the browser (check DevTools > Computed font-family)
- [ ] Verify `document.fonts` shows "DM Sans" with status "loaded" in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)