### PR TITLE
Fix broken image preview in attachment serving

### DIFF
--- a/src/routes/attachments.test.ts
+++ b/src/routes/attachments.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createTestDb } from "../test/setup";
+import { createApp } from "../server";
+import { ProjectManager } from "../runtime/project-manager";
+import { Scheduler } from "../runtime/scheduler";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import * as workspace from "../services/workspace";
+
+let app: ReturnType<typeof createApp>;
+let testDir: string;
+let projectId: string;
+let agentId: string;
+
+beforeEach(async () => {
+  createTestDb();
+  testDir = join(
+    tmpdir(),
+    `attachments_route_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+  );
+  process.env.SHIRE_PROJECTS_DIR = testDir;
+
+  mock.module("../runtime/harness", () => ({
+    createHarness: () => ({
+      start: async () => {},
+      sendMessage: async () => {},
+      interrupt: async () => {},
+      clearSession: async () => {},
+      stop: async () => {},
+      onEvent: () => {},
+      isProcessing: () => false,
+      getSessionId: () => null,
+    }),
+  }));
+
+  const projectManager = new ProjectManager();
+  const scheduler = new Scheduler(projectManager);
+  app = createApp({ projectManager, scheduler });
+
+  const createRes = await request("POST", "/api/projects", { name: "test-project" });
+  const projectData = (await createRes.json()) as Record<string, string>;
+  projectId = projectData.id;
+
+  const agentRes = await request("POST", `/api/projects/${projectId}/agents`, {
+    name: "test-agent",
+    description: "Test",
+  });
+  const agentData = (await agentRes.json()) as Record<string, string>;
+  agentId = agentData.id;
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+async function request(method: string, path: string, body?: unknown) {
+  const opts: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (body) opts.body = JSON.stringify(body);
+  return app.request(path, opts);
+}
+
+function createAttachment(attId: string, filename: string, content: Buffer) {
+  const dir = workspace.attachmentDir(projectId, agentId, attId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, filename), content);
+}
+
+describe("GET /api/projects/:id/agents/:aid/attachments/:attId/:filename", () => {
+  it("returns correct Content-Type for PNG images", async () => {
+    createAttachment("att-1", "photo.png", Buffer.from("fake-png"));
+
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/${agentId}/attachments/att-1/photo.png`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Content-Disposition")).toBe('inline; filename="photo.png"');
+  });
+
+  it("returns correct Content-Type for JPEG images", async () => {
+    createAttachment("att-2", "photo.jpg", Buffer.from("fake-jpg"));
+
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/${agentId}/attachments/att-2/photo.jpg`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/jpeg");
+    expect(res.headers.get("Content-Disposition")).toBe('inline; filename="photo.jpg"');
+  });
+
+  it("returns Content-Disposition: attachment for non-image files", async () => {
+    createAttachment("att-3", "data.csv", Buffer.from("a,b,c"));
+
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/${agentId}/attachments/att-3/data.csv`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv");
+    expect(res.headers.get("Content-Disposition")).toBe('attachment; filename="data.csv"');
+  });
+
+  it("returns application/octet-stream for unknown extensions", async () => {
+    createAttachment("att-4", "file.xyz", Buffer.from("unknown"));
+
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/${agentId}/attachments/att-4/file.xyz`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(res.headers.get("Content-Disposition")).toBe('attachment; filename="file.xyz"');
+  });
+
+  it("returns 404 for missing attachment", async () => {
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/${agentId}/attachments/missing/file.png`,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects path traversal in filename", async () => {
+    createAttachment("att-safe", "ok.txt", Buffer.from("safe"));
+
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/${agentId}/attachments/att-safe/..%2F..%2Fetc%2Fpasswd`,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("serves SVG as attachment, not inline, to prevent XSS", async () => {
+    createAttachment("att-svg", "icon.svg", Buffer.from("<svg></svg>"));
+
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/${agentId}/attachments/att-svg/icon.svg`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
+    expect(res.headers.get("Content-Disposition")).toBe('attachment; filename="icon.svg"');
+  });
+
+  it("rejects path traversal in agentId", async () => {
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/agents/..%2F..%2Fetc/attachments/att-1/file.txt`,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("resolves project by name", async () => {
+    createAttachment("att-5", "image.gif", Buffer.from("fake-gif"));
+
+    const res = await request(
+      "GET",
+      `/api/projects/test-project/agents/${agentId}/attachments/att-5/image.gif`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/gif");
+  });
+});

--- a/src/routes/attachments.ts
+++ b/src/routes/attachments.ts
@@ -3,6 +3,7 @@ import { readFile, access } from "fs/promises";
 import { basename } from "path";
 import * as workspace from "../services/workspace";
 import * as projectsService from "../services/projects";
+import { mimeFromPath } from "../utils/mime";
 import type { AppEnv } from "../types";
 
 export const attachmentRoutes = new Hono<AppEnv>().get(
@@ -13,7 +14,12 @@ export const attachmentRoutes = new Hono<AppEnv>().get(
     const attId = c.req.param("attId");
     const filename = c.req.param("filename");
 
-    if (filename.includes("..") || filename.includes("/") || attId.includes("..")) {
+    if (
+      filename.includes("..") ||
+      filename.includes("/") ||
+      attId.includes("..") ||
+      agentId.includes("..")
+    ) {
       return c.json({ error: "Invalid path" }, 400);
     }
 
@@ -31,10 +37,13 @@ export const attachmentRoutes = new Hono<AppEnv>().get(
 
     try {
       const data = await readFile(filePath);
+      const contentType = mimeFromPath(filename);
+      const isSafeImage = contentType.startsWith("image/") && contentType !== "image/svg+xml";
+      const disposition = isSafeImage ? "inline" : "attachment";
       return new Response(data, {
         headers: {
-          "Content-Disposition": `attachment; filename="${basename(filename)}"`,
-          "Content-Type": "application/octet-stream",
+          "Content-Disposition": `${disposition}; filename="${basename(filename)}"`,
+          "Content-Type": contentType,
         },
       });
     } catch {

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -3,6 +3,7 @@ import { readFile, readdir, rename, unlink, writeFile, mkdir, stat } from "fs/pr
 import { join, basename } from "path";
 import yaml from "js-yaml";
 import { safeYamlLoad } from "../utils/yaml";
+import { mimeFromPath } from "../utils/mime";
 import {
   bus,
   type AgentStatus,
@@ -80,26 +81,6 @@ function serializeMessage(msg: {
         attachments: (content.attachments ?? []) as SerializedMessage["attachments"],
       };
   }
-}
-
-const MIME_TYPES: Record<string, string> = {
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".svg": "image/svg+xml",
-  ".pdf": "application/pdf",
-  ".json": "application/json",
-  ".txt": "text/plain",
-  ".md": "text/markdown",
-  ".html": "text/html",
-  ".csv": "text/csv",
-  ".zip": "application/zip",
-};
-
-function mimeFromPath(filename: string): string {
-  const ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
-  return MIME_TYPES[ext] ?? "application/octet-stream";
 }
 
 export class AgentManager {

--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { mimeFromPath } from "./mime";
+
+describe("mimeFromPath", () => {
+  test("returns image/png for .png files", () => {
+    expect(mimeFromPath("photo.png")).toBe("image/png");
+  });
+
+  test("returns image/jpeg for .jpg and .jpeg files", () => {
+    expect(mimeFromPath("photo.jpg")).toBe("image/jpeg");
+    expect(mimeFromPath("photo.jpeg")).toBe("image/jpeg");
+  });
+
+  test("handles case-insensitive extensions", () => {
+    expect(mimeFromPath("photo.PNG")).toBe("image/png");
+    expect(mimeFromPath("photo.JPEG")).toBe("image/jpeg");
+  });
+
+  test("returns application/pdf for .pdf files", () => {
+    expect(mimeFromPath("doc.pdf")).toBe("application/pdf");
+  });
+
+  test("returns application/octet-stream for unknown extensions", () => {
+    expect(mimeFromPath("file.xyz")).toBe("application/octet-stream");
+  });
+
+  test("returns application/octet-stream for files without extension", () => {
+    expect(mimeFromPath("noext")).toBe("application/octet-stream");
+  });
+
+  test("returns image/webp for .webp files", () => {
+    expect(mimeFromPath("image.webp")).toBe("image/webp");
+  });
+});

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,0 +1,22 @@
+import { extname } from "path";
+
+const MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".pdf": "application/pdf",
+  ".json": "application/json",
+  ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".html": "text/html",
+  ".csv": "text/csv",
+  ".zip": "application/zip",
+};
+
+export function mimeFromPath(filename: string): string {
+  const ext = extname(filename).toLowerCase();
+  return MIME_TYPES[ext] ?? "application/octet-stream";
+}


### PR DESCRIPTION
## Summary

- Image previews in user messages were broken because the attachment route served all files with `Content-Type: application/octet-stream`, while the server sets `X-Content-Type-Options: nosniff` globally — causing browsers to refuse rendering images in `<img>` tags
- Extracted MIME type utility to shared `src/utils/mime.ts` and serve attachments with the correct Content-Type
- Images use `Content-Disposition: inline` (except SVG to prevent XSS), non-images use `attachment`
- Added `agentId` to path traversal validation

## Test plan

- [x] New unit tests for `mimeFromPath` utility (7 tests)
- [x] New route tests for attachment serving (9 tests) covering Content-Type, Content-Disposition, path traversal, SVG XSS prevention, and project name resolution
- [x] All 509 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)