### PR TITLE
Switch license from BUSL-1.1 to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Victor Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -190,4 +190,4 @@ shire
 
 ## License
 
-[Business Source License 1.1](LICENSE) — free for non-production use. Converts to Apache 2.0 on 2030-03-24.
+[MIT License](LICENSE)

--- a/npm/agents-shire/package.json
+++ b/npm/agents-shire/package.json
@@ -12,7 +12,7 @@
     "@agents-shire/cli-linux-arm64": "0.1.0",
     "@agents-shire/cli-win32-x64": "0.1.0"
   },
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/victor36max/shire"

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "shire": "shire"
   },
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/victor36max/shire"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "shire": "shire"
   },
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/victor36max/shire"

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "shire": "shire"
   },
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/victor36max/shire"

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "shire": "shire"
   },
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/victor36max/shire"

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "shire": "shire.exe"
   },
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/victor36max/shire"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "shire",
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "shire": "./src/cli.ts"


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file (copyright 2026 Victor Chan)
- Add `"license": "MIT"` to root package.json
- Update all 6 npm sub-package package.json files from BUSL-1.1 to MIT

## Test plan
- [x] No BUSL references remain (`grep -r BUSL` returns nothing)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)