### PR TITLE
Prepare npm publish and fix compiled binary

### DIFF
--- a/src/runtime/harness/claude-code-harness.ts
+++ b/src/runtime/harness/claude-code-harness.ts
@@ -42,6 +42,7 @@ export class ClaudeCodeHarness implements Harness {
             .filter(Boolean)
             .join("\n\n"),
           cwd: this.config.cwd,
+          pathToClaudeCodeExecutable: "claude",
           allowedTools: ["Bash", "Read", "Edit", "Write", "Skill"],
           settingSources: ["project"],
           permissionMode: "bypassPermissions",


### PR DESCRIPTION
## Summary
- Rename npm packages to `@agents-shire/cli-*`, meta-package to `agents-shire`
- Fix release workflow: `setup-node`, cross-platform scripts, GitHub Releases trigger, `macos-15` runner
- Use Bun HTML import + `Bun.build()` API with `bun-plugin-tailwind` for styled production binary
- Fix white screen on deploy: stale asset URLs return 404 instead of HTML
- Fix Claude Code harness in compiled binary: set `pathToClaudeCodeExecutable` to `"claude"` since the SDK's `import.meta.url` path resolution breaks inside `/$bunfs/`

## Verified locally (Playwright)
- [x] Styled frontend renders correctly
- [x] Stale chunk URLs return 404
- [x] Agent harness works — sent message, got response
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)