### PR TITLE
Fix zero-height spinner on hard refresh

### DIFF
--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -1,13 +1,9 @@
 /* See the Tailwind configuration guide for advanced usage
    https://tailwindcss.com/docs/configuration */
 
-@import "tailwindcss" source(none);
+@import "tailwindcss";
 @import "tw-animate-css";
 @plugin "@tailwindcss/typography";
-@source "../css";
-@source "../components";
-@source "../pages";
-@source "../lib";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/frontend/providers/ProjectLayoutProvider.tsx
+++ b/src/frontend/providers/ProjectLayoutProvider.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext } from "react";
+import { createContext, Suspense, useContext } from "react";
 import { Outlet } from "react-router-dom";
+import { Spinner } from "../components/ui/spinner";
 
 export interface ProjectLayoutContextValue {
   projectId: string | undefined;
@@ -26,7 +27,15 @@ interface ProjectLayoutProviderProps {
 export function ProjectLayoutProvider({ value }: ProjectLayoutProviderProps) {
   return (
     <ProjectLayoutContext.Provider value={value}>
-      <Outlet />
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center flex-1">
+            <Spinner size="lg" className="text-muted-foreground" />
+          </div>
+        }
+      >
+        <Outlet />
+      </Suspense>
     </ProjectLayoutContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Removed `source(none)` from Tailwind config — `main.tsx` and `providers/` weren't listed as `@source` directories, so classes like `h-screen` in the Suspense fallback were never generated, causing the spinner to have zero height
- Added Suspense boundary inside `ProjectLayoutProvider` around `<Outlet />` so lazy route children show a spinner in the content area instead of replacing the entire sidebar layout

## Test plan
- [x] Hard refresh on `/` — spinner is centered and full-height
- [x] Hard refresh on `/projects/:name` — spinner is centered and full-height
- [x] All 444 tests pass, lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)