### PR TITLE
Add file access boundary to agent system prompt

### DIFF
--- a/src/runtime/agent-manager.test.ts
+++ b/src/runtime/agent-manager.test.ts
@@ -470,6 +470,53 @@ describe("AgentManager", () => {
     });
   });
 
+  describe("buildInternalPrompt", () => {
+    it("includes file access boundary with correct paths", () => {
+      const mgr = createManager();
+      const prompt = (
+        mgr as unknown as { buildInternalPrompt: () => string }
+      ).buildInternalPrompt();
+      const projectRoot = workspace.root(projectId);
+      const agentPath = workspace.agentDir(projectId, agentId);
+      const sharedPath = workspace.sharedDir(projectId);
+      const projectDoc = workspace.projectDocPath(projectId);
+
+      expect(prompt).toContain("## File Access Boundary — MANDATORY");
+      expect(prompt).toContain(`Your project root is \`${projectRoot}\``);
+      expect(prompt).toContain("MUST NOT create, modify, move, copy, or delete");
+
+      // Write-allowed paths are listed correctly
+      expect(prompt).toContain(`Your own directory: \`${agentPath}\``);
+      expect(prompt).toContain(`The shared drive: \`${sharedPath}\``);
+      expect(prompt).toContain(`Project document: \`${projectDoc}\``);
+
+      // Read-only paths
+      expect(prompt).toContain(`${projectRoot}/agents/`);
+    });
+
+    it("restricts writing to other agents directories", () => {
+      const mgr = createManager();
+      const prompt = (
+        mgr as unknown as { buildInternalPrompt: () => string }
+      ).buildInternalPrompt();
+
+      expect(prompt).toContain("Writing to another agent's directory");
+      expect(prompt).toContain("Read-only paths");
+      expect(prompt).toContain("Other agents' directories");
+    });
+
+    it("requires agent-specific state in own directory", () => {
+      const mgr = createManager();
+      const prompt = (
+        mgr as unknown as { buildInternalPrompt: () => string }
+      ).buildInternalPrompt();
+
+      expect(prompt).toContain("Agent-specific state");
+      expect(prompt).toContain("rules, memory files, skills, or configuration");
+      expect(prompt).toContain("MUST be stored within your own directory");
+    });
+  });
+
   describe("workspace setup", () => {
     it("creates agent directories on start", async () => {
       await workspace.ensureProjectDirs(projectId);

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -840,12 +840,11 @@ export class AgentManager {
 
   private buildInternalPrompt(): string {
     const peersPath = workspace.peersPath(this.projectId);
-    const outboxPath = join(
-      workspace.agentDir(this.projectId, this.agentId),
-      "outbox/<any-name>.yaml",
-    );
+    const agentDir = workspace.agentDir(this.projectId, this.agentId);
+    const outboxPath = join(agentDir, "outbox/<any-name>.yaml");
     const sharedPath = workspace.sharedDir(this.projectId);
     const projectDoc = workspace.projectDocPath(this.projectId);
+    const projectRoot = workspace.root(this.projectId);
 
     return `# Inter-Agent Communication
 
@@ -895,6 +894,32 @@ Read \`${projectDoc}\` for project context before starting tasks.
 - Read \`${peersPath}\` before messaging to confirm the target agent exists
 - Be specific about what you need from the other agent
 - Don't send messages unnecessarily — only when collaboration genuinely helps
+
+## File Access Boundary — MANDATORY
+
+Your project root is \`${projectRoot}\`. You MUST NOT create, modify, move, copy, or delete any file or directory outside this path. This applies to ALL tools:
+
+- **Write / Edit**: Only target paths under \`${projectRoot}\`
+- **Bash**: Do not use shell commands (cp, mv, rm, mkdir, touch, tee, sed, >, >>) to write outside \`${projectRoot}\`. Do not use symlinks or hard links to escape this boundary.
+- **Read**: You may read a file outside the project root only if the user's message contains an explicit absolute path to that file. Never write based on paths discovered outside the boundary.
+
+**Write-allowed paths** (you may create, modify, and delete files here):
+- Your own directory: \`${agentDir}\` and all its subdirectories (inbox/, outbox/, attachments/)
+- The shared drive: \`${sharedPath}\`
+- Project document: \`${projectDoc}\`
+
+**Read-only paths** (you may read but MUST NOT write, modify, or delete):
+- Other agents' directories under \`${projectRoot}/agents/\` — these belong to other agents
+- \`${peersPath}\` — read to discover available agents before messaging
+
+**Agent-specific state**: Any rules, memory files, skills, or configuration that are specific to you (this agent) MUST be stored within your own directory \`${agentDir}\`. Never write agent-specific state to the shared drive or other locations.
+
+Violations include:
+- Writing to another agent's directory
+- Writing agent-specific rules, memory, or skills outside your own directory
+- Writing to another project's folder
+- Modifying system files or dotfiles outside the project root
+- Using Bash to pipe, redirect, or copy data to paths outside \`${projectRoot}\`
 `;
   }
 


### PR DESCRIPTION
## Summary
- Adds a **File Access Boundary — MANDATORY** section to the internal system prompt in `buildInternalPrompt()`
- Agents can only create/modify/delete files within their project folder (`~/.shire/projects/{projectId}/`)
- Write access: agent's own directory, shared drive, PROJECT.md
- Read-only: other agents' directories, peers.yaml
- Agent-specific state (rules, memory, skills) must be stored in the agent's own directory
- Covers all tools: Write, Edit, Bash (including shell commands, symlinks, redirects)

## Test plan
- [x] 3 new unit tests verify the prompt contains correct boundary section with dynamic paths
- [x] All 28 agent-manager tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)