### PR TITLE
Fix UTC timestamps displaying as local time

### DIFF
--- a/drizzle/0003_unusual_valkyrie.sql
+++ b/drizzle/0003_unusual_valkyrie.sql
@@ -1,0 +1,92 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_agents` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`name` text NOT NULL,
+	`session_id` text,
+	`description` text,
+	`harness` text,
+	`model` text,
+	`system_prompt` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_agents`("id", "project_id", "name", "session_id", "description", "harness", "model", "system_prompt", "created_at", "updated_at") SELECT "id", "project_id", "name", "session_id", "description", "harness", "model", "system_prompt", "created_at", "updated_at" FROM `agents`;--> statement-breakpoint
+DROP TABLE `agents`;--> statement-breakpoint
+ALTER TABLE `__new_agents` RENAME TO `agents`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `agents_project_name` ON `agents` (`project_id`,`name`);--> statement-breakpoint
+CREATE TABLE `__new_alert_channels` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`channel_type` text NOT NULL,
+	`config` text NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_alert_channels`("id", "project_id", "channel_type", "config", "enabled", "created_at", "updated_at") SELECT "id", "project_id", "channel_type", "config", "enabled", "created_at", "updated_at" FROM `alert_channels`;--> statement-breakpoint
+DROP TABLE `alert_channels`;--> statement-breakpoint
+ALTER TABLE `__new_alert_channels` RENAME TO `alert_channels`;--> statement-breakpoint
+CREATE UNIQUE INDEX `alert_channels_project_id_unique` ON `alert_channels` (`project_id`);--> statement-breakpoint
+CREATE TABLE `__new_messages` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` text NOT NULL,
+	`agent_id` text NOT NULL,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_messages`("id", "project_id", "agent_id", "role", "content", "created_at") SELECT "id", "project_id", "agent_id", "role", "content", "created_at" FROM `messages`;--> statement-breakpoint
+DROP TABLE `messages`;--> statement-breakpoint
+ALTER TABLE `__new_messages` RENAME TO `messages`;--> statement-breakpoint
+CREATE INDEX `idx_messages_agent` ON `messages` (`project_id`,`agent_id`,`id`);--> statement-breakpoint
+CREATE TABLE `__new_projects` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_projects`("id", "name", "created_at", "updated_at") SELECT "id", "name", "created_at", "updated_at" FROM `projects`;--> statement-breakpoint
+DROP TABLE `projects`;--> statement-breakpoint
+ALTER TABLE `__new_projects` RENAME TO `projects`;--> statement-breakpoint
+CREATE UNIQUE INDEX `projects_name_unique` ON `projects` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_scheduled_tasks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`agent_id` text NOT NULL,
+	`label` text NOT NULL,
+	`message` text NOT NULL,
+	`schedule_type` text NOT NULL,
+	`cron_expression` text,
+	`scheduled_at` text,
+	`enabled` integer DEFAULT true NOT NULL,
+	`last_run_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_scheduled_tasks`("id", "project_id", "agent_id", "label", "message", "schedule_type", "cron_expression", "scheduled_at", "enabled", "last_run_at", "created_at", "updated_at") SELECT "id", "project_id", "agent_id", "label", "message", "schedule_type", "cron_expression", "scheduled_at", "enabled", "last_run_at", "created_at", "updated_at" FROM `scheduled_tasks`;--> statement-breakpoint
+DROP TABLE `scheduled_tasks`;--> statement-breakpoint
+ALTER TABLE `__new_scheduled_tasks` RENAME TO `scheduled_tasks`;--> statement-breakpoint
+UPDATE `projects` SET `created_at` = `created_at` || 'Z' WHERE `created_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `projects` SET `updated_at` = `updated_at` || 'Z' WHERE `updated_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `agents` SET `created_at` = `created_at` || 'Z' WHERE `created_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `agents` SET `updated_at` = `updated_at` || 'Z' WHERE `updated_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `messages` SET `created_at` = `created_at` || 'Z' WHERE `created_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `alert_channels` SET `created_at` = `created_at` || 'Z' WHERE `created_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `alert_channels` SET `updated_at` = `updated_at` || 'Z' WHERE `updated_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `scheduled_tasks` SET `created_at` = `created_at` || 'Z' WHERE `created_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `scheduled_tasks` SET `updated_at` = `updated_at` || 'Z' WHERE `updated_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `scheduled_tasks` SET `last_run_at` = `last_run_at` || 'Z' WHERE `last_run_at` IS NOT NULL AND `last_run_at` NOT LIKE '%Z';--> statement-breakpoint
+UPDATE `scheduled_tasks` SET `scheduled_at` = `scheduled_at` || 'Z' WHERE `scheduled_at` IS NOT NULL AND `scheduled_at` NOT LIKE '%Z';

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,469 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "120664f0-85b2-44b0-aa5d-d23af984cd13",
+  "prevId": "4b189153-9f03-4bb8-8901-89b62d54efb9",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agents_project_name": {
+          "name": "agents_project_name",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agents_project_id_projects_id_fk": {
+          "name": "agents_project_id_projects_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_channels": {
+      "name": "alert_channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "alert_channels_project_id_unique": {
+          "name": "alert_channels_project_id_unique",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "alert_channels_project_id_projects_id_fk": {
+          "name": "alert_channels_project_id_projects_id_fk",
+          "tableFrom": "alert_channels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_messages_agent": {
+          "name": "idx_messages_agent",
+          "columns": [
+            "project_id",
+            "agent_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_project_id_projects_id_fk": {
+          "name": "messages_project_id_projects_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_agent_id_agents_id_fk": {
+          "name": "messages_agent_id_agents_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_tasks_project_id_projects_id_fk": {
+          "name": "scheduled_tasks_project_id_projects_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_tasks_agent_id_agents_id_fk": {
+          "name": "scheduled_tasks_agent_id_agents_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1774966625077,
       "tag": "0002_thankful_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1775018748655,
+      "tag": "0003_unusual_valkyrie",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,10 +8,10 @@ export const projects = sqliteTable("projects", {
   name: text("name").notNull().unique(),
   createdAt: text("created_at")
     .notNull()
-    .default(sql`(datetime('now'))`),
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   updatedAt: text("updated_at")
     .notNull()
-    .default(sql`(datetime('now'))`),
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });
 
 export const agents = sqliteTable(
@@ -31,10 +31,10 @@ export const agents = sqliteTable(
     systemPrompt: text("system_prompt"),
     createdAt: text("created_at")
       .notNull()
-      .default(sql`(datetime('now'))`),
+      .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
     updatedAt: text("updated_at")
       .notNull()
-      .default(sql`(datetime('now'))`),
+      .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   },
   (t) => [unique("agents_project_name").on(t.projectId, t.name)],
 );
@@ -53,7 +53,7 @@ export const messages = sqliteTable(
     content: text("content", { mode: "json" }).notNull().$type<Record<string, unknown>>(),
     createdAt: text("created_at")
       .notNull()
-      .default(sql`(datetime('now'))`),
+      .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   },
   (t) => [index("idx_messages_agent").on(t.projectId, t.agentId, t.id)],
 );
@@ -77,10 +77,10 @@ export const scheduledTasks = sqliteTable("scheduled_tasks", {
   lastRunAt: text("last_run_at"),
   createdAt: text("created_at")
     .notNull()
-    .default(sql`(datetime('now'))`),
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   updatedAt: text("updated_at")
     .notNull()
-    .default(sql`(datetime('now'))`),
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });
 
 export type AlertSeverity = "info" | "success" | "warning" | "error";
@@ -107,10 +107,10 @@ export const alertChannels = sqliteTable("alert_channels", {
   enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
   createdAt: text("created_at")
     .notNull()
-    .default(sql`(datetime('now'))`),
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   updatedAt: text("updated_at")
     .notNull()
-    .default(sql`(datetime('now'))`),
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });
 
 export type Project = typeof projects.$inferSelect;

--- a/src/frontend/components/ActivityLog.tsx
+++ b/src/frontend/components/ActivityLog.tsx
@@ -3,6 +3,7 @@ import { Button } from "./ui/button";
 import { Clock, Info } from "lucide-react";
 import { Spinner } from "./ui/spinner";
 import type { InterAgentMessage } from "./types";
+import { parseUtcTimestamp } from "../lib/time";
 
 interface ActivityLogProps {
   messages: InterAgentMessage[];
@@ -93,7 +94,7 @@ export default function ActivityLog({
                   </>
                 )}
               </span>
-              <time>{new Date(msg.ts).toLocaleString()}</time>
+              <time>{parseUtcTimestamp(msg.ts).toLocaleString()}</time>
             </div>
             <p className="text-sm whitespace-pre-wrap">{displayText}</p>
             {isLong && (

--- a/src/frontend/components/SchedulesPage.tsx
+++ b/src/frontend/components/SchedulesPage.tsx
@@ -48,7 +48,7 @@ import {
   useToggleSchedule,
   useRunScheduleNow,
 } from "../lib/hooks";
-import { timeAgo } from "../lib/time";
+import { parseUtcTimestamp, timeAgo } from "../lib/time";
 import { useSubscription } from "../lib/ws";
 
 interface ScheduleFormState extends CronFormFields {
@@ -84,7 +84,7 @@ function localToUtcIso(date: string, time: string): string {
 
 /** Convert a UTC ISO string to local date and time strings */
 function utcIsoToLocal(isoString: string): { date: string; time: string } {
-  const d = new Date(isoString);
+  const d = parseUtcTimestamp(isoString);
   const year = d.getFullYear();
   const month = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
@@ -257,7 +257,7 @@ export default function SchedulesPage() {
                       {task.scheduleType === "recurring" && task.cronExpression
                         ? describeCron(task.cronExpression)
                         : task.scheduledAt
-                          ? new Date(task.scheduledAt).toLocaleString()
+                          ? parseUtcTimestamp(task.scheduledAt).toLocaleString()
                           : "—"}
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">

--- a/src/frontend/lib/time.ts
+++ b/src/frontend/lib/time.ts
@@ -2,10 +2,22 @@
  * Shared time formatting utilities for the frontend.
  */
 
+/**
+ * Parse a timestamp string as UTC. SQLite's datetime('now') produces bare
+ * strings like "2026-04-01 12:00:00" without a timezone suffix. Browsers
+ * interpret those as local time, so we append 'Z' to force UTC parsing.
+ */
+export function parseUtcTimestamp(ts: string): Date {
+  if (/[Zz]$/.test(ts) || /[+-]\d{2}:?\d{2}$/.test(ts)) {
+    return new Date(ts);
+  }
+  return new Date(ts.replace(" ", "T") + "Z");
+}
+
 /** Short relative time string: "just now", "3m ago", "2h ago", "5d ago" */
 export function timeAgo(isoString: string): string {
   const now = Date.now();
-  const then = new Date(isoString).getTime();
+  const then = parseUtcTimestamp(isoString).getTime();
   const diff = Math.floor((now - then) / 1000);
   if (diff < 60) return "just now";
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
@@ -33,7 +45,7 @@ const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "
  */
 export function messageTimeLabel(isoString: string): string {
   const now = new Date(Date.now());
-  const date = new Date(isoString);
+  const date = parseUtcTimestamp(isoString);
   const diffSec = Math.floor((now.getTime() - date.getTime()) / 1000);
 
   if (diffSec < 60) return "just now";
@@ -51,7 +63,7 @@ export function messageTimeLabel(isoString: string): string {
 /** Day separator label: "Today", "Yesterday", or "Monday, March 15, 2026" */
 export function dateSeparatorLabel(isoString: string): string {
   const now = new Date(Date.now());
-  const date = new Date(isoString);
+  const date = parseUtcTimestamp(isoString);
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const msgDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const dayDiff = Math.floor((today.getTime() - msgDay.getTime()) / 86_400_000);
@@ -68,8 +80,8 @@ export function dateSeparatorLabel(isoString: string): string {
 
 /** Check whether two ISO date strings fall on the same calendar day (local time). */
 export function isSameDay(a: string, b: string): boolean {
-  const da = new Date(a);
-  const db = new Date(b);
+  const da = parseUtcTimestamp(a);
+  const db = parseUtcTimestamp(b);
   return (
     da.getFullYear() === db.getFullYear() &&
     da.getMonth() === db.getMonth() &&

--- a/src/frontend/test/time.test.ts
+++ b/src/frontend/test/time.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { timeAgo, messageTimeLabel, dateSeparatorLabel, isSameDay } from "../lib/time";
+import {
+  parseUtcTimestamp,
+  timeAgo,
+  messageTimeLabel,
+  dateSeparatorLabel,
+  isSameDay,
+} from "../lib/time";
 
 // Pin "now" to 2026-03-31 14:30:00 local time for deterministic tests
 const NOW = new Date(2026, 2, 31, 14, 30, 0).getTime();
@@ -12,6 +18,28 @@ beforeEach(() => {
 
 afterEach(() => {
   Date.now = origDateNow;
+});
+
+describe("parseUtcTimestamp", () => {
+  it("appends Z to bare SQLite timestamps", () => {
+    const d = parseUtcTimestamp("2026-04-01 12:00:00");
+    expect(d.toISOString()).toBe("2026-04-01T12:00:00.000Z");
+  });
+
+  it("handles ISO strings with Z suffix unchanged", () => {
+    const d = parseUtcTimestamp("2026-04-01T12:00:00.000Z");
+    expect(d.toISOString()).toBe("2026-04-01T12:00:00.000Z");
+  });
+
+  it("handles ISO strings with timezone offset", () => {
+    const d = parseUtcTimestamp("2026-04-01T12:00:00+05:00");
+    expect(d.toISOString()).toBe("2026-04-01T07:00:00.000Z");
+  });
+
+  it("handles T-separated strings without timezone", () => {
+    const d = parseUtcTimestamp("2026-04-01T12:00:00");
+    expect(d.toISOString()).toBe("2026-04-01T12:00:00.000Z");
+  });
 });
 
 describe("timeAgo", () => {
@@ -33,6 +61,13 @@ describe("timeAgo", () => {
   it("returns days ago", () => {
     const ts = new Date(NOW - 2 * 86_400_000).toISOString();
     expect(timeAgo(ts)).toBe("2d ago");
+  });
+
+  it("handles bare SQLite UTC timestamp", () => {
+    // 5 minutes ago in UTC, formatted as bare SQLite string
+    const fiveMinAgo = new Date(NOW - 5 * 60_000);
+    const bare = fiveMinAgo.toISOString().replace("T", " ").replace(".000Z", "");
+    expect(timeAgo(bare)).toBe("5m ago");
   });
 });
 


### PR DESCRIPTION
## Summary
- Changed SQLite timestamp defaults from `datetime('now')` to `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` to produce proper ISO 8601 with `Z` suffix
- Added migration to backfill existing timestamps with `Z` suffix
- Added `parseUtcTimestamp()` frontend helper as a safety guard for bare SQLite timestamps
- Fixed all call sites: `time.ts` utilities, `ActivityLog.tsx`, `SchedulesPage.tsx`

## Test plan
- [x] All 502 tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [ ] Manually verify timestamps display in local time in the chat panel
- [ ] Verify activity log timestamps are correct
- [ ] Verify schedule page timestamps are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)