### PR TITLE
Add grace period before reconnecting toast

### DIFF
--- a/src/frontend/lib/useConnectionToast.ts
+++ b/src/frontend/lib/useConnectionToast.ts
@@ -3,31 +3,57 @@ import { toast } from "sonner";
 import { useConnectionState } from "./ws";
 
 const TOAST_ID = "connection-status";
+const GRACE_PERIOD_MS = 10_000;
 
 export function useConnectionToast(): void {
   const state = useConnectionState();
   const hasBeenConnected = useRef(false);
   const prevState = useRef(state);
+  const graceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showedReconnecting = useRef(false);
 
   useEffect(() => {
     const prev = prevState.current;
     prevState.current = state;
 
     if (state === "connected") {
+      // Clear any pending grace timer
+      if (graceTimer.current) {
+        clearTimeout(graceTimer.current);
+        graceTimer.current = null;
+      }
+
       if (!hasBeenConnected.current) {
-        // First connection — stay silent
         hasBeenConnected.current = true;
         return;
       }
-      if (prev !== "connected") {
+
+      // Only show "Connected" if we previously showed "Reconnecting…"
+      if (prev !== "connected" && showedReconnecting.current) {
         toast.success("Connected", { id: TOAST_ID, duration: 2000 });
+        showedReconnecting.current = false;
       }
       return;
     }
 
-    // Only show disconnect/reconnecting toasts after we've been connected once
     if (!hasBeenConnected.current) return;
 
-    toast.loading("Reconnecting…", { id: TOAST_ID, duration: Infinity });
+    // Start grace period — only show toast if disconnection persists
+    if (!graceTimer.current) {
+      graceTimer.current = setTimeout(() => {
+        graceTimer.current = null;
+        showedReconnecting.current = true;
+        toast.loading("Reconnecting…", { id: TOAST_ID, duration: Infinity });
+      }, GRACE_PERIOD_MS);
+    }
   }, [state]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (graceTimer.current) {
+        clearTimeout(graceTimer.current);
+      }
+    };
+  }, []);
 }

--- a/src/frontend/test/useConnectionToast.test.tsx
+++ b/src/frontend/test/useConnectionToast.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { toast } from "sonner";
 import { useConnectionToast } from "../lib/useConnectionToast";
 
@@ -16,52 +16,124 @@ mock.module("sonner", () => ({
   },
 }));
 
+const GRACE_PERIOD_MS = 10_000;
+
 describe("useConnectionToast", () => {
+  let originalSetTimeout: typeof globalThis.setTimeout;
+  let originalClearTimeout: typeof globalThis.clearTimeout;
+  let timers: Array<{ callback: () => void; delay: number; id: number }>;
+  let nextId: number;
+
   beforeEach(() => {
     mockState = "disconnected";
     (toast.loading as ReturnType<typeof mock>).mockClear();
     (toast.success as ReturnType<typeof mock>).mockClear();
+
+    // Install fake timers
+    timers = [];
+    nextId = 1;
+    originalSetTimeout = globalThis.setTimeout;
+    originalClearTimeout = globalThis.clearTimeout;
+
+    // @ts-expect-error -- fake timer returns number id
+    globalThis.setTimeout = (cb: () => void, delay: number) => {
+      const id = nextId++;
+      timers.push({ callback: cb, delay, id });
+      return id;
+    };
+    const fakeClearTimeout = (
+      id: number | string | ReturnType<typeof originalSetTimeout> | undefined,
+    ) => {
+      timers = timers.filter((t) => t.id !== id);
+    };
+    globalThis.clearTimeout = fakeClearTimeout as typeof globalThis.clearTimeout;
   });
 
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  });
+
+  function advanceTimers() {
+    const pending = [...timers];
+    timers = [];
+    for (const t of pending) {
+      t.callback();
+    }
+  }
+
   it("does not show any toast on initial connection sequence", () => {
-    // Start disconnected
     const { rerender } = renderHook(() => useConnectionToast());
     expect(toast.loading).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
 
-    // Move to connecting
     mockState = "connecting";
     rerender();
     expect(toast.loading).not.toHaveBeenCalled();
 
-    // Move to connected (first time)
     mockState = "connected";
     rerender();
     expect(toast.success).not.toHaveBeenCalled();
   });
 
