### PR TITLE
Prepare npm packages for first publish under @agents-shire

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
             target: bun-darwin-arm64
             npm-dir: darwin-arm64
             binary: shire
-          - runner: macos-13
+          - runner: macos-15
             target: bun-darwin-x64
             npm-dir: darwin-x64
             binary: shire


### PR DESCRIPTION
## Summary
- Rename all npm platform packages from `@shire/cli-*` to `@agents-shire/cli-*` (the `shire` name is taken on npm)
- Rename meta-package from `shire` to `agents-shire` (`npm install -g agents-shire` → `shire` command)
- Fix release workflow: add `actions/setup-node` for npm auth, replace `jq` with cross-platform `node -e` scripts, use `process.env` to avoid shell injection
- Trigger release workflow from GitHub Releases instead of bare tag pushes
- Fix deprecated `macos-13` runner → `macos-15`

## Test plan
- [x] No stale `@shire/` references remain (grep verified)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run scripts/build-binaries.ts local` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)