### PR TITLE
Fix scheduled tasks firing on wrong day (day-of-week shift)

### DIFF
--- a/src/frontend/components/SchedulesPage.tsx
+++ b/src/frontend/components/SchedulesPage.tsx
@@ -29,6 +29,14 @@ import { ChevronLeft, Plus, Play, Pencil, Trash2 } from "lucide-react";
 import { Spinner, PageLoader } from "./ui/spinner";
 import { ErrorState } from "./ui/error-state";
 import { navigate } from "../lib/navigate";
+import {
+  DAY_LABELS,
+  buildCronExpression,
+  describeCron,
+  parseCronToForm,
+  type CronFormFields,
+  type Frequency,
+} from "../lib/cron-utils";
 import { type ScheduledTask } from "./types";
 import {
   useProjectId,
@@ -42,19 +50,11 @@ import {
 } from "../lib/hooks";
 import { useSubscription } from "../lib/ws";
 
-type Frequency = "every_n_minutes" | "hourly" | "daily" | "weekly" | "monthly";
-
-interface ScheduleFormState {
+interface ScheduleFormState extends CronFormFields {
   label: string;
   agentId: string;
   message: string;
   scheduleType: "once" | "recurring";
-  frequency: Frequency;
-  minute: string;
-  hour: string;
-  daysOfWeek: number[];
-  dayOfMonth: string;
-  intervalMinutes: string;
   date: string;
   time: string;
 }
@@ -73,21 +73,6 @@ const DEFAULT_FORM: ScheduleFormState = {
   date: "",
   time: "09:00",
 };
-
-const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-
-// Get the local timezone offset in hours (e.g., UTC-5 returns -5)
-const TZ_OFFSET_HOURS = new Date().getTimezoneOffset() / -60;
-
-/** Convert local hour to UTC hour */
-function localHourToUtc(hour: number): number {
-  return (((hour - TZ_OFFSET_HOURS) % 24) + 24) % 24;
-}
-
-/** Convert UTC hour to local hour */
-function utcHourToLocal(hour: number): number {
-  return (((hour + TZ_OFFSET_HOURS) % 24) + 24) % 24;
-}
 
 /** Convert a local date + time string to a UTC ISO string */
 function localToUtcIso(date: string, time: string): string {
@@ -109,73 +94,6 @@ function utcIsoToLocal(isoString: string): { date: string; time: string } {
 
 // Props interface removed — component now owns its data fetching
 
-function buildCronExpression(form: ScheduleFormState): string {
-  // Convert local hour/minute to UTC for the cron expression stored on the server
-  const localMin = parseInt(form.minute || "0");
-  const localHr = parseInt(form.hour || "9");
-  const utcHr = localHourToUtc(localHr);
-  const min = String(localMin);
-  const hr = String(utcHr);
-
-  switch (form.frequency) {
-    case "every_n_minutes":
-      return `*/${form.intervalMinutes || "30"} * * * *`;
-    case "hourly":
-      return `${min} * * * *`;
-    case "daily":
-      return `${min} ${hr} * * *`;
-    case "weekly": {
-      if (form.daysOfWeek.length === 0) return `${min} ${hr} * * *`;
-      const dayNames = form.daysOfWeek
-        .sort((a, b) => a - b)
-        .map((d) => DAY_LABELS[d - 1]?.toUpperCase().slice(0, 3))
-        .join(",");
-      return `${min} ${hr} * * ${dayNames}`;
-    }
-    case "monthly":
-      return `${min} ${hr} ${form.dayOfMonth || "1"} * *`;
-    default:
-      return `${min} ${hr} * * *`;
-  }
-}
-
-function describeCron(cron: string): string {
-  const parts = cron.split(" ");
-  if (parts.length !== 5) return cron;
-  const [min, hr, dom, , dow] = parts;
-
-  if (min?.startsWith("*/")) {
-    return `Every ${min.slice(2)} minutes`;
-  }
-  if (hr === "*" && dom === "*") {
-    return `Hourly at :${min?.padStart(2, "0")}`;
-  }
-
-  // Convert UTC cron hour to local for display
-  const utcHour = parseInt(hr || "0");
-  const localHour = utcHourToLocal(utcHour);
-  const timeStr = formatTime(localHour, parseInt(min || "0"));
-
-  if (dow && dow !== "*") {
-    const dayStr = dow
-      .split(",")
-      .map((d) => d.slice(0, 3))
-      .map((d) => d.charAt(0) + d.slice(1).toLowerCase())
-      .join(", ");
-    return `${dayStr} at ${timeStr}`;
-  }
-  if (dom && dom !== "*") {
-    return `Monthly on day ${dom} at ${timeStr}`;
-  }
-  return `Daily at ${timeStr}`;
-}
-
-function formatTime(hour: number, minute: number): string {
-  const ampm = hour >= 12 ? "PM" : "AM";
-  const h = hour % 12 || 12;
-  return `${h}:${minute.toString().padStart(2, "0")} ${ampm}`;
-}
-
 function timeAgo(isoString: string): string {
   const now = Date.now();
   const then = new Date(isoString).getTime();
@@ -184,49 +102,6 @@ function timeAgo(isoString: string): string {
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
   return `${Math.floor(diff / 86400)}d ago`;
-}
-
-function parseCronToForm(cron: string): Partial<ScheduleFormState> {
-  const parts = cron.split(" ");
-  if (parts.length !== 5) return {};
-  const [min, hr, dom, , dow] = parts;
-
-  if (min?.startsWith("*/")) {
-    return {
-      frequency: "every_n_minutes",
-      intervalMinutes: min.slice(2),
-    };
-  }
-  if (hr === "*") {
-    return { frequency: "hourly", minute: min || "0" };
-  }
-
-  // Convert UTC hour from cron to local for the form
-  const localHour = String(utcHourToLocal(parseInt(hr || "9")));
-
-  if (dow && dow !== "*") {
-    const days = dow.split(",").map((d) => {
-      const idx = DAY_LABELS.findIndex(
-        (l) => l.toUpperCase().slice(0, 3) === d.toUpperCase().slice(0, 3),
-      );
-      return idx + 1;
-    });
-    return {
-      frequency: "weekly",
-      hour: localHour,
-      minute: min || "0",
-      daysOfWeek: days,
-    };
-  }
-  if (dom && dom !== "*") {
-    return {
-      frequency: "monthly",
-      hour: localHour,
-      minute: min || "0",
-      dayOfMonth: dom,
-    };
-  }
-  return { frequency: "daily", hour: localHour, minute: min || "0" };
 }
 
 export default function SchedulesPage() {

--- a/src/frontend/lib/cron-utils.test.ts
+++ b/src/frontend/lib/cron-utils.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCronExpression,
+  describeCron,
+  parseCronToForm,
+  localHourToUtc,
+  utcHourToLocal,
+  getDayShift,
+  getReverseDayShift,
+  type CronFormFields,
+} from "./cron-utils";
+
+const baseForm: CronFormFields = {
+  frequency: "weekly",
+  minute: "42",
+  hour: "4",
+  daysOfWeek: [2, 3, 4, 5, 6], // Tue-Sat
+  dayOfMonth: "1",
+  intervalMinutes: "30",
+};
+
+describe("localHourToUtc / utcHourToLocal", () => {
+  test("UTC+8: local 4 → UTC 20", () => {
+    expect(localHourToUtc(4, 8)).toBe(20);
+  });
+
+  test("UTC+8: UTC 20 → local 4", () => {
+    expect(utcHourToLocal(20, 8)).toBe(4);
+  });
+
+  test("UTC-5: local 22 → UTC 3 (next day)", () => {
+    expect(localHourToUtc(22, -5)).toBe(3);
+  });
+
+  test("UTC-5: UTC 3 → local 22", () => {
+    expect(utcHourToLocal(3, -5)).toBe(22);
+  });
+
+  test("UTC+0: local 10 → UTC 10", () => {
+    expect(localHourToUtc(10, 0)).toBe(10);
+  });
+});
+
+describe("getDayShift", () => {
+  test("UTC+8 at 4 AM: day shifts -1 (previous day in UTC)", () => {
+    expect(getDayShift(4, 8)).toBe(-1);
+  });
+
+  test("UTC+8 at 10 AM: no day shift", () => {
+    expect(getDayShift(10, 8)).toBe(0);
+  });
+
+  test("UTC-5 at 22: day shifts +1 (next day in UTC)", () => {
+    expect(getDayShift(22, -5)).toBe(1);
+  });
+
+  test("UTC-5 at 2 AM: no day shift", () => {
+    expect(getDayShift(2, -5)).toBe(0);
+  });
+
+  test("UTC+0: never shifts", () => {
+    expect(getDayShift(0, 0)).toBe(0);
+    expect(getDayShift(23, 0)).toBe(0);
+  });
+});
+
+describe("getReverseDayShift", () => {
+  test("UTC+8 with UTC hour 20: reverse shift +1 (local is next day)", () => {
+    expect(getReverseDayShift(20, 8)).toBe(1);
+  });
+
+  test("UTC+8 with UTC hour 10: no reverse shift", () => {
+    expect(getReverseDayShift(10, 8)).toBe(0);
+  });
+
+  test("UTC-5 with UTC hour 3: reverse shift -1 (local is previous day)", () => {
+    expect(getReverseDayShift(3, -5)).toBe(-1);
+  });
+});
+
+describe("buildCronExpression — day-of-week shift", () => {
+  test("UTC+8 at 4:42 AM: Tue-Sat local → Mon-Fri in cron", () => {
+    const cron = buildCronExpression(baseForm, 8);
+    // Tue(2)-Sat(6) shifted by -1 → Mon(1)-Fri(5)
+    expect(cron).toBe("42 20 * * MON,TUE,WED,THU,FRI");
+  });
+
+  test("UTC+8 at 10 AM: no day shift, Tue-Sat stays Tue-Sat", () => {
+    const form = { ...baseForm, hour: "10" };
+    const cron = buildCronExpression(form, 8);
+    expect(cron).toBe("42 2 * * TUE,WED,THU,FRI,SAT");
+  });
+
+  test("UTC-5 at 10 PM: Mon-Fri local → Tue-Sat in cron", () => {
+    const form: CronFormFields = {
+      ...baseForm,
+      hour: "22",
+      daysOfWeek: [1, 2, 3, 4, 5], // Mon-Fri
+    };
+    const cron = buildCronExpression(form, -5);
+    // Mon(1)-Fri(5) shifted by +1 → Tue(2)-Sat(6)
+    expect(cron).toBe("42 3 * * TUE,WED,THU,FRI,SAT");
+  });
+
+  test("UTC+0: no day shift", () => {
+    const cron = buildCronExpression(baseForm, 0);
+    expect(cron).toBe("42 4 * * TUE,WED,THU,FRI,SAT");
+  });
+
+  test("UTC+8 at 4 AM: Sun wraps to Sat", () => {
+    const form = { ...baseForm, daysOfWeek: [7] }; // Sun
+    const cron = buildCronExpression(form, 8);
+    // Sun(7) shifted by -1 → Sat(6)
+    expect(cron).toBe("42 20 * * SAT");
+  });
+
+  test("UTC-5 at 10 PM: Sat wraps to Sun", () => {
+    const form: CronFormFields = {
+      ...baseForm,
+      hour: "22",
+      daysOfWeek: [6], // Sat
+    };
+    const cron = buildCronExpression(form, -5);
+    // Sat(6) shifted by +1 → Sun(7)
+    expect(cron).toBe("42 3 * * SUN");
+  });
+
+  test("daily frequency is not affected by day shift", () => {
+    const form: CronFormFields = { ...baseForm, frequency: "daily" };
+    const cron = buildCronExpression(form, 8);
+    expect(cron).toBe("42 20 * * *");
+  });
+});
+
+describe("describeCron — shows local days", () => {
+  test("UTC+8: MON-FRI in cron → Tue-Sat in display", () => {
+    const desc = describeCron("42 20 * * MON,TUE,WED,THU,FRI", 8);
+    expect(desc).toBe("Tue, Wed, Thu, Fri, Sat at 4:42 AM");
+  });
+
+  test("UTC-5: TUE-SAT in cron → Mon-Fri in display", () => {
+    const desc = describeCron("42 3 * * TUE,WED,THU,FRI,SAT", -5);
+    expect(desc).toBe("Mon, Tue, Wed, Thu, Fri at 10:42 PM");
+  });
+
+  test("UTC+0: no shift in display", () => {
+    const desc = describeCron("42 4 * * TUE,WED,THU,FRI,SAT", 0);
+    expect(desc).toBe("Tue, Wed, Thu, Fri, Sat at 4:42 AM");
+  });
+
+  test("daily cron not affected", () => {
+    const desc = describeCron("0 20 * * *", 8);
+    expect(desc).toBe("Daily at 4:00 AM");
+  });
+});
+
+describe("parseCronToForm — reverses day shift", () => {
+  test("UTC+8: MON-FRI in cron → Tue-Sat in form", () => {
+    const result = parseCronToForm("42 20 * * MON,TUE,WED,THU,FRI", 8);
+    expect(result.frequency).toBe("weekly");
+    expect(result.hour).toBe("4");
+    expect(result.minute).toBe("42");
+    expect(result.daysOfWeek?.sort()).toEqual([2, 3, 4, 5, 6]); // Tue-Sat
+  });
+
+  test("UTC-5: TUE-SAT in cron → Mon-Fri in form", () => {
+    const result = parseCronToForm("42 3 * * TUE,WED,THU,FRI,SAT", -5);
+    expect(result.frequency).toBe("weekly");
+    expect(result.hour).toBe("22");
+    expect(result.daysOfWeek?.sort()).toEqual([1, 2, 3, 4, 5]); // Mon-Fri
+  });
+
+  test("UTC+0: no shift", () => {
+    const result = parseCronToForm("42 4 * * TUE,WED,THU,FRI,SAT", 0);
+    expect(result.daysOfWeek?.sort()).toEqual([2, 3, 4, 5, 6]);
+  });
+});
+
+describe("round-trip: buildCron → parseCronToForm preserves local intent", () => {
+  test("UTC+8: Tue-Sat at 4:42 AM round-trips correctly", () => {
+    const cron = buildCronExpression(baseForm, 8);
+    const parsed = parseCronToForm(cron, 8);
+    expect(parsed.hour).toBe("4");
+    expect(parsed.minute).toBe("42");
+    expect(parsed.daysOfWeek?.sort()).toEqual([2, 3, 4, 5, 6]);
+  });
+
+  test("UTC-5: Mon-Fri at 10 PM round-trips correctly", () => {
+    const form: CronFormFields = {
+      ...baseForm,
+      hour: "22",
+      daysOfWeek: [1, 2, 3, 4, 5],
+    };
+    const cron = buildCronExpression(form, -5);
+    const parsed = parseCronToForm(cron, -5);
+    expect(parsed.hour).toBe("22");
+    expect(parsed.daysOfWeek?.sort()).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("UTC+0: no shift needed, round-trips correctly", () => {
+    const cron = buildCronExpression(baseForm, 0);
+    const parsed = parseCronToForm(cron, 0);
+    expect(parsed.hour).toBe("4");
+    expect(parsed.daysOfWeek?.sort()).toEqual([2, 3, 4, 5, 6]);
+  });
+});

--- a/src/frontend/lib/cron-utils.ts
+++ b/src/frontend/lib/cron-utils.ts
@@ -1,0 +1,173 @@
+export const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+export type Frequency = "every_n_minutes" | "hourly" | "daily" | "weekly" | "monthly";
+
+export interface CronFormFields {
+  frequency: Frequency;
+  minute: string;
+  hour: string;
+  daysOfWeek: number[];
+  dayOfMonth: string;
+  intervalMinutes: string;
+}
+
+/** Get the local timezone offset in hours (e.g., UTC+8 returns 8, UTC-5 returns -5) */
+export function getTzOffsetHours(): number {
+  return new Date().getTimezoneOffset() / -60;
+}
+
+/** Convert local hour to UTC hour */
+export function localHourToUtc(hour: number, tzOffset = getTzOffsetHours()): number {
+  return (((hour - tzOffset) % 24) + 24) % 24;
+}
+
+/** Convert UTC hour to local hour */
+export function utcHourToLocal(hour: number, tzOffset = getTzOffsetHours()): number {
+  return (((hour + tzOffset) % 24) + 24) % 24;
+}
+
+/**
+ * Compute day-of-week shift when converting local hour to UTC.
+ * Returns -1 if UTC is previous day, +1 if next day, 0 if same day.
+ */
+export function getDayShift(localHour: number, tzOffset = getTzOffsetHours()): number {
+  return Math.floor((localHour - tzOffset) / 24);
+}
+
+/**
+ * Compute reverse day-of-week shift when converting UTC hour to local.
+ * Returns -1, 0, or +1.
+ */
+export function getReverseDayShift(utcHour: number, tzOffset = getTzOffsetHours()): number {
+  return Math.floor((utcHour + tzOffset) / 24);
+}
+
+/** Shift a 1-based day (1=Mon..7=Sun) by dayShift, wrapping around the week. */
+function shiftDay(day: number, dayShift: number): number {
+  return ((((day - 1 + dayShift) % 7) + 7) % 7) + 1;
+}
+
+export function buildCronExpression(form: CronFormFields, tzOffset = getTzOffsetHours()): string {
+  const localMin = parseInt(form.minute || "0");
+  const localHr = parseInt(form.hour || "9");
+  const utcHr = localHourToUtc(localHr, tzOffset);
+  const min = String(localMin);
+  const hr = String(utcHr);
+
+  switch (form.frequency) {
+    case "every_n_minutes":
+      return `*/${form.intervalMinutes || "30"} * * * *`;
+    case "hourly":
+      return `${min} * * * *`;
+    case "daily":
+      return `${min} ${hr} * * *`;
+    case "weekly": {
+      if (form.daysOfWeek.length === 0) return `${min} ${hr} * * *`;
+      const dayShift = getDayShift(localHr, tzOffset);
+      const dayNames = form.daysOfWeek
+        .map((d) => shiftDay(d, dayShift))
+        .sort((a, b) => a - b)
+        .map((d) => DAY_LABELS[d - 1]?.toUpperCase().slice(0, 3))
+        .join(",");
+      return `${min} ${hr} * * ${dayNames}`;
+    }
+    case "monthly":
+      return `${min} ${hr} ${form.dayOfMonth || "1"} * *`;
+    default:
+      return `${min} ${hr} * * *`;
+  }
+}
+
+export function formatTime(hour: number, minute: number): string {
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const h = hour % 12 || 12;
+  return `${h}:${minute.toString().padStart(2, "0")} ${ampm}`;
+}
+
+export function describeCron(cron: string, tzOffset = getTzOffsetHours()): string {
+  const parts = cron.split(" ");
+  if (parts.length !== 5) return cron;
+  const [min, hr, dom, , dow] = parts;
+
+  if (min?.startsWith("*/")) {
+    return `Every ${min.slice(2)} minutes`;
+  }
+  if (hr === "*" && dom === "*") {
+    return `Hourly at :${min?.padStart(2, "0")}`;
+  }
+
+  const utcHour = parseInt(hr || "0");
+  const localHour = utcHourToLocal(utcHour, tzOffset);
+  const timeStr = formatTime(localHour, parseInt(min || "0"));
+
+  if (dow && dow !== "*") {
+    const reverseDayShift = getReverseDayShift(utcHour, tzOffset);
+    const dayStr = dow
+      .split(",")
+      .map((d) => {
+        const idx = DAY_LABELS.findIndex(
+          (l) => l.toUpperCase().slice(0, 3) === d.toUpperCase().slice(0, 3),
+        );
+        if (idx === -1) return d.charAt(0) + d.slice(1).toLowerCase();
+        const localIdx = shiftDay(idx + 1, reverseDayShift) - 1;
+        return DAY_LABELS[localIdx];
+      })
+      .join(", ");
+    return `${dayStr} at ${timeStr}`;
+  }
+  if (dom && dom !== "*") {
+    return `Monthly on day ${dom} at ${timeStr}`;
+  }
+  return `Daily at ${timeStr}`;
+}
+
+export function parseCronToForm(
+  cron: string,
+  tzOffset = getTzOffsetHours(),
+): Partial<CronFormFields> {
+  const parts = cron.split(" ");
+  if (parts.length !== 5) return {};
+  const [min, hr, dom, , dow] = parts;
+
+  if (min?.startsWith("*/")) {
+    return {
+      frequency: "every_n_minutes",
+      intervalMinutes: min.slice(2),
+    };
+  }
+  if (hr === "*") {
+    return { frequency: "hourly", minute: min || "0" };
+  }
+
+  const utcHour = parseInt(hr || "9");
+  const localHour = String(utcHourToLocal(utcHour, tzOffset));
+
+  if (dow && dow !== "*") {
+    const reverseDayShift = getReverseDayShift(utcHour, tzOffset);
+    const days = dow
+      .split(",")
+      .map((d) => {
+        const idx = DAY_LABELS.findIndex(
+          (l) => l.toUpperCase().slice(0, 3) === d.toUpperCase().slice(0, 3),
+        );
+        if (idx === -1) return null;
+        return shiftDay(idx + 1, reverseDayShift);
+      })
+      .filter((d): d is number => d !== null);
+    return {
+      frequency: "weekly",
+      hour: localHour,
+      minute: min || "0",
+      daysOfWeek: days,
+    };
+  }
+  if (dom && dom !== "*") {
+    return {
+      frequency: "monthly",
+      hour: localHour,
+      minute: min || "0",
+      dayOfMonth: dom,
+    };
+  }
+  return { frequency: "daily", hour: localHour, minute: min || "0" };
+}

--- a/src/runtime/scheduler.ts
+++ b/src/runtime/scheduler.ts
@@ -39,7 +39,7 @@ export class Scheduler {
     const callback = () => this.fireTask(task);
 
     if (task.scheduleType === "recurring" && task.cronExpression) {
-      const job = schedule.scheduleJob(task.cronExpression, callback);
+      const job = schedule.scheduleJob({ rule: task.cronExpression, tz: "Etc/UTC" }, callback);
       if (job) this.jobs.set(task.id, job);
     } else if (task.scheduleType === "once" && task.scheduledAt) {
       const date = new Date(task.scheduledAt);


### PR DESCRIPTION
## Summary
- When converting local time to UTC for cron expressions, the hour was correctly shifted but the **day-of-week was not**. In UTC+8, a task set for Tuesday 4:42 AM local (= Monday 20:42 UTC) still had `TUE` in the cron instead of `MON`, causing tasks to fire one day late.
- Extracted cron helpers into `src/frontend/lib/cron-utils.ts` with proper day-of-week shift logic in `buildCronExpression`, `parseCronToForm`, and `describeCron`.
- Added `tz: "Etc/UTC"` to `node-schedule`'s `scheduleJob` call to ensure UTC interpretation regardless of server locale.
- **Existing schedules** need to be re-saved through the edit UI to pick up the corrected day-of-week values.

## Test plan
- [x] 30 unit tests covering day shift math, round-trips, and edge cases (UTC+8, UTC-5, UTC+0, wrap-around Sun↔Mon)
- [x] All 539 existing tests pass
- [x] TypeScript strict mode — no errors
- [x] ESLint + Prettier — no issues
- [ ] Manual: re-save schedules on the server, verify tasks fire on the correct day

🤖 Generated with [Claude Code](https://claude.com/claude-code)