### PR TITLE
Fix scheduled tasks toggle returning 404

### DIFF
--- a/src/frontend/lib/hooks/schedules.ts
+++ b/src/frontend/lib/hooks/schedules.ts
@@ -9,7 +9,7 @@ export function useSchedules(projectId: string | undefined) {
     queryFn: async () =>
       unwrap(
         await api.projects[":id"].schedules.$get({ param: { id: projectId! } }),
-      ) as unknown as ScheduledTask[],
+      ) as unknown as Promise<ScheduledTask[]>,
     enabled: !!projectId,
   });
 }

--- a/src/routes/schedules.test.ts
+++ b/src/routes/schedules.test.ts
@@ -125,4 +125,59 @@ describe("GET /api/projects/:id/schedules", () => {
     const data = await res.json();
     expect(data).toEqual([]);
   });
+
+  it("returns flat objects with agentName", async () => {
+    const agentRes = await request("POST", `/api/projects/${projectId}/agents`, {
+      name: "list-agent",
+    });
+    const agent = (await agentRes.json()) as Record<string, string>;
+
+    await request("POST", `/api/projects/${projectId}/schedules`, {
+      agentId: agent.id,
+      label: "my-task",
+      message: "hello",
+      scheduleType: "recurring",
+      cronExpression: "0 9 * * *",
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/schedules`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Record<string, unknown>[];
+    expect(data).toHaveLength(1);
+    expect(data[0].label).toBe("my-task");
+    expect(data[0].agentName).toBe("list-agent");
+    expect(data[0].id).toBeDefined();
+    // Should be flat — no nested scheduled_tasks key
+    expect(data[0]).not.toHaveProperty("scheduled_tasks");
+  });
+});
+
+describe("POST /api/projects/:id/schedules/:sid/toggle", () => {
+  it("toggles enabled using id from the flat list response", async () => {
+    const agentRes = await request("POST", `/api/projects/${projectId}/agents`, {
+      name: "toggle-agent",
+    });
+    const agent = (await agentRes.json()) as Record<string, string>;
+
+    await request("POST", `/api/projects/${projectId}/schedules`, {
+      agentId: agent.id,
+      label: "toggle-task",
+      message: "hi",
+      scheduleType: "recurring",
+      cronExpression: "0 9 * * *",
+    });
+
+    const listRes = await request("GET", `/api/projects/${projectId}/schedules`);
+    const tasks = (await listRes.json()) as { id: string; enabled: boolean }[];
+    expect(tasks[0].enabled).toBe(true);
+
+    const toggleRes = await request(
+      "POST",
+      `/api/projects/${projectId}/schedules/${tasks[0].id}/toggle`,
+      { enabled: false },
+    );
+    expect(toggleRes.status).toBe(200);
+    const toggled = (await toggleRes.json()) as { enabled: boolean };
+    expect(toggled.enabled).toBe(false);
+  });
 });

--- a/src/routes/schedules.ts
+++ b/src/routes/schedules.ts
@@ -49,7 +49,13 @@ const updateScheduleSchema = z.object({
 export const scheduleRoutes = new Hono<AppEnv>()
   .get("/projects/:id/schedules", (c) => {
     const projectId = c.req.param("id");
-    return c.json(schedulesService.listScheduledTasks(projectId));
+    const rows = schedulesService.listScheduledTasks(projectId);
+    return c.json(
+      rows.map((r) => ({
+        ...r.scheduled_tasks,
+        agentName: r.agents?.name ?? "",
+      })),
+    );
   })
   .post("/projects/:id/schedules", zValidator("json", createScheduleSchema), (c) => {
     const scheduler = c.get("scheduler");


### PR DESCRIPTION
## Summary
- The GET `/api/projects/:id/schedules` endpoint returned nested Drizzle join objects (`{ scheduled_tasks: {...}, agents: {...} }`) instead of flat objects
- The frontend expected flat objects with `id`, `label`, `agentName` at the top level, so `task.id` was `undefined` at runtime
- The toggle sent `sid=undefined` to the backend → 404 "Task not found"
- This also caused the Label and Agent columns to display as empty on the Scheduled Tasks page

## Changes
- **`src/routes/schedules.ts`** — Flatten the GET list response by spreading `scheduled_tasks` and adding `agentName` from the joined agent
- **`src/frontend/lib/hooks/schedules.ts`** — Clean up the type cast
- **`src/routes/schedules.test.ts`** — Add tests for flat response shape and end-to-end toggle flow

## Test plan
- [x] Existing schedule route tests pass (8/8)
- [x] New test: GET returns flat objects with `agentName` and no nested `scheduled_tasks` key
- [x] New test: Toggle endpoint works with `id` from the flat list response
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)