### PR TITLE
Fix shire -v to read version from package.json

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5,6 +5,7 @@ import { existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { logFilePath } from "./daemon";
 import { openBrowser, shouldOpenBrowser } from "./cli";
+import pkg from "../package.json";
 
 const CLI_PATH = join(import.meta.dirname, "cli.ts");
 
@@ -24,6 +25,7 @@ describe("CLI", () => {
   it("prints version with --version", async () => {
     const result = await $`bun run ${CLI_PATH} --version`.text();
     expect(result.trim()).toMatch(/^shire v\d+\.\d+\.\d+$/);
+    expect(result.trim()).toBe(`shire v${pkg.version}`);
   });
 
   it("exits with error for unknown argument", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,8 +12,9 @@ import {
   logFilePath,
 } from "./daemon";
 import { startServer } from "./index";
+import pkg from "../package.json";
 
-const VERSION = "0.1.0";
+const VERSION = pkg.version;
 
 interface ParsedArgs {
   command: string;


### PR DESCRIPTION
## Summary
- Replace hardcoded `VERSION = "0.1.0"` in `src/cli.ts` with a JSON import from `package.json`
- Add test assertion that CLI version output matches `package.json` version

## Test plan
- [x] `bun test src/cli.test.ts` — all 4 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)