### PR TITLE
Prepare npm publish under @agents-shire + fix compiled binary

### DIFF
--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -93,7 +93,7 @@ async function buildBinary(target: Target, frontendDir: string): Promise<void> {
 
   console.log(`Building ${target.bunTarget} → npm/${target.npmDir}/${target.binaryName}`);
 
-  await $`bun build src/cli.ts --compile --target=${target.bunTarget} --outfile=${outFile}`.cwd(
+  await $`bun build src/cli.ts --compile --target=${target.bunTarget} --outfile=${outFile} --define process.env.NODE_ENV='"production"'`.cwd(
     ROOT,
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,8 @@ const DEFAULT_PORT = 8080;
  * When running as a compiled binary: assets sit alongside the binary.
  */
 function getPackageRoot(): string {
-  // In a compiled binary, argv[1] is undefined (no script path).
-  // When running from source, argv[1] is the script path (e.g., src/cli.ts).
-  if (!process.argv[1]) {
+  // In a compiled Bun binary, argv[1] starts with /$bunfs/root/
+  if (process.argv[1]?.startsWith("/$bunfs/")) {
     return dirname(process.execPath);
   }
   return join(__dirname, "..");


### PR DESCRIPTION
## Summary
- Rename all npm packages from `@shire/cli-*` to `@agents-shire/cli-*` (`shire` name is taken)
- Meta-package: `npm install -g agents-shire` → `shire` command
- Fix release workflow: add `setup-node` for npm auth, cross-platform version scripts, use GitHub Releases trigger, fix deprecated `macos-13` runner
- Fix compiled binary: detect `/$bunfs/` path for correct asset resolution, bake `NODE_ENV=production` at compile time

## Test plan
- [x] Built local binary, confirmed migrations run and server starts
- [x] No stale `@shire/` references (grep verified)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run scripts/build-binaries.ts local` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)