### PR TITLE
Prepare npm publish and fix compiled binary

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { $ } from "bun";
 import { join } from "path";
+import { existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { logFilePath } from "./daemon";
 
 const CLI_PATH = join(import.meta.dirname, "cli.ts");
 
@@ -28,5 +31,41 @@ describe("CLI", () => {
     } catch {
       // Expected to fail with non-zero exit code
     }
+  });
+
+  describe("daemon mode", () => {
+    const testDataDir = join(tmpdir(), `shire-cli-test-${process.pid}`);
+
+    beforeEach(() => {
+      process.env.SHIRE_DATA_DIR = testDataDir;
+      rmSync(testDataDir, { recursive: true, force: true });
+    });
+
+    afterEach(() => {
+      // Stop any daemon we started
+      try {
+        $`bun run ${CLI_PATH} stop`.quiet();
+      } catch {
+        // May not be running
+      }
+      delete process.env.SHIRE_DATA_DIR;
+      rmSync(testDataDir, { recursive: true, force: true });
+    });
+
+    it("creates data directory on first daemon start", async () => {
+      expect(existsSync(testDataDir)).toBe(false);
+
+      // Start daemon — it will fail to boot the server (no db), but the directory should be created
+      try {
+        await $`bun run ${CLI_PATH} start -d -p 19876`
+          .env({ ...process.env, SHIRE_DATA_DIR: testDataDir })
+          .text();
+      } catch {
+        // Server may fail, but directory should exist
+      }
+
+      expect(existsSync(testDataDir)).toBe(true);
+      expect(existsSync(logFilePath())).toBe(true);
+    });
   });
 });

--- a/src/runtime/harness/claude-code-harness.test.ts
+++ b/src/runtime/harness/claude-code-harness.test.ts
@@ -314,6 +314,16 @@ describe("ClaudeCodeHarness", () => {
     expect(String(errorEvent!.payload.message)).toContain("something went wrong");
   });
 
+  test("sendMessage() passes pathToClaudeCodeExecutable", async () => {
+    const mockQuery = createMockQuery([resultSuccess("Hi", "s1")]);
+    const harness = new ClaudeCodeHarness(mockQuery);
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hello");
+
+    expect(calls(mockQuery)[0][0].options?.pathToClaudeCodeExecutable).toBe("claude");
+  });
+
   test("sendMessage() prefixes from agent name", async () => {
     const mockQuery = createMockQuery([resultSuccess("Ok", "s1")]);
     const harness = new ClaudeCodeHarness(mockQuery);


### PR DESCRIPTION
## Summary
- Rename npm packages to `@agents-shire/cli-*`, meta-package to `agents-shire`
- Fix release workflow: `setup-node`, cross-platform scripts, GitHub Releases trigger, `macos-15` runner
- Use Bun HTML import + `Bun.build()` API with `bun-plugin-tailwind` for styled production binary
- Fix white screen on deploy: stale asset URLs return 404 instead of HTML
- Fix Claude Code harness: set `pathToClaudeCodeExecutable` to `"claude"`
- Fix daemon mode: create `~/.shire/` on first run, strip `/$bunfs/` path from argv

## Verified locally
- [x] Styled frontend renders (Playwright)
- [x] Agent harness works (Playwright)
- [x] Daemon mode: start -d, status, stop (including fresh install)
- [x] Stale chunk URLs return 404
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)