### PR TITLE
Refactor system prompt into its own module

### DIFF
--- a/src/runtime/agent-manager.test.ts
+++ b/src/runtime/agent-manager.test.ts
@@ -470,52 +470,7 @@ describe("AgentManager", () => {
     });
   });
 
-  describe("buildInternalPrompt", () => {
-    it("includes file access boundary with correct paths", () => {
-      const mgr = createManager();
-      const prompt = (
-        mgr as unknown as { buildInternalPrompt: () => string }
-      ).buildInternalPrompt();
-      const projectRoot = workspace.root(projectId);
-      const agentPath = workspace.agentDir(projectId, agentId);
-      const sharedPath = workspace.sharedDir(projectId);
-      const projectDoc = workspace.projectDocPath(projectId);
-
-      expect(prompt).toContain("## File Access Boundary — MANDATORY");
-      expect(prompt).toContain(`Your project root is \`${projectRoot}\``);
-      expect(prompt).toContain("MUST NOT create, modify, move, copy, or delete");
-
-      // Write-allowed paths are listed correctly
-      expect(prompt).toContain(`Your own directory: \`${agentPath}\``);
-      expect(prompt).toContain(`The shared drive: \`${sharedPath}\``);
-      expect(prompt).toContain(`Project document: \`${projectDoc}\``);
-
-      // Read-only paths
-      expect(prompt).toContain(`${projectRoot}/agents/`);
-    });
-
-    it("restricts writing to other agents directories", () => {
-      const mgr = createManager();
-      const prompt = (
-        mgr as unknown as { buildInternalPrompt: () => string }
-      ).buildInternalPrompt();
-
-      expect(prompt).toContain("Writing to another agent's directory");
-      expect(prompt).toContain("Read-only paths");
-      expect(prompt).toContain("Other agents' directories");
-    });
-
-    it("requires agent-specific state in own directory", () => {
-      const mgr = createManager();
-      const prompt = (
-        mgr as unknown as { buildInternalPrompt: () => string }
-      ).buildInternalPrompt();
-
-      expect(prompt).toContain("Agent-specific state");
-      expect(prompt).toContain("rules, memory files, skills, or configuration");
-      expect(prompt).toContain("MUST be stored within your own directory");
-    });
-  });
+  // buildInternalPrompt tests have been moved to system-prompt.test.ts
 
   describe("workspace setup", () => {
     it("creates agent directories on start", async () => {

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -12,11 +12,11 @@ import {
   type SerializedMessage,
 } from "../events";
 import * as agentsService from "../services/agents";
-import * as alertChannelsService from "../services/alert-channels";
 import * as workspace from "../services/workspace";
 import * as skillsService from "../services/skills";
 import { createHarness, type Harness, type HarnessType } from "./harness";
 import type { AgentEvent } from "./harness/types";
+import { buildInternalPrompt } from "./system-prompt";
 
 export type { AgentStatus } from "../events";
 
@@ -332,7 +332,11 @@ export class AgentManager {
     const model = agent.model ?? "claude-sonnet-4-6";
     const systemPrompt = agent.systemPrompt ?? "";
     const agentDir = workspace.agentDir(this.projectId, this.agentId);
-    const internalSystemPrompt = this.buildInternalPrompt();
+    const internalSystemPrompt = buildInternalPrompt({
+      agentName: this.agentName,
+      projectId: this.projectId,
+      agentId: this.agentId,
+    });
 
     this.harness = createHarness(harnessType);
     this.harness.onEvent((event: AgentEvent) => this.handleHarnessEvent(event));
@@ -824,130 +828,6 @@ export class AgentManager {
     await workspace.ensureAgentDirs(this.projectId, this.agentId);
     const agent = agentsService.getAgent(this.agentId);
     await skillsService.ensureSkillsDir(this.projectId, this.agentId, agent?.harness ?? undefined);
-  }
-
-  private buildInternalPrompt(): string {
-    const peersPath = workspace.peersPath(this.projectId);
-    const agentDir = workspace.agentDir(this.projectId, this.agentId);
-    const outboxPath = join(agentDir, "outbox/<any-name>.yaml");
-    const sharedPath = workspace.sharedDir(this.projectId);
-    const projectDoc = workspace.projectDocPath(this.projectId);
-    const projectRoot = workspace.root(this.projectId);
-
-    let prompt = `# Inter-Agent Communication
-
-You are **${this.agentName}**, one of several agents running in a shared environment.
-
-## First Responder Rule
-When the user sends you a message, YOU are the lead for that task:
-- You are responsible for delivering the final result to the user
-- Delegate to other agents when they have capabilities you lack
-- When you receive replies, synthesize their input and present the final answer
-- The user sees YOUR output, not the other agents' — always produce the complete response
-
-## Discovering Peers
-Read \`${peersPath}\` to see available agents and their descriptions.
-
-## Sending Messages
-To message another agent, write a YAML file to your **outbox**:
-
-**Path:** \`${outboxPath}\`
-
-**Format:**
-\`\`\`yaml
-to: target-agent-name
-text: Your message here
-\`\`\`
-
-Quote the \`text\` value if it contains special YAML characters (\`:\`, \`#\`, \`{\`, \`}\`).
-
-The system delivers the message to the target agent automatically.
-Outbox files are removed once delivered — this is expected.
-
-## Receiving Messages
-Messages arrive in your conversation automatically:
-- **User messages:** sent directly by the user
-- **Agent messages:** arrive prefixed with \`[Message from agent "<name>"]\`
-
-## Attachments
-Write files to \`attachments/outbox/\` to share them with the user in chat.
-
-## Shared Drive
-All agents can read and write files in \`${sharedPath}/\`.
-
-## Project Document
-Read \`${projectDoc}\` for project context before starting tasks.
-
-## Guidelines
-- Read \`${peersPath}\` before messaging to confirm the target agent exists
-- Be specific about what you need from the other agent
-- Don't send messages unnecessarily — only when collaboration genuinely helps
-
-## File Access Boundary — MANDATORY
-
-Your project root is \`${projectRoot}\`. You MUST NOT create, modify, move, copy, or delete any file or directory outside this path. This applies to ALL tools:
-
-- **Write / Edit**: Only target paths under \`${projectRoot}\`
-- **Bash**: Do not use shell commands (cp, mv, rm, mkdir, touch, tee, sed, >, >>) to write outside \`${projectRoot}\`. Do not use symlinks or hard links to escape this boundary.
-- **Read**: You may read a file outside the project root only if the user's message contains an explicit absolute path to that file. Never write based on paths discovered outside the boundary.
-
-**Write-allowed paths** (you may create, modify, and delete files here):
-- Your own directory: \`${agentDir}\` and all its subdirectories (inbox/, outbox/, attachments/)
-- The shared drive: \`${sharedPath}\`
-- Project document: \`${projectDoc}\`
-
-**Read-only paths** (you may read but MUST NOT write, modify, or delete):
-- Other agents' directories under \`${projectRoot}/agents/\` — these belong to other agents
-- \`${peersPath}\` — read to discover available agents before messaging
-
-**Agent-specific state**: Any rules, memory files, skills, or configuration that are specific to you (this agent) MUST be stored within your own directory \`${agentDir}\`. Never write agent-specific state to the shared drive or other locations.
-
-Violations include:
-- Writing to another agent's directory
-- Writing agent-specific rules, memory, or skills outside your own directory
-- Writing to another project's folder
-- Modifying system files or dotfiles outside the project root
-- Using Bash to pipe, redirect, or copy data to paths outside \`${projectRoot}\`
-`;
-
-    // Conditionally inject alert instructions when a channel is configured
-    if (alertChannelsService.hasAlertChannel(this.projectId)) {
-      prompt += `
-## Sending Alerts / Notifications
-
-When something important happens that the user should know about — such as task completion,
-errors, build failures, or warnings — write a YAML file to your **outbox** with a special target:
-
-**Path:** \`${outboxPath.replace("<any-name>", "<alert-name>")}\`
-
-**Format:**
-\`\`\`yaml
-to: system_alert
-text: alert
-title: Short summary of the alert
-body: Detailed description of what happened
-severity: info  # one of: info | success | warning | error
-\`\`\`
-
-The \`text\` field is required by the outbox system. Set it to any non-empty string (e.g. "alert").
-
-The system will deliver the alert to the user's configured notification channel.
-Alert files are removed once delivered — this is expected.
-
-**Severity levels:**
-- \`info\` — general status updates
-- \`success\` — task completed successfully
-- \`warning\` — potential problems that may need attention
-- \`error\` — failures and critical issues
-
-**Guidelines:**
-- Keep titles concise (under 100 characters)
-- Include actionable details in the body
-- Don't send alerts for routine operations — only for notable events
-`;
-    }
-
-    return prompt;
   }
 
   // --- Broadcasting ---

--- a/src/runtime/system-prompt.test.ts
+++ b/src/runtime/system-prompt.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+import { createTestDb } from "../test/setup";
+import * as projects from "../services/projects";
+import * as agentsService from "../services/agents";
+import * as alertChannelsService from "../services/alert-channels";
+import { buildInternalPrompt } from "./system-prompt";
+
+let testDir: string;
+let projectId: string;
+let agentId: string;
+
+beforeEach(() => {
+  createTestDb();
+  testDir = join(tmpdir(), `sp_test_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+  process.env.SHIRE_PROJECTS_DIR = testDir;
+  const project = projects.createProject(`test-project-${Date.now()}`);
+  projectId = project.id;
+  const agent = agentsService.createAgent(projectId, { name: "test-agent" });
+  agentId = agent.id;
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("buildInternalPrompt", () => {
+  it("includes the agent name", () => {
+    const prompt = buildInternalPrompt({ agentName: "my-agent", projectId, agentId });
+    expect(prompt).toContain("You are **my-agent**");
+  });
+
+  it("includes all core sections", () => {
+    const prompt = buildInternalPrompt({ agentName: "my-agent", projectId, agentId });
+    expect(prompt).toContain("## First Responder Rule");
+    expect(prompt).toContain("## Discovering Peers");
+    expect(prompt).toContain("## Sending Messages");
+    expect(prompt).toContain("## Receiving Messages");
+    expect(prompt).toContain("## Attachments");
+    expect(prompt).toContain("## Shared Drive");
+    expect(prompt).toContain("## Project Document");
+    expect(prompt).toContain("## Guidelines");
+    expect(prompt).toContain("## File Access Boundary — MANDATORY");
+  });
+
+  it("includes workspace paths", () => {
+    const prompt = buildInternalPrompt({ agentName: "my-agent", projectId, agentId });
+    expect(prompt).toContain(join(testDir, projectId, "peers.yaml"));
+    expect(prompt).toContain(join(testDir, projectId, "agents", agentId));
+    expect(prompt).toContain(join(testDir, projectId, "shared"));
+    expect(prompt).toContain(join(testDir, projectId, "PROJECT.md"));
+  });
+
+  it("includes file access boundary with write-allowed and read-only paths", () => {
+    const prompt = buildInternalPrompt({ agentName: "my-agent", projectId, agentId });
+    const projectRoot = join(testDir, projectId);
+    const agentPath = join(testDir, projectId, "agents", agentId);
+    const sharedPath = join(testDir, projectId, "shared");
+    const projectDoc = join(testDir, projectId, "PROJECT.md");
+
+    expect(prompt).toContain(`Your project root is \`${projectRoot}\``);
+    expect(prompt).toContain("MUST NOT create, modify, move, copy, or delete");
+    expect(prompt).toContain(`Your own directory: \`${agentPath}\``);
+    expect(prompt).toContain(`The shared drive: \`${sharedPath}\``);
+    expect(prompt).toContain(`Project document: \`${projectDoc}\``);
+    expect(prompt).toContain(`${projectRoot}/agents/`);
+    expect(prompt).toContain("Writing to another agent's directory");
+    expect(prompt).toContain("Agent-specific state");
+    expect(prompt).toContain("MUST be stored within your own directory");
+  });
+
+  it("excludes alert section when no alert channel is configured", () => {
+    const prompt = buildInternalPrompt({ agentName: "my-agent", projectId, agentId });
+    expect(prompt).not.toContain("## Sending Alerts / Notifications");
+    expect(prompt).not.toContain("system_alert");
+  });
+
+  it("includes alert section when alert channel is configured", () => {
+    alertChannelsService.upsertAlertChannel(projectId, {
+      config: { type: "discord", webhookUrl: "https://example.com/hook" },
+      enabled: true,
+    });
+    const prompt = buildInternalPrompt({ agentName: "my-agent", projectId, agentId });
+    expect(prompt).toContain("## Sending Alerts / Notifications");
+    expect(prompt).toContain("system_alert");
+    expect(prompt).toContain("severity: info");
+    expect(prompt).toContain(
+      join(testDir, projectId, "agents", agentId, "outbox/<alert-name>.yaml"),
+    );
+  });
+});

--- a/src/runtime/system-prompt.ts
+++ b/src/runtime/system-prompt.ts
@@ -1,0 +1,137 @@
+import { join } from "path";
+import * as alertChannelsService from "../services/alert-channels";
+import * as workspace from "../services/workspace";
+
+interface BuildInternalPromptOpts {
+  agentName: string;
+  projectId: string;
+  agentId: string;
+}
+
+export function buildInternalPrompt({
+  agentName,
+  projectId,
+  agentId,
+}: BuildInternalPromptOpts): string {
+  const peersPath = workspace.peersPath(projectId);
+  const agentDir = workspace.agentDir(projectId, agentId);
+  const outboxPath = join(agentDir, "outbox/<any-name>.yaml");
+  const sharedPath = workspace.sharedDir(projectId);
+  const projectDoc = workspace.projectDocPath(projectId);
+  const projectRoot = workspace.root(projectId);
+
+  let prompt = `# Inter-Agent Communication
+
+You are **${agentName}**, one of several agents running in a shared environment.
+
+## First Responder Rule
+When the user sends you a message, YOU are the lead for that task:
+- You are responsible for delivering the final result to the user
+- Delegate to other agents when they have capabilities you lack
+- When you receive replies, synthesize their input and present the final answer
+- The user sees YOUR output, not the other agents' — always produce the complete response
+
+## Discovering Peers
+Read \`${peersPath}\` to see available agents and their descriptions.
+
+## Sending Messages
+To message another agent, write a YAML file to your **outbox**:
+
+**Path:** \`${outboxPath}\`
+
+**Format:**
+\`\`\`yaml
+to: target-agent-name
+text: Your message here
+\`\`\`
+
+Quote the \`text\` value if it contains special YAML characters (\`:\`, \`#\`, \`{\`, \`}\`).
+
+The system delivers the message to the target agent automatically.
+Outbox files are removed once delivered — this is expected.
+
+## Receiving Messages
+Messages arrive in your conversation automatically:
+- **User messages:** sent directly by the user
+- **Agent messages:** arrive prefixed with \`[Message from agent "<name>"]\`
+
+## Attachments
+Write files to \`attachments/outbox/\` to share them with the user in chat.
+
+## Shared Drive
+All agents can read and write files in \`${sharedPath}/\`.
+
+## Project Document
+Read \`${projectDoc}\` for project context before starting tasks.
+
+## Guidelines
+- Read \`${peersPath}\` before messaging to confirm the target agent exists
+- Be specific about what you need from the other agent
+- Don't send messages unnecessarily — only when collaboration genuinely helps
+
+## File Access Boundary — MANDATORY
+
+Your project root is \`${projectRoot}\`. You MUST NOT create, modify, move, copy, or delete any file or directory outside this path. This applies to ALL tools:
+
+- **Write / Edit**: Only target paths under \`${projectRoot}\`
+- **Bash**: Do not use shell commands (cp, mv, rm, mkdir, touch, tee, sed, >, >>) to write outside \`${projectRoot}\`. Do not use symlinks or hard links to escape this boundary.
+- **Read**: You may read a file outside the project root only if the user's message contains an explicit absolute path to that file. Never write based on paths discovered outside the boundary.
+
+**Write-allowed paths** (you may create, modify, and delete files here):
+- Your own directory: \`${agentDir}\` and all its subdirectories (inbox/, outbox/, attachments/)
+- The shared drive: \`${sharedPath}\`
+- Project document: \`${projectDoc}\`
+
+**Read-only paths** (you may read but MUST NOT write, modify, or delete):
+- Other agents' directories under \`${projectRoot}/agents/\` — these belong to other agents
+- \`${peersPath}\` — read to discover available agents before messaging
+
+**Agent-specific state**: Any rules, memory files, skills, or configuration that are specific to you (this agent) MUST be stored within your own directory \`${agentDir}\`. Never write agent-specific state to the shared drive or other locations.
+
+Violations include:
+- Writing to another agent's directory
+- Writing agent-specific rules, memory, or skills outside your own directory
+- Writing to another project's folder
+- Modifying system files or dotfiles outside the project root
+- Using Bash to pipe, redirect, or copy data to paths outside \`${projectRoot}\`
+`;
+
+  // Conditionally inject alert instructions when a channel is configured
+  if (alertChannelsService.hasAlertChannel(projectId)) {
+    prompt += `
+## Sending Alerts / Notifications
+
+When something important happens that the user should know about — such as task completion,
+errors, build failures, or warnings — write a YAML file to your **outbox** with a special target:
+
+**Path:** \`${outboxPath.replace("<any-name>", "<alert-name>")}\`
+
+**Format:**
+\`\`\`yaml
+to: system_alert
+text: alert
+title: Short summary of the alert
+body: Detailed description of what happened
+severity: info  # one of: info | success | warning | error
+\`\`\`
+
+The \`text\` field is required by the outbox system. Set it to any non-empty string (e.g. "alert").
+
+The system will deliver the alert to the user's configured notification channel.
+Alert files are removed once delivered — this is expected.
+
+**Severity levels:**
+- \`info\` — general status updates
+- \`success\` — task completed successfully
+- \`warning\` — potential problems that may need attention
+- \`error\` — failures and critical issues
+
+**Guidelines:**
+- Keep titles concise (under 100 characters)
+- Include actionable details in the body
+- Don't send alerts for routine operations — only for notable events
+`;
+  }
+
+  return prompt;
+}


### PR DESCRIPTION
## Summary
- Extract `buildInternalPrompt()` from `agent-manager.ts` (~123 lines) into `src/runtime/system-prompt.ts`
- Move related tests to `system-prompt.test.ts` with expanded coverage (file access boundary paths, alert path interpolation)
- Remove unused `alertChannelsService` import from `agent-manager.ts`

## Test plan
- [x] All 524 tests pass (excluding pre-existing CLI port conflict)
- [x] Typecheck passes
- [x] Lint passes
- [x] New tests cover: agent name, core sections, workspace paths, file access boundary, alert section inclusion/exclusion, alert path interpolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)