### PR TITLE
Show clickable URL and auto-open browser on start

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -37,8 +37,17 @@ describe("CLI", () => {
 
   describe("openBrowser", () => {
     it("spawns the platform-specific open command", () => {
-      const prev = process.env.SHIRE_NO_OPEN;
-      delete process.env.SHIRE_NO_OPEN;
+      const saved: Record<string, string | undefined> = {};
+      const keys = ["SHIRE_NO_OPEN", "SSH_CLIENT", "SSH_TTY"];
+      for (const k of keys) {
+        saved[k] = process.env[k];
+        delete process.env[k];
+      }
+      // Ensure DISPLAY is set on Linux so shouldOpenBrowser() returns true
+      if (process.platform === "linux") {
+        saved.DISPLAY = process.env.DISPLAY;
+        process.env.DISPLAY = ":0";
+      }
       const spawnSpy = spyOn(Bun, "spawn").mockReturnValue({} as ReturnType<typeof Bun.spawn>);
       try {
         openBrowser("http://localhost:8080");
@@ -48,7 +57,10 @@ describe("CLI", () => {
         expect(args).toEqual([expectedCmd, "http://localhost:8080"]);
       } finally {
         spawnSpy.mockRestore();
-        if (prev !== undefined) process.env.SHIRE_NO_OPEN = prev;
+        for (const k of [...keys, "DISPLAY"]) {
+          if (saved[k] !== undefined) process.env[k] = saved[k];
+          else delete process.env[k];
+        }
       }
     });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { logFilePath } from "./daemon";
-import { openBrowser } from "./cli";
+import { openBrowser, shouldOpenBrowser } from "./cli";
 
 const CLI_PATH = join(import.meta.dirname, "cli.ts");
 
@@ -18,6 +18,7 @@ describe("CLI", () => {
     expect(result).toContain("status");
     expect(result).toContain("--port");
     expect(result).toContain("--daemon");
+    expect(result).toContain("--no-open");
   });
 
   it("prints version with --version", async () => {
@@ -60,6 +61,17 @@ describe("CLI", () => {
       } finally {
         spawnSpy.mockRestore();
         delete process.env.SHIRE_NO_OPEN;
+      }
+    });
+
+    it("skips opening in SSH sessions", () => {
+      const prev = process.env.SSH_CLIENT;
+      process.env.SSH_CLIENT = "192.168.1.1 12345 22";
+      try {
+        expect(shouldOpenBrowser()).toBe(false);
+      } finally {
+        if (prev !== undefined) process.env.SSH_CLIENT = prev;
+        else delete process.env.SSH_CLIENT;
       }
     });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { $ } from "bun";
 import { join } from "path";
 import { existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { logFilePath } from "./daemon";
+import { openBrowser } from "./cli";
 
 const CLI_PATH = join(import.meta.dirname, "cli.ts");
 
@@ -33,6 +34,50 @@ describe("CLI", () => {
     }
   });
 
+  describe("openBrowser", () => {
+    it("spawns the platform-specific open command", () => {
+      const prev = process.env.SHIRE_NO_OPEN;
+      delete process.env.SHIRE_NO_OPEN;
+      const spawnSpy = spyOn(Bun, "spawn").mockReturnValue({} as ReturnType<typeof Bun.spawn>);
+      try {
+        openBrowser("http://localhost:8080");
+        expect(spawnSpy).toHaveBeenCalledTimes(1);
+        const args = spawnSpy.mock.calls[0][0] as string[];
+        const expectedCmd = process.platform === "darwin" ? "open" : "xdg-open";
+        expect(args).toEqual([expectedCmd, "http://localhost:8080"]);
+      } finally {
+        spawnSpy.mockRestore();
+        if (prev !== undefined) process.env.SHIRE_NO_OPEN = prev;
+      }
+    });
+
+    it("skips opening when SHIRE_NO_OPEN is set", () => {
+      process.env.SHIRE_NO_OPEN = "1";
+      const spawnSpy = spyOn(Bun, "spawn").mockReturnValue({} as ReturnType<typeof Bun.spawn>);
+      try {
+        openBrowser("http://localhost:8080");
+        expect(spawnSpy).not.toHaveBeenCalled();
+      } finally {
+        spawnSpy.mockRestore();
+        delete process.env.SHIRE_NO_OPEN;
+      }
+    });
+
+    it("does not throw when spawn fails", () => {
+      const prev = process.env.SHIRE_NO_OPEN;
+      delete process.env.SHIRE_NO_OPEN;
+      const spawnSpy = spyOn(Bun, "spawn").mockImplementation(() => {
+        throw new Error("spawn failed");
+      });
+      try {
+        expect(() => openBrowser("http://localhost:8080")).not.toThrow();
+      } finally {
+        spawnSpy.mockRestore();
+        if (prev !== undefined) process.env.SHIRE_NO_OPEN = prev;
+      }
+    });
+  });
+
   describe("daemon mode", () => {
     const testDataDir = join(tmpdir(), `shire-cli-test-${process.pid}`);
 
@@ -52,18 +97,15 @@ describe("CLI", () => {
       rmSync(testDataDir, { recursive: true, force: true });
     });
 
-    it("creates data directory on first daemon start", async () => {
+    it("daemon output includes clickable URL and creates data directory", async () => {
       expect(existsSync(testDataDir)).toBe(false);
 
-      // Start daemon — it will fail to boot the server (no db), but the directory should be created
-      try {
-        await $`bun run ${CLI_PATH} start -d -p 19876`
-          .env({ ...process.env, SHIRE_DATA_DIR: testDataDir })
-          .text();
-      } catch {
-        // Server may fail, but directory should exist
-      }
+      const result = await $`bun run ${CLI_PATH} start -d -p 19876`
+        .env({ ...process.env, SHIRE_DATA_DIR: testDataDir, SHIRE_NO_OPEN: "1" })
+        .text();
 
+      expect(result).toContain("http://localhost:19876");
+      expect(result).toContain("URL:");
       expect(existsSync(testDataDir)).toBe(true);
       expect(existsSync(logFilePath())).toBe(true);
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ interface ParsedArgs {
   command: string;
   port: number;
   daemon: boolean;
+  noOpen: boolean;
   isDaemonChild: boolean;
 }
 
@@ -27,6 +28,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let command = "start";
   let port = 8080;
   let daemon = false;
+  let noOpen = false;
   let isDaemonChild = false;
 
   for (let i = 0; i < args.length; i++) {
@@ -38,6 +40,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       command = "version";
     } else if (arg === "--daemon" || arg === "-d") {
       daemon = true;
+    } else if (arg === "--no-open") {
+      noOpen = true;
     } else if (arg === "--_daemon-child") {
       isDaemonChild = true;
     } else if (arg === "--port" || arg === "-p") {
@@ -56,11 +60,20 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
   }
 
-  return { command, port, daemon, isDaemonChild };
+  return { command, port, daemon, noOpen, isDaemonChild };
+}
+
+export function shouldOpenBrowser(): boolean {
+  if (process.env.SHIRE_NO_OPEN) return false;
+  if (process.env.SSH_CLIENT || process.env.SSH_TTY) return false;
+  if (process.platform === "linux" && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    return false;
+  }
+  return true;
 }
 
 export function openBrowser(url: string): void {
-  if (process.env.SHIRE_NO_OPEN) return;
+  if (!shouldOpenBrowser()) return;
   if (!/^https?:\/\//.test(url)) return;
   try {
     const cmd = process.platform === "darwin" ? "open" : "xdg-open";
@@ -84,6 +97,7 @@ Commands:
 Options:
   -p, --port     Port to listen on (default: 8080)
   -d, --daemon   Run in background (daemon mode)
+  --no-open      Don't open browser on start
   -h, --help     Show this help message
   -v, --version  Show version
 `);
@@ -146,7 +160,9 @@ async function handleStart(args: ParsedArgs): Promise<void> {
   }
 
   const server = await startServer({ port: args.port });
-  openBrowser(`http://localhost:${server.port}`);
+  if (!args.noOpen) {
+    openBrowser(`http://localhost:${server.port}`);
+  }
 }
 
 function handleStop(): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,17 @@ function parseArgs(argv: string[]): ParsedArgs {
   return { command, port, daemon, isDaemonChild };
 }
 
+export function openBrowser(url: string): void {
+  if (process.env.SHIRE_NO_OPEN) return;
+  if (!/^https?:\/\//.test(url)) return;
+  try {
+    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+    Bun.spawn([cmd, url], { stdio: ["ignore", "ignore", "ignore"] });
+  } catch {
+    // Non-fatal — user can open manually
+  }
+}
+
 function printHelp(): void {
   console.log(`shire v${VERSION} — AI agent orchestration platform
 
@@ -113,8 +124,9 @@ async function handleStart(args: ParsedArgs): Promise<void> {
     }
 
     child.unref();
+    const url = `http://localhost:${args.port}`;
     console.log(`Shire daemon started (PID ${child.pid})`);
-    console.log(`  Port: ${args.port}`);
+    console.log(`  URL:  ${url}`);
     console.log(`  Logs: ${logFilePath()}`);
     process.exit(0);
   }
@@ -133,7 +145,8 @@ async function handleStart(args: ParsedArgs): Promise<void> {
     process.on("SIGINT", cleanup);
   }
 
-  await startServer({ port: args.port });
+  const server = await startServer({ port: args.port });
+  openBrowser(`http://localhost:${server.port}`);
 }
 
 function handleStop(): void {


### PR DESCRIPTION
## Summary
- Daemon mode now prints `URL: http://localhost:PORT` instead of `Port: 8080`, making the URL clickable in terminals
- Both foreground and daemon modes auto-open the default browser after the server is ready
- Added `SHIRE_NO_OPEN` env var to suppress browser opening (for tests/CI)
- URL validation guard prevents `openBrowser` from handling non-HTTP schemes

## Test plan
- [x] `bun test` — 447 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: `bun run dev` opens browser automatically
- [ ] Manual: `shire start -d` prints clickable URL and opens browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)