### PR TITLE
Prepare npm publish and fix compiled binary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,6 @@ export async function startServer(opts: StartOptions = {}) {
         HEAD: (req: Request) => app.fetch(req),
       },
       "/": homepage,
-      "/*": homepage,
     },
     async fetch(req, server) {
       if (req.headers.get("upgrade") === "websocket") {
@@ -83,7 +82,17 @@ export async function startServer(opts: StartOptions = {}) {
         return new Response("WebSocket upgrade failed", { status: 400 });
       }
 
-      return new Response("Not Found", { status: 404 });
+      const { pathname } = new URL(req.url);
+
+      // Requests with file extensions are static assets — if they reach here,
+      // they weren't matched by the manifest's asset routes, so they're stale/missing
+      if (/\.[a-z0-9]+$/i.test(pathname)) {
+        return new Response("Not Found", { status: 404 });
+      }
+
+      // SPA fallback — serve the pre-built index HTML for client-side routing
+      const manifest = homepage as unknown as { index: string };
+      return new Response(Bun.file(manifest.index));
     },
     websocket: {
       message(ws, message) {


### PR DESCRIPTION
## Summary
- Rename npm packages to `@agents-shire/cli-*`, meta-package to `agents-shire`
- Fix release workflow: `setup-node`, cross-platform scripts, GitHub Releases trigger, `macos-15` runner
- Use Bun HTML import + `Bun.build()` API with `bun-plugin-tailwind` for fully styled production binary
- Fix white screen on deploy: stale asset URLs now 404 instead of returning HTML
- SPA fallback serves index HTML for client-side routes without file extensions

## Verified locally (Playwright)
- [x] Styled frontend renders correctly in compiled binary
- [x] Stale chunk URLs return 404
- [x] SPA routes serve index HTML
- [x] All 442 tests pass, lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)