### PR TITLE
Prepare npm publish and fix compiled binary

### DIFF
--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -6,7 +6,7 @@
  *   bun run scripts/build-binaries.ts          # Build all platforms
  *   bun run scripts/build-binaries.ts local     # Build for current platform only
  */
-import { $ } from "bun";
+import tailwind from "bun-plugin-tailwind";
 import { cpSync, mkdirSync } from "fs";
 import { join } from "path";
 
@@ -39,11 +39,26 @@ async function buildBinary(target: Target): Promise<void> {
 
   console.log(`Building ${target.bunTarget} → npm/${target.npmDir}/${target.binaryName}`);
 
-  // bun build --compile handles HTML imports automatically — it bundles
-  // the frontend (JS, CSS, assets) into the binary via the manifest
-  await $`bun build src/cli.ts --compile --target=${target.bunTarget} --outfile=${outFile} --define process.env.NODE_ENV='"production"'`.cwd(
-    ROOT,
-  );
+  const result = await Bun.build({
+    entrypoints: [join(ROOT, "src", "cli.ts")],
+    compile: {
+      target: target.bunTarget as "bun-darwin-arm64",
+      outfile: outFile,
+    },
+    minify: true,
+    define: {
+      "process.env.NODE_ENV": JSON.stringify("production"),
+    },
+    plugins: [tailwind],
+  });
+
+  if (!result.success) {
+    console.error("Build failed:");
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    process.exit(1);
+  }
 
   // Copy migrations (needed at runtime, not bundled by bun build)
   const drizzleSrc = join(ROOT, "drizzle");


### PR DESCRIPTION
## Summary
- Rename npm packages to `@agents-shire/cli-*`, meta-package to `agents-shire`
- Fix release workflow: `setup-node`, cross-platform scripts, GitHub Releases trigger, `macos-15` runner
- Use Bun HTML import for both dev and prod frontend serving (-168 lines)
- Use `Bun.build()` API with `bun-plugin-tailwind` so CSS is fully compiled in the binary
- Set `NODE_ENV=production` in compiled binary

## Verified locally
- [x] Binary starts, serves styled frontend (Playwright verified)
- [x] All 442 tests pass
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)