### PR TITLE
Add .claude/settings.json to agent workspace for skill management

### DIFF
--- a/src/services/workspace-settings.test.ts
+++ b/src/services/workspace-settings.test.ts
@@ -36,4 +36,45 @@ describe("workspace settings", () => {
       expect(readFileSync(workspace.projectDocPath(PROJECT_ID), "utf-8")).toBe("# Updated");
     });
   });
+
+  describe("agent claude settings", () => {
+    const AGENT_ID = "claude-settings-test";
+
+    it("ensureAgentDirs creates .claude/settings.json with permissions", async () => {
+      await workspace.ensureAgentDirs(PROJECT_ID, AGENT_ID);
+      const content = JSON.parse(
+        readFileSync(workspace.claudeSettingsPath(PROJECT_ID, AGENT_ID), "utf-8"),
+      );
+      expect(content.permissions.allow).toContain("Edit(.claude/**)");
+      expect(content.permissions.allow).toContain("Write(.claude/**)");
+    });
+
+    it("ensureAgentDirsSync creates .claude/settings.json with permissions", () => {
+      workspace.ensureAgentDirsSync(PROJECT_ID, AGENT_ID);
+      const content = JSON.parse(
+        readFileSync(workspace.claudeSettingsPath(PROJECT_ID, AGENT_ID), "utf-8"),
+      );
+      expect(content.permissions.allow).toContain("Edit(.claude/**)");
+    });
+
+    it("does not overwrite existing settings.json", async () => {
+      await workspace.ensureAgentDirs(PROJECT_ID, AGENT_ID);
+      const customSettings = JSON.stringify({
+        permissions: { allow: ["Edit(.claude/**)", "Write(.claude/**)", "Bash(custom:*)"] },
+      });
+      writeFileSync(workspace.claudeSettingsPath(PROJECT_ID, AGENT_ID), customSettings);
+      await workspace.ensureAgentDirs(PROJECT_ID, AGENT_ID);
+      const content = readFileSync(workspace.claudeSettingsPath(PROJECT_ID, AGENT_ID), "utf-8");
+      expect(content).toBe(customSettings);
+    });
+
+    it("does not overwrite existing settings.json (sync)", () => {
+      workspace.ensureAgentDirsSync(PROJECT_ID, AGENT_ID);
+      const customSettings = JSON.stringify({ permissions: { allow: ["custom"] } });
+      writeFileSync(workspace.claudeSettingsPath(PROJECT_ID, AGENT_ID), customSettings);
+      workspace.ensureAgentDirsSync(PROJECT_ID, AGENT_ID);
+      const content = readFileSync(workspace.claudeSettingsPath(PROJECT_ID, AGENT_ID), "utf-8");
+      expect(content).toBe(customSettings);
+    });
+  });
 });

--- a/src/services/workspace.test.ts
+++ b/src/services/workspace.test.ts
@@ -36,4 +36,16 @@ describe("workspace paths", () => {
     const path = workspace.attachmentPath(PROJECT_ID, "agent-1", "att-1", "file.pdf");
     expect(path).toContain("agents/agent-1/attachments/att-1/file.pdf");
   });
+
+  it("claudeConfigDir is under agent dir", () => {
+    expect(workspace.claudeConfigDir(PROJECT_ID, "agent-123")).toBe(
+      workspace.agentDir(PROJECT_ID, "agent-123") + "/.claude",
+    );
+  });
+
+  it("claudeSettingsPath points to settings.json", () => {
+    expect(workspace.claudeSettingsPath(PROJECT_ID, "agent-123")).toBe(
+      workspace.agentDir(PROJECT_ID, "agent-123") + "/.claude/settings.json",
+    );
+  });
 });

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { homedir } from "os";
-import { mkdir } from "fs/promises";
-import { mkdirSync, rmSync } from "fs";
+import { access, mkdir, writeFile } from "fs/promises";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 
 export function projectsDir(): string {
   return process.env.SHIRE_PROJECTS_DIR || join(homedir(), ".shire", "projects");
@@ -60,6 +60,24 @@ export function skillDir(
   return join(skillsDir(projectId, agentId, harness), skillName);
 }
 
+export function claudeConfigDir(projectId: string, agentId: string): string {
+  return join(agentDir(projectId, agentId), ".claude");
+}
+
+export function claudeSettingsPath(projectId: string, agentId: string): string {
+  return join(claudeConfigDir(projectId, agentId), "settings.json");
+}
+
+const AGENT_CLAUDE_SETTINGS = JSON.stringify(
+  {
+    permissions: {
+      allow: ["Edit(.claude/**)", "Write(.claude/**)"],
+    },
+  },
+  null,
+  2,
+);
+
 export function sharedDir(projectId: string): string {
   return join(root(projectId), "shared");
 }
@@ -86,7 +104,14 @@ export async function ensureAgentDirs(projectId: string, agentId: string): Promi
     mkdir(outboxDir(projectId, agentId), { recursive: true }),
     mkdir(attachmentsDir(projectId, agentId), { recursive: true }),
     mkdir(join(attachmentsDir(projectId, agentId), "outbox"), { recursive: true }),
+    mkdir(claudeConfigDir(projectId, agentId), { recursive: true }),
   ]);
+  const settingsPath = claudeSettingsPath(projectId, agentId);
+  try {
+    await access(settingsPath);
+  } catch {
+    await writeFile(settingsPath, AGENT_CLAUDE_SETTINGS, "utf-8");
+  }
 }
 
 /** Sync versions for use inside DB transactions */
@@ -102,6 +127,11 @@ export function ensureAgentDirsSync(projectId: string, agentId: string): void {
   mkdirSync(outboxDir(projectId, agentId), { recursive: true });
   mkdirSync(attachmentsDir(projectId, agentId), { recursive: true });
   mkdirSync(join(attachmentsDir(projectId, agentId), "outbox"), { recursive: true });
+  mkdirSync(claudeConfigDir(projectId, agentId), { recursive: true });
+  const settingsPath = claudeSettingsPath(projectId, agentId);
+  if (!existsSync(settingsPath)) {
+    writeFileSync(settingsPath, AGENT_CLAUDE_SETTINGS, "utf-8");
+  }
 }
 
 export function removeAgentDirSync(projectId: string, agentId: string): void {


### PR DESCRIPTION
## Summary
- Creates a `.claude/settings.json` with `Edit(.claude/**)` and `Write(.claude/**)` permissions during agent workspace setup
- Allows Claude harness agents to freely create/update/delete their own skills in `.claude/` subdirectories
- Only writes the default settings on first creation — preserves agent-customized settings on subsequent restarts

## Test plan
- [x] `ensureAgentDirs` creates `.claude/settings.json` with correct permissions
- [x] `ensureAgentDirsSync` creates `.claude/settings.json` with correct permissions
- [x] Existing settings.json is not overwritten on restart (async + sync)
- [x] Path helpers return correct paths
- [x] All 515 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)