### PR TITLE
Fix startup freeze after database migration

### DIFF
--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -145,8 +145,13 @@ export class AgentManager {
       this.startWatchers();
       this.setStatus("active");
 
-      // Process any existing inbox messages (no subscriber at cold boot, skip broadcast)
-      await this.processInbox();
+      // Process any existing inbox messages in the background (fs.watch won't fire for pre-existing files)
+      this.busy = true;
+      this.processInbox()
+        .catch((err) => console.error(`Inbox processing error for ${this.agentName}:`, err))
+        .finally(() => {
+          this.busy = false;
+        });
     } catch (err) {
       console.error(`Bootstrap failed for ${this.agentName}:`, err);
       this.setStatus("idle");

--- a/src/runtime/coordinator.test.ts
+++ b/src/runtime/coordinator.test.ts
@@ -5,7 +5,7 @@ import * as agentsService from "../services/agents";
 import * as projects from "../services/projects";
 import * as workspace from "../services/workspace";
 import { bus } from "../events";
-import { rmSync, readFileSync, existsSync, readdirSync } from "fs";
+import { rmSync, readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from "fs";
 import { join } from "path";
 import yaml from "js-yaml";
 import { tmpdir } from "os";
@@ -42,6 +42,66 @@ beforeEach(() => {
 afterEach(async () => {
   await coordinator.stopAll();
   rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("deployAndScan", () => {
+  it("boots multiple agents in parallel without blocking on inbox", async () => {
+    // Create agents in DB before deploying
+    agentsService.createAgent(projectId, { name: "alpha" });
+    agentsService.createAgent(projectId, { name: "bravo" });
+    agentsService.createAgent(projectId, { name: "charlie" });
+
+    // deployAndScan should complete quickly even with multiple agents
+    const start = Date.now();
+    await coordinator.deployAndScan();
+    const elapsed = Date.now() - start;
+
+    const statuses = coordinator.listAgentStatuses();
+    expect(statuses.length).toBe(3);
+    for (const s of statuses) {
+      expect(s.status).toBe("active");
+    }
+    // Should be fast (parallel) — well under 1s
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it("does not block startup on stale inbox messages", async () => {
+    const agent = agentsService.createAgent(projectId, { name: "inbox-agent" });
+
+    // Write a stale inbox message before deploying
+    const inboxDir = workspace.inboxDir(projectId, agent.id);
+    mkdirSync(inboxDir, { recursive: true });
+    writeFileSync(
+      join(inboxDir, "stale.yaml"),
+      "ts: 1000\ntype: user_message\nfrom: user\npayload:\n  text: old message\n",
+    );
+
+    // deployAndScan should still complete quickly
+    const start = Date.now();
+    await coordinator.deployAndScan();
+    const elapsed = Date.now() - start;
+
+    const statuses = coordinator.listAgentStatuses();
+    expect(statuses[0].status).toBe("active");
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it("continues booting other agents when one fails", async () => {
+    // Create two agents; the second will have a corrupted harness
+    agentsService.createAgent(projectId, { name: "good-agent" });
+    const badAgent = agentsService.createAgent(projectId, { name: "bad-agent" });
+
+    // Sabotage: remove the bad agent from DB so startHarness fails
+    agentsService.deleteAgent(badAgent.id);
+
+    await coordinator.deployAndScan();
+
+    // The good agent should still be active
+    const statuses = coordinator.listAgentStatuses();
+    const good = statuses.find((s) => s.name === "good-agent");
+    expect(good).toBeDefined();
+    expect(good!.status).toBe("active");
+  });
 });
 
 describe("createAgent", () => {

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -66,8 +66,16 @@ export class Coordinator {
     await workspace.ensureProjectDirs(this.projectId);
 
     const dbAgents = agentsService.listAgents(this.projectId);
-    for (const agent of dbAgents) {
-      await this.startAgentManager(agent.id, agent.name);
+    const results = await Promise.allSettled(
+      dbAgents.map((agent) => this.startAgentManager(agent.id, agent.name)),
+    );
+    const ok = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.filter((r) => r.status === "rejected");
+    for (const f of failed) {
+      console.error(`Coordinator[${this.projectId}]: agent boot failed:`, f.reason);
+    }
+    if (failed.length > 0) {
+      console.warn(`Coordinator[${this.projectId}]: ${ok}/${dbAgents.length} agent(s) started`);
     }
 
     await this.writePeersYaml();

--- a/src/runtime/project-manager.ts
+++ b/src/runtime/project-manager.ts
@@ -12,10 +12,11 @@ export class ProjectManager {
 
   async boot(): Promise<void> {
     const projects = projectsService.listProjects();
-    for (const project of projects) {
-      await this.bootProject(project.id);
-    }
-    console.log(`ProjectManager: booted ${projects.length} project(s)`);
+    const results = await Promise.allSettled(
+      projects.map((project) => this.bootProject(project.id)),
+    );
+    const ok = results.filter((r) => r.status === "fulfilled" && r.value === true).length;
+    console.log(`ProjectManager: booted ${ok}/${projects.length} project(s)`);
   }
 
   async createProject(


### PR DESCRIPTION
## Summary
- Parallelize project and agent boot using `Promise.allSettled` (was sequential `for...await`)
- Fire-and-forget `processInbox()` at startup so stale inbox messages don't block the server
- Guard fire-and-forget inbox processing with `this.busy` flag to prevent race with watcher

## Test plan
- [x] 461 tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] New tests: parallel boot, stale inbox non-blocking, resilience when agent fails to boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)