### PR TITLE
Prepare npm packages for first publish under @agents-shire scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           bun-version: "1.3.11"
 
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
       - run: bun install --frozen-lockfile
 
       - name: Build binary and assets
@@ -50,10 +54,16 @@ jobs:
 
       - name: Set version in package.json
         shell: bash
+        env:
+          PKG_VERSION: ${{ github.ref_name }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           cd npm/${{ matrix.npm-dir }}
-          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = process.env.PKG_VERSION.replace(/^v/, '');
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
 
       - name: Publish platform package
         run: npm publish --access public
@@ -73,17 +83,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
       - name: Set version in meta-package
+        shell: bash
+        env:
+          PKG_VERSION: ${{ github.ref_name }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          cd npm/shire
-          jq --arg v "$VERSION" '
-            .version = $v |
-            .optionalDependencies |= with_entries(.value = $v)
-          ' package.json > tmp.json && mv tmp.json package.json
+          cd npm/agents-shire
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const version = process.env.PKG_VERSION.replace(/^v/, '');
+            pkg.version = version;
+            for (const key of Object.keys(pkg.optionalDependencies)) {
+              pkg.optionalDependencies[key] = version;
+            }
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
 
       - name: Publish meta-package
         run: npm publish --access public
-        working-directory: npm/shire
+        working-directory: npm/agents-shire
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -174,17 +174,17 @@ git push origin v0.2.0
 ```
 
 This builds platform-specific binaries and publishes:
-- `@shire/cli-darwin-arm64` (macOS Apple Silicon)
-- `@shire/cli-darwin-x64` (macOS Intel)
-- `@shire/cli-linux-x64` (Linux x64)
-- `@shire/cli-linux-arm64` (Linux ARM)
-- `@shire/cli-win32-x64` (Windows x64)
-- `shire` (meta-package that installs the right binary)
+- `@agents-shire/cli-darwin-arm64` (macOS Apple Silicon)
+- `@agents-shire/cli-darwin-x64` (macOS Intel)
+- `@agents-shire/cli-linux-x64` (Linux x64)
+- `@agents-shire/cli-linux-arm64` (Linux ARM)
+- `@agents-shire/cli-win32-x64` (Windows x64)
+- `agents-shire` (meta-package that installs the right binary)
 
 Users install with:
 
 ```bash
-npm install -g shire
+npm install -g agents-shire
 shire
 ```
 

--- a/npm/agents-shire/bin/shire
+++ b/npm/agents-shire/bin/shire
@@ -5,11 +5,11 @@ const { execFileSync } = require("child_process");
 const { join } = require("path");
 
 const PLATFORMS = {
-  "darwin-arm64": "@shire/cli-darwin-arm64",
-  "darwin-x64": "@shire/cli-darwin-x64",
-  "linux-x64": "@shire/cli-linux-x64",
-  "linux-arm64": "@shire/cli-linux-arm64",
-  "win32-x64": "@shire/cli-win32-x64",
+  "darwin-arm64": "@agents-shire/cli-darwin-arm64",
+  "darwin-x64": "@agents-shire/cli-darwin-x64",
+  "linux-x64": "@agents-shire/cli-linux-x64",
+  "linux-arm64": "@agents-shire/cli-linux-arm64",
+  "win32-x64": "@agents-shire/cli-win32-x64",
 };
 
 const platformKey = `${process.platform}-${process.arch}`;
@@ -32,7 +32,7 @@ try {
   console.error(
     `Could not find package "${packageName}".\n` +
       `This usually means the optional dependency was not installed.\n` +
-      `Try: npm install -g shire`,
+      `Try: npm install -g agents-shire`,
   );
   process.exit(1);
 }

--- a/npm/agents-shire/package.json
+++ b/npm/agents-shire/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "shire",
+  "name": "agents-shire",
   "version": "0.1.0",
   "description": "AI agent orchestration platform",
   "bin": {
     "shire": "bin/shire"
   },
   "optionalDependencies": {
-    "@shire/cli-darwin-arm64": "0.1.0",
-    "@shire/cli-darwin-x64": "0.1.0",
-    "@shire/cli-linux-x64": "0.1.0",
-    "@shire/cli-linux-arm64": "0.1.0",
-    "@shire/cli-win32-x64": "0.1.0"
+    "@agents-shire/cli-darwin-arm64": "0.1.0",
+    "@agents-shire/cli-darwin-x64": "0.1.0",
+    "@agents-shire/cli-linux-x64": "0.1.0",
+    "@agents-shire/cli-linux-arm64": "0.1.0",
+    "@agents-shire/cli-win32-x64": "0.1.0"
   },
   "license": "BUSL-1.1",
   "repository": {

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shire/cli-darwin-arm64",
+  "name": "@agents-shire/cli-darwin-arm64",
   "version": "0.1.0",
   "description": "Shire CLI binary for macOS ARM64 (Apple Silicon)",
   "os": ["darwin"],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shire/cli-darwin-x64",
+  "name": "@agents-shire/cli-darwin-x64",
   "version": "0.1.0",
   "description": "Shire CLI binary for macOS x64 (Intel)",
   "os": ["darwin"],

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shire/cli-linux-arm64",
+  "name": "@agents-shire/cli-linux-arm64",
   "version": "0.1.0",
   "description": "Shire CLI binary for Linux ARM64",
   "os": ["linux"],

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shire/cli-linux-x64",
+  "name": "@agents-shire/cli-linux-x64",
   "version": "0.1.0",
   "description": "Shire CLI binary for Linux x64",
   "os": ["linux"],

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shire/cli-win32-x64",
+  "name": "@agents-shire/cli-win32-x64",
   "version": "0.1.0",
   "description": "Shire CLI binary for Windows x64",
   "os": ["win32"],


### PR DESCRIPTION
## Summary
- Rename all npm platform packages from `@shire/cli-*` to `@agents-shire/cli-*` (the `shire` name is taken on npm)
- Rename meta-package from `shire` to `agents-shire` (`npm install -g agents-shire` → `shire` command)
- Fix release workflow: add `actions/setup-node` for npm auth, replace `jq` with cross-platform `node -e` scripts, use `process.env` to avoid shell injection

## Before first release
1. Create npm org `agents-shire` at https://www.npmjs.com/org/create
2. Create an npm **Automation** token (bypasses 2FA for CI)
3. Add `NPM_TOKEN` secret in GitHub repo settings (Settings → Secrets → Actions)
4. Tag a release: `git tag v0.1.0 && git push origin v0.1.0`

## Test plan
- [x] No stale `@shire/` references remain (grep verified)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run scripts/build-binaries.ts local` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)