### PR TITLE
Prepare npm publish and fix compiled binary frontend

### DIFF
--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -33,76 +33,19 @@ function getCurrentTarget(): Target | undefined {
   return TARGETS.find((t) => t.npmDir === key);
 }
 
-async function buildFrontend(outDir: string): Promise<void> {
-  console.log("Building frontend...");
-
-  const tailwind = (await import("bun-plugin-tailwind")).default;
-
-  const result = await Bun.build({
-    entrypoints: [join(ROOT, "src", "frontend", "main.tsx")],
-    outdir: outDir,
-    minify: true,
-    splitting: true,
-    target: "browser",
-    publicPath: "/",
-    plugins: [tailwind],
-  });
-
-  if (!result.success) {
-    console.error("Frontend build failed:");
-    for (const log of result.logs) {
-      console.error(log);
-    }
-    process.exit(1);
-  }
-
-  // Copy index.html and update script/link refs to point to built assets
-  const htmlSrc = join(ROOT, "src", "frontend", "index.html");
-  const htmlContent = await Bun.file(htmlSrc).text();
-
-  // Find the built JS and CSS output files
-  const jsOutput = result.outputs.find((o) => o.path.endsWith(".js") && o.kind === "entry-point");
-  const cssOutput = result.outputs.find((o) => o.path.endsWith(".css"));
-
-  const jsName = jsOutput ? jsOutput.path.split("/").pop() : "main.js";
-  const cssName = cssOutput ? cssOutput.path.split("/").pop() : "app.css";
-
-  const updatedHtml = htmlContent
-    .replace(/<link rel="stylesheet" href="[^"]*"/, `<link rel="stylesheet" href="/${cssName}"`)
-    .replace(/<script type="module" src="[^"]*"/, `<script type="module" src="/${jsName}"`);
-
-  await Bun.write(join(outDir, "index.html"), updatedHtml);
-
-  // Copy font files
-  const fontsDir = join(ROOT, "node_modules", "@fontsource-variable", "dm-sans", "files");
-  const { existsSync, readdirSync } = await import("fs");
-  if (existsSync(fontsDir)) {
-    for (const file of readdirSync(fontsDir)) {
-      if (file.endsWith(".woff2") || file.endsWith(".woff")) {
-        cpSync(join(fontsDir, file), join(outDir, file));
-      }
-    }
-  }
-
-  console.log("Frontend build complete.");
-}
-
-async function buildBinary(target: Target, frontendDir: string): Promise<void> {
+async function buildBinary(target: Target): Promise<void> {
   const outDir = join(ROOT, "npm", target.npmDir);
   const outFile = join(outDir, target.binaryName);
 
   console.log(`Building ${target.bunTarget} → npm/${target.npmDir}/${target.binaryName}`);
 
-  await $`bun build src/cli.ts --compile --target=${target.bunTarget} --outfile=${outFile} --define process.env.NODE_ENV='"production"'`.cwd(
+  // bun build --compile handles HTML imports automatically — it bundles
+  // the frontend (JS, CSS, assets) into the binary via the manifest
+  await $`bun build src/cli.ts --compile --target=${target.bunTarget} --outfile=${outFile}`.cwd(
     ROOT,
   );
 
-  // Copy pre-built frontend alongside the binary
-  const frontendDest = join(outDir, "frontend");
-  mkdirSync(frontendDest, { recursive: true });
-  cpSync(frontendDir, frontendDest, { recursive: true });
-
-  // Copy migrations
+  // Copy migrations (needed at runtime, not bundled by bun build)
   const drizzleSrc = join(ROOT, "drizzle");
   const drizzleDest = join(outDir, "drizzle");
   mkdirSync(drizzleDest, { recursive: true });
@@ -114,21 +57,16 @@ async function buildBinary(target: Target, frontendDir: string): Promise<void> {
 async function main(): Promise<void> {
   const localOnly = process.argv.includes("local");
 
-  // Pre-build frontend for production
-  const frontendOut = join(ROOT, "dist", "frontend");
-  mkdirSync(frontendOut, { recursive: true });
-  await buildFrontend(frontendOut);
-
   if (localOnly) {
     const current = getCurrentTarget();
     if (!current) {
       console.error(`No target for current platform: ${process.platform}-${process.arch}`);
       process.exit(1);
     }
-    await buildBinary(current, frontendOut);
+    await buildBinary(current);
   } else {
     for (const target of TARGETS) {
-      await buildBinary(target, frontendOut);
+      await buildBinary(target);
     }
   }
 

--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -1,13 +1,9 @@
 /* See the Tailwind configuration guide for advanced usage
    https://tailwindcss.com/docs/configuration */
 
-@import "tailwindcss" source(none);
+@import "tailwindcss";
 @import "tw-animate-css";
 @plugin "@tailwindcss/typography";
-@source "../css";
-@source "../components";
-@source "../pages";
-@source "../lib";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@ import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import { createApp, handleWsMessage, handleWsClose, type AppContext } from "./server";
 import { ProjectManager } from "./runtime/project-manager";
 import { Scheduler } from "./runtime/scheduler";
-import { join, dirname, resolve } from "path";
+import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { existsSync } from "fs";
+import homepage from "./frontend/index.html";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -57,78 +57,33 @@ export async function startServer(opts: StartOptions = {}) {
   const ctx: AppContext = { projectManager, scheduler };
   const app = createApp(ctx);
 
-  // 5. Start server — dev uses Bun's fullstack bundler, prod serves pre-built files
+  // 5. Start server — Bun's HTML import handles both dev (HMR) and prod (pre-built manifest)
   type WsData = Record<string, unknown>;
-
-  if (DEV) {
-    // Dynamic import of HTML for Bun's fullstack dev bundler (HMR, CSS processing)
-    // Variable path prevents bun build --compile from bundling this
-    const htmlPath = "./frontend/index.html";
-    const homepage = await import(htmlPath);
-
-    const server = Bun.serve<WsData>({
-      port,
-      development: true,
-      routes: {
-        "/api/*": {
-          GET: (req: Request) => app.fetch(req),
-          POST: (req: Request) => app.fetch(req),
-          PUT: (req: Request) => app.fetch(req),
-          PATCH: (req: Request) => app.fetch(req),
-          DELETE: (req: Request) => app.fetch(req),
-          OPTIONS: (req: Request) => app.fetch(req),
-          HEAD: (req: Request) => app.fetch(req),
-        },
-        "/": homepage.default,
-        "/*": homepage.default,
-      },
-      async fetch(req, server) {
-        // WebSocket upgrades (e.g. /ws) — must be in fetch since routes can't do upgrades
-        if (req.headers.get("upgrade") === "websocket") {
-          const upgraded = server.upgrade(req, { data: {} });
-          if (upgraded) return undefined;
-          return new Response("WebSocket upgrade failed", { status: 400 });
-        }
-
-        // Fallback
-        return new Response("Not Found", { status: 404 });
-      },
-      websocket: {
-        message(ws, message) {
-          handleWsMessage(ws, String(message));
-        },
-        close(ws) {
-          handleWsClose(ws);
-        },
-      },
-    });
-
-    console.log(`Shire running at http://localhost:${server.port} (dev)`);
-    return server;
-  }
-
-  // Production: serve pre-built static files
-  const FRONTEND_DIST = join(root, "frontend");
-  const indexHtml = existsSync(join(FRONTEND_DIST, "index.html"))
-    ? Bun.file(join(FRONTEND_DIST, "index.html"))
-    : null;
 
   const server = Bun.serve<WsData>({
     port,
+    development: DEV,
+    routes: {
+      "/api/*": {
+        GET: (req: Request) => app.fetch(req),
+        POST: (req: Request) => app.fetch(req),
+        PUT: (req: Request) => app.fetch(req),
+        PATCH: (req: Request) => app.fetch(req),
+        DELETE: (req: Request) => app.fetch(req),
+        OPTIONS: (req: Request) => app.fetch(req),
+        HEAD: (req: Request) => app.fetch(req),
+      },
+      "/": homepage,
+      "/*": homepage,
+    },
     async fetch(req, server) {
-      const url = new URL(req.url);
-
       if (req.headers.get("upgrade") === "websocket") {
         const upgraded = server.upgrade(req, { data: {} });
         if (upgraded) return undefined;
         return new Response("WebSocket upgrade failed", { status: 400 });
       }
 
-      if (url.pathname.startsWith("/api")) {
-        return app.fetch(req);
-      }
-
-      return serveStatic(url, FRONTEND_DIST, indexHtml);
+      return new Response("Not Found", { status: 404 });
     },
     websocket: {
       message(ws, message) {
@@ -140,36 +95,6 @@ export async function startServer(opts: StartOptions = {}) {
     },
   });
 
-  console.log(`Shire running at http://localhost:${server.port}`);
+  console.log(`Shire running at http://localhost:${server.port}${DEV ? " (dev)" : ""}`);
   return server;
-}
-
-// Production: serve pre-built frontend static files
-async function serveStatic(
-  url: URL,
-  frontendDist: string,
-  indexHtml: ReturnType<typeof Bun.file> | null,
-): Promise<Response> {
-  const filePath = resolve(join(frontendDist, url.pathname));
-
-  // Prevent path traversal — resolved path must stay within frontendDist
-  if (!filePath.startsWith(frontendDist + "/") && filePath !== frontendDist) {
-    return new Response("Forbidden", { status: 403 });
-  }
-
-  // Serve static files (must have a file extension in the last segment)
-  const lastSegment = filePath.substring(filePath.lastIndexOf("/") + 1);
-  if (lastSegment.includes(".")) {
-    const file = Bun.file(filePath);
-    if (await file.exists()) {
-      return new Response(file);
-    }
-  }
-
-  // SPA fallback
-  if (indexHtml) {
-    return new Response(indexHtml);
-  }
-
-  return new Response("Not Found", { status: 404 });
 }


### PR DESCRIPTION
## Summary
- Rename npm packages from `@shire/cli-*` to `@agents-shire/cli-*` (name taken)
- Meta-package: `npm install -g agents-shire` → `shire` command
- Fix release workflow: add `setup-node`, cross-platform scripts, GitHub Releases trigger, `macos-15` runner
- Use Bun HTML import for both dev and prod — eliminates separate frontend build step and manual static file serving (-168 lines)
- Compiled binary now correctly serves JS, CSS, and HTML via Bun's built-in manifest

## Test plan
- [x] Built local binary, confirmed server starts and serves frontend with CSS
- [x] All 442 tests pass
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)