### PR TITLE
Fix visible gap between streaming text and persisted message

### DIFF
--- a/src/frontend/components/AgentChatView.tsx
+++ b/src/frontend/components/AgentChatView.tsx
@@ -10,6 +10,7 @@ import WelcomePanel from "./WelcomePanel";
 import { useAgents, useMessages, useMarkRead } from "../lib/hooks";
 import { useSubscription, type AgentWsEvent } from "../lib/ws";
 import { useProjectLayout } from "../providers/ProjectLayoutProvider";
+import { insertMessageIntoCache } from "../lib/insertMessageIntoCache";
 
 type AgentData = NonNullable<ReturnType<typeof useAgents>["data"]>;
 
@@ -50,20 +51,33 @@ export default function AgentChatView() {
   // handled by ProjectLayout's project-level subscription, not here)
   const handleAgentEvent = useCallback(
     (event: AgentWsEvent) => {
+      if (!projectId || !selectedAgentId) return;
+
+      // Optimistically insert the message into the cache if the event carries one,
+      // so it appears instantly without waiting for a refetch round-trip.
+      if ("message" in event && event.message) {
+        insertMessageIntoCache(queryClient, projectId, selectedAgentId, event.message);
+      }
+
       switch (event.type) {
         case "text_delta": {
           const { delta } = event.payload;
           if (delta) setStreamingText((prev) => prev + delta);
           break;
         }
-        case "text":
+        case "text": {
+          setStreamingText("");
+          // Background refetch to reconcile with server state
+          queryClient.invalidateQueries({
+            queryKey: ["messages", projectId, selectedAgentId],
+          });
+          break;
+        }
         case "turn_complete": {
           setStreamingText("");
-          if (selectedAgentId) {
-            queryClient.invalidateQueries({
-              queryKey: ["messages", projectId, selectedAgentId],
-            });
-          }
+          queryClient.invalidateQueries({
+            queryKey: ["messages", projectId, selectedAgentId],
+          });
           break;
         }
         case "tool_use":
@@ -72,11 +86,9 @@ export default function AgentChatView() {
         case "attachment":
         case "error":
         case "system_message": {
-          if (selectedAgentId) {
-            queryClient.invalidateQueries({
-              queryKey: ["messages", projectId, selectedAgentId],
-            });
-          }
+          queryClient.invalidateQueries({
+            queryKey: ["messages", projectId, selectedAgentId],
+          });
           break;
         }
       }

--- a/src/frontend/lib/insertMessageIntoCache.ts
+++ b/src/frontend/lib/insertMessageIntoCache.ts
@@ -1,0 +1,44 @@
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
+import type { MessagesResponse } from "./hooks/messages";
+import type { WsSerializedMessage } from "./ws";
+
+/** Convert a WsSerializedMessage to the API row format and append it to the query cache. */
+export function insertMessageIntoCache(
+  queryClient: QueryClient,
+  projectId: string,
+  agentId: string,
+  msg: WsSerializedMessage,
+) {
+  const row: MessagesResponse["messages"][number] = {
+    id: msg.id,
+    projectId,
+    agentId,
+    role: msg.role,
+    content: {
+      ...(msg.text != null && { text: msg.text }),
+      ...(msg.tool != null && { tool: msg.tool }),
+      ...(msg.tool_use_id != null && { tool_use_id: msg.tool_use_id }),
+      ...(msg.input != null && { input: msg.input }),
+      // null output means "tool still running" — preserve it distinct from undefined (absent)
+      ...(msg.output !== undefined && { output: msg.output }),
+      ...(msg.isError != null && { isError: msg.isError }),
+      ...(msg.fromAgent != null && { fromAgent: msg.fromAgent }),
+      ...(msg.attachments != null && { attachments: msg.attachments }),
+    },
+    createdAt: msg.ts,
+  };
+
+  queryClient.setQueryData<InfiniteData<MessagesResponse>>(
+    ["messages", projectId, agentId],
+    (old) => {
+      if (!old || old.pages.length === 0) return old;
+      // Page 0 = newest (no cursor). Skip if already present.
+      const firstPage = old.pages[0];
+      if (firstPage.messages.some((m) => m.id === row.id)) return old;
+      return {
+        ...old,
+        pages: [{ ...firstPage, messages: [...firstPage.messages, row] }, ...old.pages.slice(1)],
+      };
+    },
+  );
+}

--- a/src/frontend/test/insertMessageIntoCache.test.ts
+++ b/src/frontend/test/insertMessageIntoCache.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "bun:test";
+import { QueryClient, type InfiniteData } from "@tanstack/react-query";
+import type { MessagesResponse } from "../lib/hooks/messages";
+import type { WsSerializedMessage } from "../lib/ws";
+import { insertMessageIntoCache } from "../lib/insertMessageIntoCache";
+
+function makeCache(messages: MessagesResponse["messages"]): InfiniteData<MessagesResponse> {
+  return {
+    pages: [{ messages, hasMore: false }],
+    pageParams: [undefined],
+  };
+}
+
+const wsMsg: WsSerializedMessage = {
+  id: 42,
+  role: "agent",
+  ts: "2026-03-29T00:00:00.000Z",
+  text: "Hello world",
+};
+
+describe("insertMessageIntoCache", () => {
+  it("appends a new message to page 0", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["messages", "p1", "a1"], makeCache([]));
+
+    insertMessageIntoCache(qc, "p1", "a1", wsMsg);
+
+    const data = qc.getQueryData<InfiniteData<MessagesResponse>>(["messages", "p1", "a1"]);
+    expect(data!.pages[0].messages).toHaveLength(1);
+    expect(data!.pages[0].messages[0]).toMatchObject({
+      id: 42,
+      role: "agent",
+      content: { text: "Hello world" },
+      createdAt: "2026-03-29T00:00:00.000Z",
+    });
+  });
+
+  it("skips duplicate messages (same id)", () => {
+    const qc = new QueryClient();
+    const existing = {
+      id: 42,
+      projectId: "p1",
+      agentId: "a1",
+      role: "agent",
+      content: { text: "Hello world" },
+      createdAt: "2026-03-29T00:00:00.000Z",
+    };
+    qc.setQueryData(["messages", "p1", "a1"], makeCache([existing]));
+
+    insertMessageIntoCache(qc, "p1", "a1", wsMsg);
+
+    const data = qc.getQueryData<InfiniteData<MessagesResponse>>(["messages", "p1", "a1"]);
+    expect(data!.pages[0].messages).toHaveLength(1);
+  });
+
+  it("does nothing when cache is empty", () => {
+    const qc = new QueryClient();
+
+    insertMessageIntoCache(qc, "p1", "a1", wsMsg);
+
+    const data = qc.getQueryData<InfiniteData<MessagesResponse>>(["messages", "p1", "a1"]);
+    expect(data).toBeUndefined();
+  });
+
+  it("converts all WsSerializedMessage fields to content fields", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["messages", "p1", "a1"], makeCache([]));
+
+    const toolMsg: WsSerializedMessage = {
+      id: 99,
+      role: "tool_use",
+      ts: "2026-03-29T00:00:01.000Z",
+      tool: "Read",
+      tool_use_id: "tu_123",
+      input: { file: "test.ts" },
+      output: "file contents",
+      isError: false,
+    };
+
+    insertMessageIntoCache(qc, "p1", "a1", toolMsg);
+
+    const data = qc.getQueryData<InfiniteData<MessagesResponse>>(["messages", "p1", "a1"]);
+    const msg = data!.pages[0].messages[0];
+    expect(msg.content).toEqual({
+      tool: "Read",
+      tool_use_id: "tu_123",
+      input: { file: "test.ts" },
+      output: "file contents",
+      isError: false,
+    });
+  });
+
+  it("preserves null output (tool still running)", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["messages", "p1", "a1"], makeCache([]));
+
+    const toolMsg: WsSerializedMessage = {
+      id: 100,
+      role: "tool_use",
+      ts: "2026-03-29T00:00:02.000Z",
+      tool: "Bash",
+      tool_use_id: "tu_456",
+      input: { command: "ls" },
+      output: null,
+    };
+
+    insertMessageIntoCache(qc, "p1", "a1", toolMsg);
+
+    const data = qc.getQueryData<InfiniteData<MessagesResponse>>(["messages", "p1", "a1"]);
+    expect(data!.pages[0].messages[0].content.output).toBeNull();
+  });
+
+  it("preserves existing messages when appending", () => {
+    const qc = new QueryClient();
+    const existing = {
+      id: 1,
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Hi" },
+      createdAt: "2026-03-28T00:00:00.000Z",
+    };
+    qc.setQueryData(["messages", "p1", "a1"], makeCache([existing]));
+
+    insertMessageIntoCache(qc, "p1", "a1", wsMsg);
+
+    const data = qc.getQueryData<InfiniteData<MessagesResponse>>(["messages", "p1", "a1"]);
+    expect(data!.pages[0].messages).toHaveLength(2);
+    expect(data!.pages[0].messages[0].id).toBe(1);
+    expect(data!.pages[0].messages[1].id).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary
- When streaming ends, the UI showed a flash where streaming text disappeared before the persisted message appeared (due to API refetch round-trip)
- Now optimistically inserts the message from the WebSocket event directly into the TanStack Query cache, eliminating the gap
- Extracted `insertMessageIntoCache` helper with full test coverage (6 tests)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes  
- [x] `bun test` passes (452 tests)
- [ ] Manual: send a message to an agent and verify streaming text transitions seamlessly to the persisted message with no flash/gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)