### PR TITLE
Prepare npm packages for first publish under @agents-shire

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Rename all npm platform packages from `@shire/cli-*` to `@agents-shire/cli-*` (the `shire` name is taken on npm)
- Rename meta-package from `shire` to `agents-shire` (`npm install -g agents-shire` → `shire` command)
- Fix release workflow: add `actions/setup-node` for npm auth, replace `jq` with cross-platform `node -e` scripts, use `process.env` to avoid shell injection
- Trigger release workflow from GitHub Releases instead of bare tag pushes

## Before first release
1. Create npm org `agents-shire` at https://www.npmjs.com/org/create
2. Create an npm **Automation** token (bypasses 2FA for CI)
3. Add `NPM_TOKEN` secret in GitHub repo settings (Settings → Secrets → Actions)
4. Create a GitHub Release with tag `v0.1.0`

## Test plan
- [x] No stale `@shire/` references remain (grep verified)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run scripts/build-binaries.ts local` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)