### PR TITLE
feat: restore agent skills with filesystem-based storage

### DIFF
--- a/src/frontend/components/AgentForm.tsx
+++ b/src/frontend/components/AgentForm.tsx
@@ -12,7 +12,7 @@ import {
   DialogDescription,
 } from "./ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
-import type { Agent, HarnessType } from "./types";
+import type { Agent, HarnessType, Skill, SkillReference } from "./types";
 
 export interface AgentFormPayload {
   id?: string;
@@ -21,6 +21,7 @@ export interface AgentFormPayload {
   harness: HarnessType;
   model?: string;
   systemPrompt?: string;
+  skills?: Skill[];
 }
 
 interface AgentFormProps {
@@ -39,6 +40,7 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
   const [model, setModel] = React.useState("");
   const [systemPrompt, setSystemPrompt] = React.useState("");
   const [harness, setHarness] = React.useState<HarnessType>("claude_code");
+  const [skills, setSkills] = React.useState<Skill[]>([]);
 
   const nameValid = name === "" || SLUG_REGEX.test(name);
 
@@ -48,6 +50,7 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
     setModel(agent?.model || "");
     setSystemPrompt(agent?.systemPrompt || "");
     setHarness(agent?.harness || "claude_code");
+    setSkills(agent?.skills || []);
   }, [agent]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -62,6 +65,7 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
       harness,
       model: model || undefined,
       systemPrompt: systemPrompt || undefined,
+      skills: skills.length > 0 ? skills : undefined,
     };
     if (isUpdate) {
       payload.id = agent!.id;
@@ -69,6 +73,42 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
 
     onSave(event, payload);
     onClose();
+  };
+
+  const addSkill = () => setSkills([...skills, { name: "", description: "", content: "" }]);
+  const removeSkill = (idx: number) => setSkills(skills.filter((_, i) => i !== idx));
+  const updateSkill = (idx: number, field: "name" | "description" | "content", value: string) => {
+    const updated = [...skills];
+    updated[idx] = { ...updated[idx], [field]: value };
+    setSkills(updated);
+  };
+  const addReference = (skillIdx: number) => {
+    const updated = [...skills];
+    updated[skillIdx] = {
+      ...updated[skillIdx],
+      references: [...(updated[skillIdx].references || []), { name: "", content: "" }],
+    };
+    setSkills(updated);
+  };
+  const removeReference = (skillIdx: number, refIdx: number) => {
+    const updated = [...skills];
+    updated[skillIdx] = {
+      ...updated[skillIdx],
+      references: (updated[skillIdx].references || []).filter((_, i) => i !== refIdx),
+    };
+    setSkills(updated);
+  };
+  const updateReference = (
+    skillIdx: number,
+    refIdx: number,
+    field: keyof SkillReference,
+    value: string,
+  ) => {
+    const updated = [...skills];
+    const refs = [...(updated[skillIdx].references || [])];
+    refs[refIdx] = { ...refs[refIdx], [field]: value };
+    updated[skillIdx] = { ...updated[skillIdx], references: refs };
+    setSkills(updated);
   };
 
   return (
@@ -150,6 +190,86 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
               placeholder="Instructions for the agent..."
               rows={4}
             />
+          </div>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label>Skills</Label>
+              <Button type="button" variant="outline" size="sm" onClick={addSkill}>
+                Add Skill
+              </Button>
+            </div>
+            {skills.map((skill, idx) => (
+              <div key={idx} className="rounded-lg border border-border p-3 space-y-2">
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={skill.name}
+                    onChange={(e) => updateSkill(idx, "name", e.target.value)}
+                    placeholder="e.g. web-scraping"
+                    className="flex-1"
+                  />
+                  <Button type="button" variant="ghost" size="sm" onClick={() => removeSkill(idx)}>
+                    Remove
+                  </Button>
+                </div>
+                <Input
+                  value={skill.description}
+                  onChange={(e) => updateSkill(idx, "description", e.target.value)}
+                  placeholder="When to use this skill..."
+                />
+                <Textarea
+                  value={skill.content}
+                  onChange={(e) => updateSkill(idx, "content", e.target.value)}
+                  placeholder="Markdown instructions..."
+                  rows={6}
+                  className="font-mono text-sm"
+                />
+                <div className="space-y-2 pl-3 border-l-2 border-border">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs text-muted-foreground">References</Label>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => addReference(idx)}
+                    >
+                      Add Reference
+                    </Button>
+                  </div>
+                  {(skill.references || []).map((ref, refIdx) => (
+                    <div key={refIdx} className="rounded border border-border p-2 space-y-1">
+                      <div className="flex items-center gap-2">
+                        <Input
+                          value={ref.name}
+                          onChange={(e) => updateReference(idx, refIdx, "name", e.target.value)}
+                          placeholder="e.g. api-patterns.md"
+                          className="flex-1 text-sm"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => removeReference(idx, refIdx)}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                      <Textarea
+                        value={ref.content}
+                        onChange={(e) => updateReference(idx, refIdx, "content", e.target.value)}
+                        placeholder="Reference content..."
+                        rows={3}
+                        className="font-mono text-sm"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+            {skills.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No skills defined. Add skills to give the agent specialized knowledge.
+              </p>
+            )}
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={onClose}>

--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -72,6 +72,7 @@ export default function ProjectLayout() {
         harness: catalogSelectedAgent.harness,
         model: catalogSelectedAgent.model,
         systemPrompt: catalogSelectedAgent.systemPrompt,
+        skills: [],
         status: "idle",
         busy: false,
         unreadCount: 0,

--- a/src/frontend/components/types.ts
+++ b/src/frontend/components/types.ts
@@ -8,6 +8,18 @@ export type HarnessType = "pi" | "claude_code";
 
 export type AgentStatus = "created" | "starting" | "bootstrapping" | "active" | "idle" | "crashed";
 
+export interface SkillReference {
+  name: string;
+  content: string;
+}
+
+export interface Skill {
+  name: string;
+  description: string;
+  content: string;
+  references?: SkillReference[];
+}
+
 export interface AgentOverview {
   id: string;
   name: string;
@@ -21,6 +33,7 @@ export interface Agent extends AgentOverview {
   model?: string;
   systemPrompt?: string;
   harness?: HarnessType;
+  skills?: Skill[];
 }
 
 export interface CatalogAgentSummary {

--- a/src/frontend/lib/hooks/agents.ts
+++ b/src/frontend/lib/hooks/agents.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { unwrap } from "./util";
-import type { AgentOverview, Agent } from "../../components/types";
+import type { AgentOverview, Agent, Skill } from "../../components/types";
 
 export function useAgents(projectId: string | undefined) {
   return useQuery<AgentOverview[]>({
@@ -33,6 +33,7 @@ interface AgentMutationData {
   harness?: "claude_code" | "pi";
   model?: string;
   systemPrompt?: string;
+  skills?: Skill[];
 }
 
 export function useCreateAgent(projectId: string) {

--- a/src/frontend/test/AgentForm.test.tsx
+++ b/src/frontend/test/AgentForm.test.tsx
@@ -19,6 +19,101 @@ function renderForm(agent: Agent | null = null) {
 }
 
 describe("AgentForm", () => {
+  it("renders skills section with empty state", () => {
+    renderForm();
+    expect(
+      screen.getByText("No skills defined. Add skills to give the agent specialized knowledge."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Add Skill")).toBeInTheDocument();
+  });
+
+  it("adds a skill when clicking Add Skill", async () => {
+    renderForm();
+    await userEvent.click(screen.getByText("Add Skill"));
+    expect(screen.getByPlaceholderText("e.g. web-scraping")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("When to use this skill...")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Markdown instructions...")).toBeInTheDocument();
+  });
+
+  it("removes a skill when clicking Remove", async () => {
+    renderForm();
+    await userEvent.click(screen.getByText("Add Skill"));
+    expect(screen.getByPlaceholderText("e.g. web-scraping")).toBeInTheDocument();
+
+    const removeButtons = screen.getAllByText("Remove");
+    await userEvent.click(removeButtons[0]);
+    expect(screen.queryByPlaceholderText("e.g. web-scraping")).not.toBeInTheDocument();
+  });
+
+  it("includes skills in structured payload", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    // Fill required name field
+    const nameInput = screen.getByLabelText("Name");
+    await user.clear(nameInput);
+    await user.paste("test-agent");
+
+    // Add and fill a skill
+    await user.click(screen.getByText("Add Skill"));
+
+    const skillName = screen.getByPlaceholderText("e.g. web-scraping");
+    await user.clear(skillName);
+    await user.paste("my-skill");
+
+    const skillDesc = screen.getByPlaceholderText("When to use this skill...");
+    await user.clear(skillDesc);
+    await user.paste("Use for testing");
+
+    const skillContent = screen.getByPlaceholderText("Markdown instructions...");
+    await user.clear(skillContent);
+    await user.paste("# Test Skill");
+
+    await user.click(screen.getByText("Save Agent"));
+
+    expect(onSave).toHaveBeenCalledWith(
+      "create-agent",
+      expect.objectContaining({ name: "test-agent" }),
+    );
+
+    const payload = (onSave.mock.calls[onSave.mock.calls.length - 1] as unknown[])[1] as Record<
+      string,
+      unknown
+    >;
+    const payloadSkills = payload.skills as Array<Record<string, string>>;
+    expect(payloadSkills).toBeDefined();
+    expect(payloadSkills).toHaveLength(1);
+    expect(payloadSkills[0].name).toBe("my-skill");
+    expect(payloadSkills[0].description).toBe("Use for testing");
+    expect(payloadSkills[0].content).toBe("# Test Skill");
+  });
+
+  it("loads skills from existing agent", () => {
+    const agent: Agent = {
+      id: "a-test",
+      name: "test",
+      status: "created",
+      busy: false,
+      unreadCount: 0,
+      harness: "claude_code",
+      skills: [
+        { name: "existing-skill", description: "An existing skill", content: "Some instructions" },
+      ],
+    };
+
+    renderForm(agent);
+    expect(screen.getByDisplayValue("existing-skill")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("An existing skill")).toBeInTheDocument();
+  });
+
+  it("adds a reference to a skill", async () => {
+    renderForm();
+    await userEvent.click(screen.getByText("Add Skill"));
+    await userEvent.click(screen.getByText("Add Reference"));
+    expect(screen.getByPlaceholderText("e.g. api-patterns.md")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Reference content...")).toBeInTheDocument();
+  });
+
   it("shows validation error for invalid agent name", async () => {
     const user = userEvent.setup();
     renderForm();

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -3,6 +3,20 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { AppEnv } from "../types";
 
+const skillSchema = z.object({
+  name: z.string().regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, "Invalid skill name"),
+  description: z.string(),
+  content: z.string(),
+  references: z
+    .array(
+      z.object({
+        name: z.string().regex(/^[^/\\]+$/, "Invalid reference filename"),
+        content: z.string(),
+      }),
+    )
+    .optional(),
+});
+
 export const agentRoutes = new Hono<AppEnv>()
   .get("/projects/:id/agents", (c) => {
     const pm = c.get("projectManager");
@@ -20,6 +34,7 @@ export const agentRoutes = new Hono<AppEnv>()
         harness: z.enum(["claude_code", "pi"]).optional(),
         model: z.string().optional(),
         systemPrompt: z.string().optional(),
+        skills: z.array(skillSchema).optional(),
       }),
     ),
     async (c) => {
@@ -52,6 +67,7 @@ export const agentRoutes = new Hono<AppEnv>()
         harness: z.enum(["claude_code", "pi"]).optional(),
         model: z.string().optional(),
         systemPrompt: z.string().optional(),
+        skills: z.array(skillSchema).optional(),
       }),
     ),
     async (c) => {

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -12,6 +12,7 @@ import {
 } from "../events";
 import * as agentsService from "../services/agents";
 import * as workspace from "../services/workspace";
+import * as skillsService from "../services/skills";
 import { createHarness, type Harness, type HarnessType } from "./harness";
 import type { AgentEvent } from "./harness/types";
 
@@ -836,6 +837,8 @@ export class AgentManager {
 
   private async setupWorkspace(): Promise<void> {
     await workspace.ensureAgentDirs(this.projectId, this.agentId);
+    const agent = agentsService.getAgent(this.agentId);
+    await skillsService.ensureSkillsDir(this.projectId, this.agentId, agent?.harness ?? undefined);
   }
 
   private buildInternalPrompt(): string {

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -12,6 +12,8 @@ import { getDb } from "../db";
 import { AgentManager } from "./agent-manager";
 import * as agentsService from "../services/agents";
 import * as workspace from "../services/workspace";
+import * as skillsService from "../services/skills";
+import type { Skill } from "../services/skills";
 import { valid as isValidSlug } from "../services/slug";
 
 export interface AgentFields {
@@ -20,6 +22,7 @@ export interface AgentFields {
   harness?: string;
   model?: string;
   systemPrompt?: string;
+  skills?: Skill[];
 }
 
 export class Coordinator {
@@ -108,6 +111,11 @@ export class Coordinator {
       return a;
     });
 
+    // Write skills to filesystem (after txn so workspace dirs exist)
+    if (params.skills?.length) {
+      await skillsService.writeSkills(this.projectId, agent.id, params.skills, params.harness);
+    }
+
     // Start process
     await this.startAgentManager(agent.id, agent.name);
     await this.writePeersYaml();
@@ -133,8 +141,28 @@ export class Coordinator {
       if (conflict) return { ok: false, error: `Agent "${params.name}" already exists` };
     }
 
-    // Update DB fields
-    agentsService.updateAgent(agentId, params);
+    // Update DB fields + migrate skills if harness changed
+    const harnessChanged = params.harness && params.harness !== agent.harness;
+    try {
+      getDb().transaction((tx) => {
+        agentsService.updateAgent(agentId, params, tx);
+        if (harnessChanged) {
+          skillsService.copySkillsSync(this.projectId, agentId, agent.harness, params.harness!);
+        }
+      });
+    } catch (err) {
+      return { ok: false, error: String(err) };
+    }
+    // Clean up old harness skills dir only after successful commit
+    if (harnessChanged) {
+      skillsService.removeSkillsDirSync(this.projectId, agentId, agent.harness);
+    }
+
+    // Write skills to filesystem if provided
+    if (params.skills !== undefined) {
+      const harness = params.harness ?? agent.harness ?? undefined;
+      await skillsService.writeSkills(this.projectId, agentId, params.skills, harness);
+    }
 
     // Restart the agent to pick up changes
     const proc = this.agents.get(agentId);
@@ -225,6 +253,11 @@ export class Coordinator {
     if (!proc) return null;
 
     const agent = agentsService.getAgent(agentId);
+    const agentSkills = await skillsService.readSkills(
+      this.projectId,
+      agentId,
+      agent?.harness ?? undefined,
+    );
     return {
       id: agentId,
       name: proc.agentName,
@@ -232,6 +265,7 @@ export class Coordinator {
       harness: agent?.harness ?? "claude_code",
       model: agent?.model ?? null,
       systemPrompt: agent?.systemPrompt ?? null,
+      skills: agentSkills,
       status: proc.status,
     };
   }

--- a/src/services/skills.test.ts
+++ b/src/services/skills.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { rmSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import * as skills from "./skills";
+import * as workspace from "./workspace";
+
+const tmpBase = join(tmpdir(), `shire-skills-test-${Date.now()}`);
+const PROJECT_ID = "test-project";
+const AGENT_ID = "test-agent";
+
+beforeEach(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+  process.env.SHIRE_PROJECTS_DIR = tmpBase;
+});
+
+afterAll(() => {
+  rmSync(tmpBase, { recursive: true, force: true });
+  delete process.env.SHIRE_PROJECTS_DIR;
+});
+
+describe("parseSkillMd / composeSkillMd", () => {
+  it("round-trips a skill", () => {
+    const skill: skills.Skill = {
+      name: "my-skill",
+      description: "A test skill",
+      content: "# Instructions\n\nDo the thing.",
+    };
+    const md = skills.composeSkillMd(skill);
+    const parsed = skills.parseSkillMd(md);
+    expect(parsed.name).toBe("my-skill");
+    expect(parsed.description).toBe("A test skill");
+    expect(parsed.content).toBe("# Instructions\n\nDo the thing.");
+  });
+
+  it("handles missing frontmatter", () => {
+    const parsed = skills.parseSkillMd("Just some content");
+    expect(parsed.name).toBe("");
+    expect(parsed.description).toBe("");
+    expect(parsed.content).toBe("Just some content");
+  });
+
+  it("round-trips a skill with YAML-special characters in description", () => {
+    const skill: skills.Skill = {
+      name: "tricky-skill",
+      description: "Use for: APIs, testing & more",
+      content: "Some content",
+    };
+    const md = skills.composeSkillMd(skill);
+    const parsed = skills.parseSkillMd(md);
+    expect(parsed.description).toBe("Use for: APIs, testing & more");
+  });
+
+  it("handles empty content", () => {
+    const md = "---\nname: empty\ndescription: nothing\n---\n";
+    const parsed = skills.parseSkillMd(md);
+    expect(parsed.name).toBe("empty");
+    expect(parsed.content).toBe("");
+  });
+});
+
+describe("readSkills / writeSkills", () => {
+  it("returns empty array when skills dir does not exist", async () => {
+    const result = await skills.readSkills(PROJECT_ID, AGENT_ID);
+    expect(result).toEqual([]);
+  });
+
+  it("writes and reads skills", async () => {
+    const input: skills.Skill[] = [
+      {
+        name: "web-scraping",
+        description: "Scrape websites",
+        content: "# Web Scraping\n\nUse fetch.",
+      },
+      { name: "data-analysis", description: "Analyze data", content: "# Data Analysis" },
+    ];
+
+    await skills.writeSkills(PROJECT_ID, AGENT_ID, input);
+    const result = await skills.readSkills(PROJECT_ID, AGENT_ID);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("data-analysis");
+    expect(result[1].name).toBe("web-scraping");
+    expect(result[1].content).toBe("# Web Scraping\n\nUse fetch.");
+  });
+
+  it("writes and reads skills with references", async () => {
+    const input: skills.Skill[] = [
+      {
+        name: "api-skill",
+        description: "Use APIs",
+        content: "# API Skill",
+        references: [
+          { name: "patterns.md", content: "# Patterns\n\nUse REST." },
+          { name: "examples.json", content: '{"key": "value"}' },
+        ],
+      },
+    ];
+
+    await skills.writeSkills(PROJECT_ID, AGENT_ID, input);
+    const result = await skills.readSkills(PROJECT_ID, AGENT_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].references).toHaveLength(2);
+    const refNames = result[0].references!.map((r) => r.name).sort();
+    expect(refNames).toEqual(["examples.json", "patterns.md"]);
+    expect(result[0].references!.find((r) => r.name === "patterns.md")!.content).toBe(
+      "# Patterns\n\nUse REST.",
+    );
+  });
+
+  it("reconciles: removes deleted skills and stale references", async () => {
+    // Write initial set
+    await skills.writeSkills(PROJECT_ID, AGENT_ID, [
+      {
+        name: "keep-me",
+        description: "Kept",
+        content: "kept",
+        references: [{ name: "old-ref.md", content: "old" }],
+      },
+      { name: "remove-me", description: "Removed", content: "removed" },
+    ]);
+
+    // Write updated set (remove-me gone, old-ref.md replaced)
+    await skills.writeSkills(PROJECT_ID, AGENT_ID, [
+      {
+        name: "keep-me",
+        description: "Kept",
+        content: "kept",
+        references: [{ name: "new-ref.md", content: "new" }],
+      },
+    ]);
+
+    const result = await skills.readSkills(PROJECT_ID, AGENT_ID);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("keep-me");
+    expect(result[0].references).toHaveLength(1);
+    expect(result[0].references![0].name).toBe("new-ref.md");
+
+    // Verify remove-me dir is gone
+    const dir = workspace.skillDir(PROJECT_ID, AGENT_ID, "remove-me");
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("deletes a single skill", async () => {
+    await skills.writeSkills(PROJECT_ID, AGENT_ID, [
+      { name: "to-delete", description: "test", content: "test" },
+    ]);
+
+    await skills.deleteSkill(PROJECT_ID, AGENT_ID, "to-delete");
+    const result = await skills.readSkills(PROJECT_ID, AGENT_ID);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("path traversal protection", () => {
+  it("rejects skill name with path traversal", async () => {
+    await expect(
+      skills.writeSkill(PROJECT_ID, AGENT_ID, {
+        name: "../evil",
+        description: "bad",
+        content: "bad",
+      }),
+    ).rejects.toThrow("Invalid skill name");
+  });
+
+  it("rejects skill name with slashes", async () => {
+    await expect(
+      skills.writeSkill(PROJECT_ID, AGENT_ID, {
+        name: "foo/bar",
+        description: "bad",
+        content: "bad",
+      }),
+    ).rejects.toThrow("Invalid skill name");
+  });
+
+  it("rejects empty skill name", async () => {
+    await expect(
+      skills.writeSkill(PROJECT_ID, AGENT_ID, { name: "", description: "bad", content: "bad" }),
+    ).rejects.toThrow("Invalid skill name");
+  });
+
+  it("rejects reference name with path traversal", async () => {
+    await expect(
+      skills.writeSkill(PROJECT_ID, AGENT_ID, {
+        name: "valid-skill",
+        description: "test",
+        content: "test",
+        references: [{ name: "../../.env", content: "SECRET=bad" }],
+      }),
+    ).rejects.toThrow("Invalid reference name");
+  });
+
+  it("rejects reference named SKILL.md", async () => {
+    await expect(
+      skills.writeSkill(PROJECT_ID, AGENT_ID, {
+        name: "valid-skill",
+        description: "test",
+        content: "test",
+        references: [{ name: "SKILL.md", content: "overwrite" }],
+      }),
+    ).rejects.toThrow("Invalid reference name");
+  });
+});
+
+describe("harness-specific paths", () => {
+  it("writes skills to .claude/skills for claude_code", async () => {
+    await skills.writeSkills(
+      PROJECT_ID,
+      AGENT_ID,
+      [{ name: "test-skill", description: "test", content: "test" }],
+      "claude_code",
+    );
+
+    const skillMd = join(
+      workspace.agentDir(PROJECT_ID, AGENT_ID),
+      ".claude",
+      "skills",
+      "test-skill",
+      "SKILL.md",
+    );
+    expect(existsSync(skillMd)).toBe(true);
+  });
+
+  it("writes skills to .agents/skills for pi", async () => {
+    await skills.writeSkills(
+      PROJECT_ID,
+      AGENT_ID,
+      [{ name: "test-skill", description: "test", content: "test" }],
+      "pi",
+    );
+
+    const skillMd = join(
+      workspace.agentDir(PROJECT_ID, AGENT_ID),
+      ".agents",
+      "skills",
+      "test-skill",
+      "SKILL.md",
+    );
+    expect(existsSync(skillMd)).toBe(true);
+  });
+
+  it("defaults to .agents/skills when no harness specified", async () => {
+    await skills.writeSkills(PROJECT_ID, AGENT_ID, [
+      { name: "test-skill", description: "test", content: "test" },
+    ]);
+
+    const skillMd = join(
+      workspace.agentDir(PROJECT_ID, AGENT_ID),
+      ".agents",
+      "skills",
+      "test-skill",
+      "SKILL.md",
+    );
+    expect(existsSync(skillMd)).toBe(true);
+  });
+});
+
+describe("copySkillsSync / removeSkillsDirSync", () => {
+  it("copies skills from one harness path to another", async () => {
+    await skills.writeSkills(
+      PROJECT_ID,
+      AGENT_ID,
+      [
+        {
+          name: "my-skill",
+          description: "test",
+          content: "hello",
+          references: [{ name: "ref.md", content: "ref content" }],
+        },
+      ],
+      "claude_code",
+    );
+
+    skills.copySkillsSync(PROJECT_ID, AGENT_ID, "claude_code", "pi");
+
+    const piSkillMd = join(
+      workspace.agentDir(PROJECT_ID, AGENT_ID),
+      ".agents",
+      "skills",
+      "my-skill",
+      "SKILL.md",
+    );
+    expect(existsSync(piSkillMd)).toBe(true);
+    expect(readFileSync(piSkillMd, "utf-8")).toContain("hello");
+
+    // Reference file also copied
+    const piRef = join(
+      workspace.agentDir(PROJECT_ID, AGENT_ID),
+      ".agents",
+      "skills",
+      "my-skill",
+      "ref.md",
+    );
+    expect(existsSync(piRef)).toBe(true);
+  });
+
+  it("removes skills dir", async () => {
+    await skills.writeSkills(
+      PROJECT_ID,
+      AGENT_ID,
+      [{ name: "temp-skill", description: "test", content: "test" }],
+      "claude_code",
+    );
+
+    const dir = workspace.skillsDir(PROJECT_ID, AGENT_ID, "claude_code");
+    expect(existsSync(dir)).toBe(true);
+
+    skills.removeSkillsDirSync(PROJECT_ID, AGENT_ID, "claude_code");
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("no-ops when source does not exist", () => {
+    // Should not throw
+    skills.copySkillsSync(PROJECT_ID, AGENT_ID, "claude_code", "pi");
+  });
+});

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1,0 +1,215 @@
+import { readdir, readFile, writeFile, mkdir, rm } from "fs/promises";
+import { cpSync, existsSync, mkdirSync, rmSync } from "fs";
+import { join, basename } from "path";
+import yaml from "js-yaml";
+import { valid as isValidSlug } from "./slug";
+import * as workspace from "./workspace";
+
+export interface SkillReference {
+  name: string;
+  content: string;
+}
+
+export interface Skill {
+  name: string;
+  description: string;
+  content: string;
+  references?: SkillReference[];
+}
+
+// --- SKILL.md parsing ---
+
+function parseSkillMd(raw: string): { name: string; description: string; content: string } {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return { name: "", description: "", content: raw.trim() };
+  const meta = yaml.load(match[1]) as Record<string, string> | undefined;
+  return {
+    name: meta?.name ?? "",
+    description: meta?.description ?? "",
+    content: match[2].trim(),
+  };
+}
+
+function composeSkillMd(skill: Skill): string {
+  const front = yaml.dump({ name: skill.name, description: skill.description }).trimEnd();
+  return `---\n${front}\n---\n\n${skill.content}\n`;
+}
+
+// --- Async operations ---
+
+export async function ensureSkillsDir(
+  projectId: string,
+  agentId: string,
+  harness?: string,
+): Promise<void> {
+  await mkdir(workspace.skillsDir(projectId, agentId, harness), { recursive: true });
+}
+
+export async function readSkills(
+  projectId: string,
+  agentId: string,
+  harness?: string,
+): Promise<Skill[]> {
+  const dir = workspace.skillsDir(projectId, agentId, harness);
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const skills: Skill[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillPath = join(dir, entry.name, "SKILL.md");
+    let raw: string;
+    try {
+      raw = await readFile(skillPath, "utf-8");
+    } catch {
+      continue;
+    }
+    const parsed = parseSkillMd(raw);
+
+    // Read reference files (everything except SKILL.md)
+    const references: SkillReference[] = [];
+    try {
+      const files = await readdir(join(dir, entry.name));
+      for (const file of files) {
+        if (file === "SKILL.md") continue;
+        const refContent = await readFile(join(dir, entry.name, file), "utf-8");
+        references.push({ name: file, content: refContent });
+      }
+    } catch {
+      /* skip references on error */
+    }
+
+    skills.push({
+      name: parsed.name || entry.name,
+      description: parsed.description,
+      content: parsed.content,
+      ...(references.length > 0 ? { references } : {}),
+    });
+  }
+
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function writeSkill(
+  projectId: string,
+  agentId: string,
+  skill: Skill,
+  harness?: string,
+): Promise<void> {
+  if (!isValidSlug(skill.name)) {
+    throw new Error(`Invalid skill name: ${skill.name}`);
+  }
+
+  const dir = workspace.skillDir(projectId, agentId, skill.name, harness);
+  await mkdir(dir, { recursive: true });
+
+  // Write SKILL.md
+  await writeFile(join(dir, "SKILL.md"), composeSkillMd(skill), "utf-8");
+
+  // Reconcile reference files: remove stale, write current
+  const existingFiles = new Set<string>();
+  try {
+    for (const f of await readdir(dir)) {
+      if (f !== "SKILL.md") existingFiles.add(f);
+    }
+  } catch {
+    /* ok */
+  }
+
+  const newRefNames = new Set<string>();
+  for (const ref of skill.references ?? []) {
+    if (!ref.name || ref.name !== basename(ref.name) || ref.name === "SKILL.md") {
+      throw new Error(`Invalid reference name: ${ref.name}`);
+    }
+    newRefNames.add(ref.name);
+    await writeFile(join(dir, ref.name), ref.content, "utf-8");
+  }
+
+  // Delete stale references
+  for (const stale of existingFiles) {
+    if (!newRefNames.has(stale)) {
+      await rm(join(dir, stale), { force: true });
+    }
+  }
+}
+
+export async function writeSkills(
+  projectId: string,
+  agentId: string,
+  skills: Skill[],
+  harness?: string,
+): Promise<void> {
+  await ensureSkillsDir(projectId, agentId, harness);
+
+  // Determine which skill dirs to remove
+  const dir = workspace.skillsDir(projectId, agentId, harness);
+  const existingDirs = new Set<string>();
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      if (e.isDirectory()) existingDirs.add(e.name);
+    }
+  } catch {
+    /* ok */
+  }
+
+  const newNames = new Set(skills.map((s) => s.name));
+
+  // Delete removed skills
+  for (const existing of existingDirs) {
+    if (!newNames.has(existing)) {
+      await rm(join(dir, existing), { recursive: true, force: true });
+    }
+  }
+
+  // Write all skills
+  for (const skill of skills) {
+    await writeSkill(projectId, agentId, skill, harness);
+  }
+}
+
+export async function deleteSkill(
+  projectId: string,
+  agentId: string,
+  skillName: string,
+  harness?: string,
+): Promise<void> {
+  if (!isValidSlug(skillName)) {
+    throw new Error(`Invalid skill name: ${skillName}`);
+  }
+  const dir = workspace.skillDir(projectId, agentId, skillName, harness);
+  await rm(dir, { recursive: true, force: true });
+}
+
+// --- Sync operations (for use inside DB transactions) ---
+
+export function copySkillsSync(
+  projectId: string,
+  agentId: string,
+  oldHarness: string | null,
+  newHarness: string,
+): void {
+  const src = workspace.skillsDir(projectId, agentId, oldHarness ?? undefined);
+  const dest = workspace.skillsDir(projectId, agentId, newHarness);
+
+  if (!existsSync(src)) return;
+
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+}
+
+export function removeSkillsDirSync(
+  projectId: string,
+  agentId: string,
+  harness?: string | null,
+): void {
+  const dir = workspace.skillsDir(projectId, agentId, harness ?? undefined);
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// Exported for testing
+export { parseSkillMd, composeSkillMd };

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -44,6 +44,22 @@ export function attachmentPath(
   return join(attachmentDir(projectId, agentId, attachmentId), filename);
 }
 
+export function skillsDir(projectId: string, agentId: string, harness?: string): string {
+  if (harness === "claude_code") {
+    return join(agentDir(projectId, agentId), ".claude", "skills");
+  }
+  return join(agentDir(projectId, agentId), ".agents", "skills");
+}
+
+export function skillDir(
+  projectId: string,
+  agentId: string,
+  skillName: string,
+  harness?: string,
+): string {
+  return join(skillsDir(projectId, agentId, harness), skillName);
+}
+
 export function sharedDir(projectId: string): string {
   return join(root(projectId), "shared");
 }


### PR DESCRIPTION
## Summary
- Restores the agent skills feature that was removed in d694a4c, now with **filesystem-based storage** instead of DB
- Skills stored as `SKILL.md` files with YAML frontmatter + markdown content, plus optional reference files
- Claude Code agents use `.claude/skills/`, Pi and future harnesses use `.agents/skills/`
- Harness changes trigger skill migration (copy in DB txn, cleanup after commit)
- Path traversal protection on both skill names (slug validation) and reference filenames

## Files changed
- **New:** `src/services/skills.ts` — filesystem CRUD service (read, write, delete, migrate)
- **New:** `src/services/skills.test.ts` — 20 tests covering parsing, CRUD, security, harness paths
- **Modified:** 9 existing files (workspace paths, coordinator, agent-manager, API routes, frontend types/form/hooks/tests)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 472 tests pass (20 new skill tests)
- [ ] Manual: create agent with skills via UI, verify SKILL.md files on disk
- [ ] Manual: edit agent, confirm skills loaded from disk
- [ ] Manual: change harness, verify skills migrated to new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)