-  it("shows loading toast when disconnected after being connected", () => {
-    // Initial connect
+  it("does not show toast immediately on disconnect", () => {
     mockState = "connected";
     const { rerender } = renderHook(() => useConnectionToast());
 
-    // Disconnect
     mockState = "disconnected";
     rerender();
+
+    // Toast should NOT appear yet — grace period hasn't elapsed
+    expect(toast.loading).not.toHaveBeenCalled();
+  });
+
+  it("shows reconnecting toast after grace period elapses", () => {
+    mockState = "connected";
+    const { rerender } = renderHook(() => useConnectionToast());
+
+    mockState = "disconnected";
+    rerender();
+
+    expect(timers).toHaveLength(1);
+    expect(timers[0].delay).toBe(GRACE_PERIOD_MS);
+
+    advanceTimers();
+
     expect(toast.loading).toHaveBeenCalledWith("Reconnecting…", {
       id: "connection-status",
       duration: Infinity,
     });
   });
 
-  it("shows success toast when reconnecting after disconnect", () => {
-    // Initial connect
+  it("does not show any toast if reconnection happens within grace period", () => {
     mockState = "connected";
     const { rerender } = renderHook(() => useConnectionToast());
 
     // Disconnect
     mockState = "disconnected";
     rerender();
+
+    // Reconnect before grace period fires
+    mockState = "connected";
+    rerender();
+
+    // Timer should have been cleared
+    advanceTimers();
+
+    expect(toast.loading).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows success toast on reconnect only if reconnecting toast was shown", () => {
+    mockState = "connected";
+    const { rerender } = renderHook(() => useConnectionToast());
+
+    mockState = "disconnected";
+    rerender();
+
+    // Grace period elapses — reconnecting toast shown
+    advanceTimers();
+    expect(toast.loading).toHaveBeenCalled();
 
     // Reconnect
     mockState = "connected";
@@ -79,12 +151,32 @@ describe("useConnectionToast", () => {
     expect(toast.success).not.toHaveBeenCalled();
   });
 
-  it("shows loading toast when in connecting state after being connected", () => {
+  it("does not show toast after unmount during grace period", () => {
+    mockState = "connected";
+    const { rerender, unmount } = renderHook(() => useConnectionToast());
+
+    mockState = "disconnected";
+    rerender();
+    expect(timers).toHaveLength(1);
+
+    unmount();
+
+    advanceTimers();
+    expect(toast.loading).not.toHaveBeenCalled();
+  });
+
+  it("starts grace period when going from connected to connecting", () => {
     mockState = "connected";
     const { rerender } = renderHook(() => useConnectionToast());
 
     mockState = "connecting";
     rerender();
+
+    // Should have started the grace timer, not shown toast yet
+    expect(toast.loading).not.toHaveBeenCalled();
+    expect(timers).toHaveLength(1);
+
+    advanceTimers();
     expect(toast.loading).toHaveBeenCalledWith("Reconnecting…", {
       id: "connection-status",
       duration: Infinity,


### PR DESCRIPTION
## Summary
- Adds a 10-second grace period before showing the "Reconnecting…" toast, preventing frequent flashing during brief network blips in hosted environments
- Only shows the "Connected" success toast if the "Reconnecting…" toast was actually displayed
- Cleans up timer on unmount to prevent stale callbacks

## Test plan
- [x] All 8 toast tests pass (`bun test src/frontend/test/useConnectionToast.test.tsx`)
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual: deploy to hosted env and verify toast only appears after sustained disconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)