### PR TITLE
Prepare npm publish and fix compiled binary

### DIFF
--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -41,7 +41,7 @@ async function buildBinary(target: Target): Promise<void> {
 
   // bun build --compile handles HTML imports automatically — it bundles
   // the frontend (JS, CSS, assets) into the binary via the manifest
-  await $`bun build src/cli.ts --compile --target=${target.bunTarget} --outfile=${outFile}`.cwd(
+  await $`bun build src/cli.ts --compile --target=${target.bunTarget} --outfile=${outFile} --define process.env.NODE_ENV='"production"'`.cwd(
     ROOT,
   );
 


### PR DESCRIPTION
## Summary
- Rename npm packages to `@agents-shire/cli-*`, meta-package to `agents-shire`
- Fix release workflow: `setup-node`, cross-platform scripts, GitHub Releases trigger, `macos-15` runner
- Use Bun HTML import for both dev and prod frontend serving (-168 lines)
- Set `NODE_ENV=production` in compiled binary so CSS serves correctly

## Verified locally
- [x] Binary starts, serves frontend with full CSS (45KB)
- [x] No "(dev)" label in production binary
- [x] All 442 tests pass
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)