### PR TITLE
Prepare npm publish and fix compiled binary

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { spawn } from "child_process";
-import { openSync } from "fs";
+import { mkdirSync, openSync } from "fs";
 import {
   writePidFile,
   readPidFile,
@@ -92,8 +92,16 @@ async function handleStart(args: ParsedArgs): Promise<void> {
 
   if (args.daemon && !args.isDaemonChild) {
     // Spawn a detached child process
-    const logFd = openSync(logFilePath(), "a");
-    const child = spawn(process.execPath, [...process.argv.slice(1), "--_daemon-child"], {
+    const logPath = logFilePath();
+    mkdirSync(logPath.substring(0, logPath.lastIndexOf("/")), { recursive: true });
+    const logFd = openSync(logPath, "a");
+    // In compiled binaries, argv[1] is /$bunfs/root/... which isn't a real path.
+    // The binary is process.execPath itself — just pass CLI args, not the script path.
+    const isCompiled = process.argv[1]?.startsWith("/$bunfs/");
+    const childArgs = isCompiled
+      ? [...process.argv.slice(2), "--_daemon-child"]
+      : [...process.argv.slice(1), "--_daemon-child"];
+    const child = spawn(process.execPath, childArgs, {
       detached: true,
       stdio: ["ignore", logFd, logFd],
       env: { ...process.env, NODE_ENV: "production" },


### PR DESCRIPTION
## Summary
- Rename npm packages to `@agents-shire/cli-*`, meta-package to `agents-shire`
- Fix release workflow: `setup-node`, cross-platform scripts, GitHub Releases trigger, `macos-15` runner
- Use Bun HTML import + `Bun.build()` API with `bun-plugin-tailwind` for styled production binary
- Fix white screen on deploy: stale asset URLs return 404 instead of HTML
- Fix Claude Code harness: set `pathToClaudeCodeExecutable` to `"claude"` (SDK's `import.meta.url` breaks in `/$bunfs/`)
- Fix daemon mode: create `~/.shire/` on first run, strip `/$bunfs/` path from argv

## Verified locally
- [x] Styled frontend renders (Playwright)
- [x] Agent harness works — sent message, got response (Playwright)
- [x] Daemon mode: start -d, status, stop all work
- [x] Fresh install (no ~/.shire) works
- [x] Stale chunk URLs return 404
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)