### PR TITLE
Add OpenCode as a third agent harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ export OPENAI_API_KEY=sk-...
 
 OpenCode auto-detects API keys from environment variables and `.env` files. Shire automatically manages the OpenCode server process — no manual `opencode serve` setup required.
 
+**Model format:** OpenCode requires the `provider/model` format (e.g. `anthropic/claude-sonnet-4-6`, `openrouter/google/gemini-2.5-pro`). This differs from the other harnesses which accept just the model name.
+
 See the [OpenCode provider docs](https://opencode.ai/docs/providers/) for the full list of supported providers and models.
 
 #### Pi Agent

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Most AI agent tools follow the same pattern — you give an instruction, an agen
 | Backend | Hono, Drizzle ORM, SQLite |
 | Frontend | React 19, React Router 7, shadcn/ui (Radix), Tailwind CSS 4, TanStack Query |
 | Bundler | Bun (fullstack dev server + production builds) |
-| Agent Harnesses | Claude Code SDK, Pi Agent SDK |
+| Agent Harnesses | Claude Code SDK, OpenCode SDK, Pi Agent SDK |
 | Scheduling | node-schedule (cron-based) |
 | Testing | Bun test + Testing Library + happy-dom |
 | Validation | Zod, TypeScript strict mode |
@@ -70,6 +70,24 @@ export ANTHROPIC_API_KEY=sk-ant-...
 export CLAUDE_CODE_OAUTH_KEY=...
 ```
 
+#### OpenCode
+
+Install [OpenCode](https://opencode.ai) and set the API key for the provider you want to use:
+
+```bash
+# Install OpenCode
+npm install -g opencode
+
+# Set an API key (same environment variables as Pi Agent)
+export ANTHROPIC_API_KEY=sk-ant-...
+# or
+export OPENAI_API_KEY=sk-...
+```
+
+OpenCode auto-detects API keys from environment variables and `.env` files. Shire automatically manages the OpenCode server process — no manual `opencode serve` setup required.
+
+See the [OpenCode provider docs](https://opencode.ai/docs/providers/) for the full list of supported providers and models.
+
 #### Pi Agent
 
 The [Pi Agent](https://github.com/badlogic/pi-mono) harness uses the `@mariozechner/pi-coding-agent` SDK, which supports a wide range of AI providers. Set the API key for the provider you want to use as an environment variable:
@@ -101,6 +119,7 @@ See the [Pi Agent docs](https://github.com/badlogic/pi-mono/blob/main/packages/c
 
 - [Bun](https://bun.sh) (v1.3.11+)
 - [Claude Code](https://claude.ai/download) (only if using the `claude_code` harness)
+- [OpenCode](https://opencode.ai) (only if using the `opencode` harness)
 
 ### Quick Start
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@hono/zod-validator": "^0.7.6",
         "@mariozechner/pi-ai": "^0.63.1",
         "@mariozechner/pi-coding-agent": "^0.63.1",
+        "@opencode-ai/sdk": "^1.3.13",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -334,6 +335,8 @@
     "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.63.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.3.13", "", {}, "sha512-/M6HlNnba+xf1EId6qFb2tG0cvq0db3PCQDug1glrf8wYOU57LYNF8WvHX9zoDKPTMv0F+O4pcP/8J+WvDaxHA=="],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/8IzqSu4/OWGRs7Fs2ROzGVwJMFTBQkgAp6sAthkBYoN7OiM4rY/CpPVs2X9w9N1W61CHSkEdNKi8HrLZKfK3g=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@hono/zod-validator": "^0.7.6",
     "@mariozechner/pi-ai": "^0.63.1",
     "@mariozechner/pi-coding-agent": "^0.63.1",
+    "@opencode-ai/sdk": "^1.3.13",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/frontend/components/AgentForm.tsx
+++ b/src/frontend/components/AgentForm.tsx
@@ -160,7 +160,7 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
             <Select
               value={harness}
               onValueChange={(v) => {
-                if (v === "claude_code" || v === "pi") setHarness(v);
+                if (v === "claude_code" || v === "pi" || v === "opencode") setHarness(v);
               }}
             >
               <SelectTrigger>
@@ -168,6 +168,7 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="claude_code">Claude Code</SelectItem>
+                <SelectItem value="opencode">OpenCode</SelectItem>
                 <SelectItem value="pi">Pi</SelectItem>
               </SelectContent>
             </Select>

--- a/src/frontend/components/AgentForm.tsx
+++ b/src/frontend/components/AgentForm.tsx
@@ -179,8 +179,18 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
               id="model"
               value={model}
               onChange={(e) => setModel(e.target.value)}
-              placeholder="e.g. claude-sonnet-4-6"
+              placeholder={
+                harness === "opencode"
+                  ? "e.g. anthropic/claude-sonnet-4-6"
+                  : "e.g. claude-sonnet-4-6"
+              }
             />
+            {harness === "opencode" && (
+              <p className="text-xs text-muted-foreground">
+                OpenCode requires provider/model format (e.g. anthropic/claude-sonnet-4-6,
+                openrouter/google/gemini-2.5-pro)
+              </p>
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="system_prompt">System Prompt</Label>

--- a/src/frontend/components/types.ts
+++ b/src/frontend/components/types.ts
@@ -4,7 +4,7 @@ export interface Project {
   status: "starting" | "running" | "error";
 }
 
-export type HarnessType = "pi" | "claude_code";
+export type HarnessType = "pi" | "claude_code" | "opencode";
 
 export type AgentStatus = "created" | "starting" | "bootstrapping" | "active" | "idle" | "crashed";
 
@@ -138,5 +138,7 @@ export const harnessLabel = (harness: HarnessType): string => {
       return "Claude Code";
     case "pi":
       return "Pi";
+    case "opencode":
+      return "OpenCode";
   }
 };

--- a/src/frontend/hooks/agents.ts
+++ b/src/frontend/hooks/agents.ts
@@ -30,7 +30,7 @@ export function useAgentDetail(projectId: string | undefined, agentId: string | 
 interface AgentMutationData {
   name: string;
   description?: string;
-  harness?: "claude_code" | "pi";
+  harness?: "claude_code" | "pi" | "opencode";
   model?: string;
   systemPrompt?: string;
   skills?: Skill[];

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -31,7 +31,7 @@ export const agentRoutes = new Hono<AppEnv>()
       z.object({
         name: z.string(),
         description: z.string().optional(),
-        harness: z.enum(["claude_code", "pi"]).optional(),
+        harness: z.enum(["claude_code", "pi", "opencode"]).optional(),
         model: z.string().optional(),
         systemPrompt: z.string().optional(),
         skills: z.array(skillSchema).optional(),
@@ -64,7 +64,7 @@ export const agentRoutes = new Hono<AppEnv>()
       z.object({
         name: z.string().optional(),
         description: z.string().optional(),
-        harness: z.enum(["claude_code", "pi"]).optional(),
+        harness: z.enum(["claude_code", "pi", "opencode"]).optional(),
         model: z.string().optional(),
         systemPrompt: z.string().optional(),
         skills: z.array(skillSchema).optional(),

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -328,7 +328,9 @@ export class AgentManager {
     if (!agent) throw new Error("Agent not found in DB");
 
     const harnessType: HarnessType =
-      agent.harness === "pi" || agent.harness === "claude_code" ? agent.harness : "claude_code";
+      agent.harness === "pi" || agent.harness === "claude_code" || agent.harness === "opencode"
+        ? agent.harness
+        : "claude_code";
     const model = agent.model ?? "claude-sonnet-4-6";
     const systemPrompt = agent.systemPrompt ?? "";
     const agentDir = workspace.agentDir(this.projectId, this.agentId);

--- a/src/runtime/harness/index.ts
+++ b/src/runtime/harness/index.ts
@@ -2,8 +2,9 @@
 import type { Harness } from "./types";
 import { PiHarness } from "./pi-harness";
 import { ClaudeCodeHarness } from "./claude-code-harness";
+import { OpenCodeHarness } from "./opencode-harness";
 
-export type HarnessType = "pi" | "claude_code";
+export type HarnessType = "pi" | "claude_code" | "opencode";
 
 export { type Harness, type HarnessConfig, type AgentEvent, type EventCallback } from "./types";
 
@@ -13,6 +14,8 @@ export function createHarness(type: HarnessType): Harness {
       return new PiHarness();
     case "claude_code":
       return new ClaudeCodeHarness();
+    case "opencode":
+      return new OpenCodeHarness();
     default:
       throw new Error(`Unknown harness type: ${type}`);
   }

--- a/src/runtime/harness/opencode-harness.test.ts
+++ b/src/runtime/harness/opencode-harness.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock } from "bun:test";
-import { OpenCodeHarness, type ClientLike } from "./opencode-harness";
+import { OpenCodeHarness } from "./opencode-harness";
+import type { OpencodeClient } from "@opencode-ai/sdk";
 import type { AgentEvent, HarnessConfig } from "./types";
 
 const baseConfig: HarnessConfig = {
@@ -54,11 +55,15 @@ type SSEEvent =
       };
     };
 
+function wrapEvent(event: SSEEvent) {
+  return { directory: "/workspace", payload: event };
+}
+
 function createMockClient(sessionId = "oc-sess-1") {
   const events: SSEEvent[] = [];
   let eventResolve: (() => void) | null = null;
 
-  const client: ClientLike = {
+  const client = {
     session: {
       create: mock(async () => ({ data: { id: sessionId } })),
       get: mock(async () => ({ data: { id: sessionId } })),
@@ -70,7 +75,7 @@ function createMockClient(sessionId = "oc-sess-1") {
         stream: (async function* () {
           while (true) {
             if (events.length > 0) {
-              yield events.shift()!;
+              yield wrapEvent(events.shift()!);
             } else {
               await new Promise<void>((resolve) => {
                 eventResolve = resolve;
@@ -80,7 +85,7 @@ function createMockClient(sessionId = "oc-sess-1") {
         })(),
       })),
     },
-  };
+  } as unknown as OpencodeClient;
 
   function pushEvent(event: SSEEvent) {
     events.push(event);
@@ -128,7 +133,7 @@ function createSimpleClient(sessionId = "oc-sess-1") {
 
   let streamClosed = false;
 
-  const client: ClientLike = {
+  const client = {
     session: {
       create: mock(async () => ({ data: { id: sessionId } })),
       get: mock(async () => ({ data: { id: sessionId } })),
@@ -140,7 +145,7 @@ function createSimpleClient(sessionId = "oc-sess-1") {
         stream: (async function* () {
           for (const event of sseEvents) {
             if (streamClosed) return;
-            yield event;
+            yield wrapEvent(event);
           }
           // Keep alive until closed
           while (!streamClosed) {
@@ -149,7 +154,7 @@ function createSimpleClient(sessionId = "oc-sess-1") {
         })(),
       })),
     },
-  };
+  } as unknown as OpencodeClient;
 
   return {
     client,
@@ -327,7 +332,7 @@ describe("OpenCodeHarness", () => {
       { type: "session.idle", properties: { sessionID: sessionId } },
     ];
 
-    const client: ClientLike = {
+    const client = {
       session: {
         create: mock(async () => ({ data: { id: sessionId } })),
         get: mock(async () => ({ data: { id: sessionId } })),
@@ -337,13 +342,13 @@ describe("OpenCodeHarness", () => {
       global: {
         event: mock(async () => ({
           stream: (async function* () {
-            for (const event of sseEvents) yield event;
+            for (const event of sseEvents) yield wrapEvent(event);
             // Keep alive
             await new Promise<void>(() => {});
           })(),
         })),
       },
-    };
+    } as unknown as OpencodeClient;
 
     const harness = new OpenCodeHarness();
     const events: AgentEvent[] = [];
@@ -390,7 +395,7 @@ describe("OpenCodeHarness", () => {
       { type: "session.idle", properties: { sessionID: sessionId } },
     ];
 
-    const client: ClientLike = {
+    const client = {
       session: {
         create: mock(async () => ({ data: { id: sessionId } })),
         get: mock(async () => ({ data: { id: sessionId } })),
@@ -400,12 +405,12 @@ describe("OpenCodeHarness", () => {
       global: {
         event: mock(async () => ({
           stream: (async function* () {
-            for (const event of sseEvents) yield event;
+            for (const event of sseEvents) yield wrapEvent(event);
             await new Promise<void>(() => {});
           })(),
         })),
       },
-    };
+    } as unknown as OpencodeClient;
 
     const harness = new OpenCodeHarness();
     const events: AgentEvent[] = [];
@@ -504,7 +509,7 @@ describe("OpenCodeHarness", () => {
     const events: SSEEvent[] = [];
     let eventResolve: (() => void) | null = null;
 
-    const client: ClientLike = {
+    const client = {
       session: {
         create: mock(async () => ({ data: { id: `oc-sess-${++callCount}` } })),
         get: mock(async () => ({ data: { id: `oc-sess-${callCount}` } })),
@@ -516,7 +521,7 @@ describe("OpenCodeHarness", () => {
           stream: (async function* () {
             while (true) {
               if (events.length > 0) {
-                yield events.shift()!;
+                yield wrapEvent(events.shift()!);
               } else {
                 await new Promise<void>((resolve) => {
                   eventResolve = resolve;
@@ -526,7 +531,7 @@ describe("OpenCodeHarness", () => {
           })(),
         })),
       },
-    };
+    } as unknown as OpencodeClient;
 
     function pushEvent(event: SSEEvent) {
       events.push(event);

--- a/src/runtime/harness/opencode-harness.test.ts
+++ b/src/runtime/harness/opencode-harness.test.ts
@@ -1,0 +1,641 @@
+import { describe, test, expect, mock } from "bun:test";
+import { OpenCodeHarness, type ClientLike } from "./opencode-harness";
+import type { AgentEvent, HarnessConfig } from "./types";
+
+const baseConfig: HarnessConfig = {
+  model: "anthropic/claude-sonnet-4-6",
+  systemPrompt: "You are a helpful assistant.",
+  cwd: "/workspace",
+};
+
+type SSEEvent =
+  | {
+      type: "message.part.updated";
+      properties: {
+        part: { type: "text"; id: string; sessionID: string; messageID: string; text: string };
+        delta?: string;
+      };
+    }
+  | {
+      type: "message.part.updated";
+      properties: {
+        part: {
+          type: "tool";
+          id: string;
+          sessionID: string;
+          messageID: string;
+          callID: string;
+          tool: string;
+          state:
+            | { status: "running"; input: Record<string, unknown>; time: { start: number } }
+            | {
+                status: "completed";
+                input: Record<string, unknown>;
+                output: string;
+                title: string;
+                metadata: Record<string, unknown>;
+                time: { start: number; end: number };
+              }
+            | {
+                status: "error";
+                input: Record<string, unknown>;
+                error: string;
+                time: { start: number; end: number };
+              };
+        };
+      };
+    }
+  | { type: "session.idle"; properties: { sessionID: string } }
+  | {
+      type: "session.error";
+      properties: {
+        sessionID?: string;
+        error?: { name: string; data: { message: string } };
+      };
+    };
+
+function createMockClient(sessionId = "oc-sess-1") {
+  const events: SSEEvent[] = [];
+  let eventResolve: (() => void) | null = null;
+
+  const client: ClientLike = {
+    session: {
+      create: mock(async () => ({ data: { id: sessionId } })),
+      get: mock(async () => ({ data: { id: sessionId } })),
+      abort: mock(async () => ({ data: true })),
+      promptAsync: mock(async () => ({ data: undefined })),
+    },
+    global: {
+      event: mock(async () => ({
+        stream: (async function* () {
+          while (true) {
+            if (events.length > 0) {
+              yield events.shift()!;
+            } else {
+              await new Promise<void>((resolve) => {
+                eventResolve = resolve;
+              });
+            }
+          }
+        })(),
+      })),
+    },
+  };
+
+  function pushEvent(event: SSEEvent) {
+    events.push(event);
+    if (eventResolve) {
+      const resolve = eventResolve;
+      eventResolve = null;
+      resolve();
+    }
+  }
+
+  return { client, pushEvent };
+}
+
+function createSimpleClient(sessionId = "oc-sess-1") {
+  // A simpler mock that fires events immediately via promptAsync
+  const sseEvents: SSEEvent[] = [
+    {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          type: "text",
+          id: "p1",
+          sessionID: sessionId,
+          messageID: "m1",
+          text: "Hello",
+        },
+        delta: "Hello",
+      },
+    },
+    {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          type: "text",
+          id: "p1",
+          sessionID: sessionId,
+          messageID: "m1",
+          text: "Hello world",
+        },
+        delta: " world",
+      },
+    },
+    { type: "session.idle", properties: { sessionID: sessionId } },
+  ];
+
+  let streamClosed = false;
+
+  const client: ClientLike = {
+    session: {
+      create: mock(async () => ({ data: { id: sessionId } })),
+      get: mock(async () => ({ data: { id: sessionId } })),
+      abort: mock(async () => ({ data: true })),
+      promptAsync: mock(async () => ({ data: undefined })),
+    },
+    global: {
+      event: mock(async () => ({
+        stream: (async function* () {
+          for (const event of sseEvents) {
+            if (streamClosed) return;
+            yield event;
+          }
+          // Keep alive until closed
+          while (!streamClosed) {
+            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+          }
+        })(),
+      })),
+    },
+  };
+
+  return {
+    client,
+    close() {
+      streamClosed = true;
+    },
+  };
+}
+
+describe("OpenCodeHarness", () => {
+  test("isProcessing() returns false initially", () => {
+    const harness = new OpenCodeHarness();
+    expect(harness.isProcessing()).toBe(false);
+  });
+
+  test("getSessionId() returns null before any message", async () => {
+    const harness = new OpenCodeHarness();
+    const { client } = createSimpleClient();
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    expect(harness.getSessionId()).toBeNull();
+    await harness.stop();
+  });
+
+  test("getSessionId() returns session id after sendMessage", async () => {
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    const { client } = createSimpleClient("oc-sess-42");
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi");
+    expect(harness.getSessionId()).toBe("oc-sess-42");
+    await harness.stop();
+  });
+
+  test("start() does not create session eagerly", async () => {
+    const { client } = createSimpleClient();
+    const factory = mock(async () => client);
+    const harness = new OpenCodeHarness();
+    harness._setClientFactory(factory);
+    await harness.start(baseConfig);
+    expect(client.session.create).not.toHaveBeenCalled();
+    await harness.stop();
+  });
+
+  test("session is created lazily on first sendMessage()", async () => {
+    const { client } = createSimpleClient();
+    const harness = new OpenCodeHarness();
+    harness.onEvent(() => {});
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi");
+    expect(client.session.create).toHaveBeenCalledTimes(1);
+    await harness.stop();
+  });
+
+  test("session is reused across multiple sendMessage() calls", async () => {
+    const { client, pushEvent } = createMockClient();
+    const harness = new OpenCodeHarness();
+    harness.onEvent(() => {});
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+
+    // First message — push idle after promptAsync fires
+    const p1 = harness.sendMessage("Hi");
+    await new Promise<void>((r) => setTimeout(r, 20));
+    pushEvent({ type: "session.idle", properties: { sessionID: "oc-sess-1" } });
+    await p1;
+
+    // Second message
+    const p2 = harness.sendMessage("Again");
+    await new Promise<void>((r) => setTimeout(r, 20));
+    pushEvent({ type: "session.idle", properties: { sessionID: "oc-sess-1" } });
+    await p2;
+
+    expect(client.session.create).toHaveBeenCalledTimes(1);
+    await harness.stop();
+  });
+
+  test("sendMessage() throws if start() was not called", async () => {
+    const harness = new OpenCodeHarness();
+    const { client } = createSimpleClient();
+    harness._setClientFactory(async () => client);
+    await expect(harness.sendMessage("Hi")).rejects.toThrow("Harness not started");
+  });
+
+  test("sendMessage() maps text_delta events", async () => {
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    const { client } = createSimpleClient();
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi");
+
+    const deltas = events.filter((e) => e.type === "text_delta");
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(deltas[0].payload.delta).toBe("Hello");
+    await harness.stop();
+  });
+
+  test("sendMessage() emits text and turn_complete events", async () => {
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    const { client } = createSimpleClient();
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi");
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain("text");
+    expect(types).toContain("turn_complete");
+    await harness.stop();
+  });
+
+  test("turn_complete includes session_id", async () => {
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    const { client } = createSimpleClient("oc-sess-99");
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi");
+
+    const tc = events.find((e) => e.type === "turn_complete");
+    expect(tc).toBeDefined();
+    expect(tc!.payload.session_id).toBe("oc-sess-99");
+    await harness.stop();
+  });
+
+  test("sendMessage() maps tool events", async () => {
+    const sessionId = "oc-sess-1";
+    const sseEvents: SSEEvent[] = [
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            type: "tool",
+            id: "p2",
+            sessionID: sessionId,
+            messageID: "m1",
+            callID: "tc1",
+            tool: "bash",
+            state: {
+              status: "running",
+              input: { command: "ls" },
+              time: { start: Date.now() },
+            },
+          },
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            type: "tool",
+            id: "p2",
+            sessionID: sessionId,
+            messageID: "m1",
+            callID: "tc1",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { command: "ls" },
+              output: "file1.txt\nfile2.txt",
+              title: "bash",
+              metadata: {},
+              time: { start: Date.now(), end: Date.now() },
+            },
+          },
+        },
+      },
+      { type: "session.idle", properties: { sessionID: sessionId } },
+    ];
+
+    const client: ClientLike = {
+      session: {
+        create: mock(async () => ({ data: { id: sessionId } })),
+        get: mock(async () => ({ data: { id: sessionId } })),
+        abort: mock(async () => ({ data: true })),
+        promptAsync: mock(async () => ({ data: undefined })),
+      },
+      global: {
+        event: mock(async () => ({
+          stream: (async function* () {
+            for (const event of sseEvents) yield event;
+            // Keep alive
+            await new Promise<void>(() => {});
+          })(),
+        })),
+      },
+    };
+
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("run ls");
+
+    const toolStart = events.filter((e) => e.type === "tool_use");
+    expect(toolStart).toHaveLength(1);
+    expect(toolStart[0].payload.tool).toBe("bash");
+    expect(toolStart[0].payload.tool_use_id).toBe("tc1");
+
+    const toolResult = events.filter((e) => e.type === "tool_result");
+    expect(toolResult).toHaveLength(1);
+    expect(toolResult[0].payload.tool_use_id).toBe("tc1");
+    expect(toolResult[0].payload.output).toBe("file1.txt\nfile2.txt");
+    expect(toolResult[0].payload.is_error).toBe(false);
+    await harness.stop();
+  });
+
+  test("sendMessage() maps tool error events", async () => {
+    const sessionId = "oc-sess-1";
+    const sseEvents: SSEEvent[] = [
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            type: "tool",
+            id: "p2",
+            sessionID: sessionId,
+            messageID: "m1",
+            callID: "tc2",
+            tool: "bash",
+            state: {
+              status: "error",
+              input: { command: "bad-cmd" },
+              error: "command not found",
+              time: { start: Date.now(), end: Date.now() },
+            },
+          },
+        },
+      },
+      { type: "session.idle", properties: { sessionID: sessionId } },
+    ];
+
+    const client: ClientLike = {
+      session: {
+        create: mock(async () => ({ data: { id: sessionId } })),
+        get: mock(async () => ({ data: { id: sessionId } })),
+        abort: mock(async () => ({ data: true })),
+        promptAsync: mock(async () => ({ data: undefined })),
+      },
+      global: {
+        event: mock(async () => ({
+          stream: (async function* () {
+            for (const event of sseEvents) yield event;
+            await new Promise<void>(() => {});
+          })(),
+        })),
+      },
+    };
+
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("run bad-cmd");
+
+    const toolResult = events.filter((e) => e.type === "tool_result");
+    expect(toolResult).toHaveLength(1);
+    expect(toolResult[0].payload.is_error).toBe(true);
+    expect(toolResult[0].payload.output).toBe("command not found");
+    await harness.stop();
+  });
+
+  test("sendMessage() prepends agent prefix", async () => {
+    const { client } = createSimpleClient();
+    const harness = new OpenCodeHarness();
+    harness.onEvent(() => {});
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Some data", "researcher-bot");
+    expect(client.session.promptAsync).toHaveBeenCalled();
+    const call = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls[0];
+    const body = call[0]?.body;
+    expect(body.parts[0].text).toBe('[Message from agent "researcher-bot"]\nSome data');
+    await harness.stop();
+  });
+
+  test("sendMessage() emits error and turn_complete on session error event", async () => {
+    const { client, pushEvent } = createMockClient();
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+
+    const p = harness.sendMessage("test");
+    await new Promise<void>((r) => setTimeout(r, 20));
+    pushEvent({
+      type: "session.error",
+      properties: {
+        sessionID: "oc-sess-1",
+        error: { name: "UnknownError", data: { message: "Rate limit exceeded" } },
+      },
+    });
+    await p;
+
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    expect(String(errorEvent!.payload.message)).toContain("Rate limit exceeded");
+    expect(events.map((e) => e.type)).toContain("turn_complete");
+    await harness.stop();
+  });
+
+  test("stop() suppresses further event emission", async () => {
+    const { client, pushEvent } = createMockClient();
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.stop();
+    pushEvent({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          type: "text",
+          id: "p1",
+          sessionID: "s1",
+          messageID: "m1",
+          text: "should not appear",
+        },
+        delta: "should not appear",
+      },
+    });
+    // Give a tick for any event processing
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    expect(events).toHaveLength(0);
+  });
+
+  test("interrupt() calls abort on the session", async () => {
+    const { client } = createSimpleClient();
+    const harness = new OpenCodeHarness();
+    harness.onEvent(() => {});
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("init");
+    await harness.interrupt();
+    expect(client.session.abort).toHaveBeenCalledTimes(1);
+    await harness.stop();
+  });
+
+  test("clearSession() causes a new session on next sendMessage()", async () => {
+    let callCount = 0;
+    const events: SSEEvent[] = [];
+    let eventResolve: (() => void) | null = null;
+
+    const client: ClientLike = {
+      session: {
+        create: mock(async () => ({ data: { id: `oc-sess-${++callCount}` } })),
+        get: mock(async () => ({ data: { id: `oc-sess-${callCount}` } })),
+        abort: mock(async () => ({ data: true })),
+        promptAsync: mock(async () => ({ data: undefined })),
+      },
+      global: {
+        event: mock(async () => ({
+          stream: (async function* () {
+            while (true) {
+              if (events.length > 0) {
+                yield events.shift()!;
+              } else {
+                await new Promise<void>((resolve) => {
+                  eventResolve = resolve;
+                });
+              }
+            }
+          })(),
+        })),
+      },
+    };
+
+    function pushEvent(event: SSEEvent) {
+      events.push(event);
+      if (eventResolve) {
+        const resolve = eventResolve;
+        eventResolve = null;
+        resolve();
+      }
+    }
+
+    const harness = new OpenCodeHarness();
+    harness.onEvent(() => {});
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+
+    const p1 = harness.sendMessage("First");
+    await new Promise<void>((r) => setTimeout(r, 20));
+    pushEvent({ type: "session.idle", properties: { sessionID: "oc-sess-1" } });
+    await p1;
+    expect(client.session.create).toHaveBeenCalledTimes(1);
+
+    await harness.clearSession();
+    expect(harness.getSessionId()).toBeNull();
+
+    const p2 = harness.sendMessage("Fresh start");
+    await new Promise<void>((r) => setTimeout(r, 20));
+    pushEvent({ type: "session.idle", properties: { sessionID: "oc-sess-2" } });
+    await p2;
+    expect(client.session.create).toHaveBeenCalledTimes(2);
+    await harness.stop();
+  });
+
+  test("sendMessage() after stop() is a no-op", async () => {
+    const { client } = createSimpleClient();
+    const harness = new OpenCodeHarness();
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.stop();
+    // Should not throw, just return silently
+    await harness.sendMessage("too late");
+    expect(client.session.promptAsync).not.toHaveBeenCalled();
+  });
+
+  test("session resume uses get() with existing session id", async () => {
+    const { client } = createSimpleClient("oc-sess-resume");
+    const harness = new OpenCodeHarness();
+    harness.onEvent(() => {});
+    harness._setClientFactory(async () => client);
+    await harness.start({ ...baseConfig, resume: "oc-sess-resume" });
+    await harness.sendMessage("Continue");
+
+    // Should not create a new session, should use existing
+    expect(client.session.create).not.toHaveBeenCalled();
+    expect(harness.getSessionId()).toBe("oc-sess-resume");
+    await harness.stop();
+  });
+
+  test("text event contains accumulated text from last delta", async () => {
+    const { client } = createSimpleClient();
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hi");
+
+    const textEvent = events.find((e) => e.type === "text");
+    expect(textEvent).toBeDefined();
+    // The last text part update has text "Hello world"
+    expect(textEvent!.payload.text).toBe("Hello world");
+    await harness.stop();
+  });
+
+  test("sendMessage() resolves when promptAsync throws", async () => {
+    const { client } = createMockClient();
+    (client.session.promptAsync as ReturnType<typeof mock>).mockImplementation(async () => {
+      throw new Error("Network failure");
+    });
+    const harness = new OpenCodeHarness();
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+
+    // Should resolve without hanging
+    await harness.sendMessage("test");
+
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    expect(String(errorEvent!.payload.message)).toContain("Network failure");
+    expect(events.map((e) => e.type)).toContain("turn_complete");
+    await harness.stop();
+  });
+
+  test("stop() resolves in-flight sendMessage", async () => {
+    const { client } = createMockClient();
+    const harness = new OpenCodeHarness();
+    harness.onEvent(() => {});
+    harness._setClientFactory(async () => client);
+    await harness.start(baseConfig);
+
+    // Start a sendMessage that will wait for turn_complete
+    const sendPromise = harness.sendMessage("long task");
+    // Let it get to the waiting state
+    await new Promise<void>((r) => setTimeout(r, 20));
+
+    // Stop should resolve the pending promise
+    await harness.stop();
+    // sendPromise should resolve without hanging
+    await sendPromise;
+  });
+});

--- a/src/runtime/harness/opencode-harness.ts
+++ b/src/runtime/harness/opencode-harness.ts
@@ -1,4 +1,9 @@
-import type { OpencodeClient, GlobalEvent, Event as OpenCodeEvent } from "@opencode-ai/sdk";
+import type {
+  OpencodeClient,
+  GlobalEvent,
+  Event as OpenCodeEvent,
+  ToolPart,
+} from "@opencode-ai/sdk";
 import type { AgentEvent, Harness, HarnessConfig, EventCallback } from "./types";
 
 type ClientFactory = (config: HarnessConfig) => Promise<OpencodeClient>;
@@ -158,17 +163,11 @@ export class OpenCodeHarness implements Harness {
   private handleSSEEvent(event: OpenCodeEvent): void {
     if (this.stopped) return;
 
-    const props = event.properties as Record<string, unknown>;
-    const sessionId = props.sessionID as string | undefined;
-    // Only process events for our session
-    if (sessionId && this.sessionId && sessionId !== this.sessionId) return;
-
     switch (event.type) {
       case "message.part.updated": {
-        const { part, delta } = props as {
-          part: { type: string; [key: string]: unknown };
-          delta?: string;
-        };
+        const { part, delta } = event.properties;
+        const sessionId = part.sessionID;
+        if (sessionId && this.sessionId && sessionId !== this.sessionId) return;
 
         if (part.type === "text") {
           if (delta) {
@@ -176,12 +175,15 @@ export class OpenCodeHarness implements Harness {
             this.emitEvent({ type: "text_delta", payload: { delta } });
           }
         } else if (part.type === "tool") {
-          this.handleToolPartUpdate(part as Record<string, unknown>);
+          this.handleToolPartUpdate(part);
         }
         break;
       }
 
       case "session.idle": {
+        const { sessionID } = event.properties;
+        if (sessionID && this.sessionId && sessionID !== this.sessionId) return;
+
         if (this.accumulatedText) {
           this.emitEvent({ type: "text", payload: { text: this.accumulatedText } });
         }
@@ -194,8 +196,13 @@ export class OpenCodeHarness implements Harness {
       }
 
       case "session.error": {
-        const error = props.error as { name: string; data: { message: string } } | undefined;
-        const message = error?.data?.message ?? "Unknown OpenCode error";
+        const { sessionID, error } = event.properties;
+        if (sessionID && this.sessionId && sessionID !== this.sessionId) return;
+
+        const message =
+          error && error.name !== "MessageOutputLengthError"
+            ? error.data.message
+            : "Unknown OpenCode error";
         this.emitEvent({ type: "error", payload: { message } });
         this.emitEvent({ type: "turn_complete", payload: {} });
         this.resolveTurn();
@@ -204,63 +211,44 @@ export class OpenCodeHarness implements Harness {
     }
   }
 
-  private handleToolPartUpdate(part: Record<string, unknown>): void {
-    const callID = part.callID as string;
-    const tool = part.tool as string;
-    const state = part.state as { status: string; [key: string]: unknown };
+  private handleToolPartUpdate(part: ToolPart): void {
+    const { callID, tool, state } = part;
     const prevStatus = this.seenToolStates.get(callID);
 
-    if (state.status === "running" && prevStatus !== "running") {
-      this.seenToolStates.set(callID, "running");
+    const emitToolUse = () => {
       this.emitEvent({
         type: "tool_use",
         payload: {
           tool,
           tool_use_id: callID,
-          input: (state.input as Record<string, unknown>) ?? {},
+          input: state.input,
           status: "started",
         },
       });
+    };
+
+    if (state.status === "running" && prevStatus !== "running") {
+      this.seenToolStates.set(callID, "running");
+      emitToolUse();
     } else if (state.status === "completed" && prevStatus !== "completed") {
       this.seenToolStates.set(callID, "completed");
-      // Emit tool_use if we haven't seen running
-      if (!prevStatus) {
-        this.emitEvent({
-          type: "tool_use",
-          payload: {
-            tool,
-            tool_use_id: callID,
-            input: (state.input as Record<string, unknown>) ?? {},
-            status: "started",
-          },
-        });
-      }
+      if (!prevStatus) emitToolUse();
       this.emitEvent({
         type: "tool_result",
         payload: {
           tool_use_id: callID,
-          output: (state.output as string) ?? "",
+          output: state.output,
           is_error: false,
         },
       });
     } else if (state.status === "error" && prevStatus !== "error") {
       this.seenToolStates.set(callID, "error");
-      if (!prevStatus) {
-        this.emitEvent({
-          type: "tool_use",
-          payload: {
-            tool,
-            tool_use_id: callID,
-            input: (state.input as Record<string, unknown>) ?? {},
-            status: "started",
-          },
-        });
-      }
+      if (!prevStatus) emitToolUse();
       this.emitEvent({
         type: "tool_result",
         payload: {
           tool_use_id: callID,
-          output: (state.error as string) ?? "Tool error",
+          output: state.error,
           is_error: true,
         },
       });

--- a/src/runtime/harness/opencode-harness.ts
+++ b/src/runtime/harness/opencode-harness.ts
@@ -46,13 +46,9 @@ export class OpenCodeHarness implements Harness {
 
     const { createOpencode } = await import("@opencode-ai/sdk");
 
-    const model = this.config.model.includes("/")
-      ? this.config.model
-      : `anthropic/${this.config.model}`;
-
     const { client, server } = await createOpencode({
       config: {
-        model,
+        model: this.config.model,
       },
     });
 
@@ -135,7 +131,6 @@ export class OpenCodeHarness implements Harness {
       this.turnResolve = resolve;
     });
 
-    const [providerID, modelID] = this.parseModel(this.config.model);
     const systemParts = [this.config.internalSystemPrompt, this.config.systemPrompt].filter(
       Boolean,
     );
@@ -148,7 +143,6 @@ export class OpenCodeHarness implements Harness {
         body: {
           parts: [{ type: "text", text: content }],
           system,
-          model: { providerID, modelID },
         },
         query: { directory: this.config.cwd },
       });
@@ -322,15 +316,6 @@ export class OpenCodeHarness implements Harness {
 
   getSessionId(): string | null {
     return this.sessionId;
-  }
-
-  private parseModel(model: string): [string, string] {
-    if (model.includes("/")) {
-      const [providerID, ...rest] = model.split("/");
-      return [providerID, rest.join("/")];
-    }
-    // Default to anthropic if no provider prefix
-    return ["anthropic", model];
   }
 
   private emitEvent(event: AgentEvent): void {

--- a/src/runtime/harness/opencode-harness.ts
+++ b/src/runtime/harness/opencode-harness.ts
@@ -85,12 +85,16 @@ export class OpenCodeHarness implements Harness {
     const client = await this.ensureClient();
     if (this.config?.resume) {
       const result = await client.session.get({ path: { id: this.config.resume } });
-      return result.data!.id;
+      const id = result.data?.id;
+      if (!id) throw new Error(`OpenCode session not found: ${this.config.resume}`);
+      return id;
     }
     const result = await client.session.create({
       query: { directory: this.config?.cwd },
     });
-    return result.data!.id;
+    const id = result.data?.id;
+    if (!id) throw new Error("Failed to create OpenCode session");
+    return id;
   }
 
   private async ensureEventStream(): Promise<void> {
@@ -199,10 +203,20 @@ export class OpenCodeHarness implements Harness {
         const { sessionID, error } = event.properties;
         if (sessionID && this.sessionId && sessionID !== this.sessionId) return;
 
-        const message =
-          error && error.name !== "MessageOutputLengthError"
-            ? error.data.message
-            : "Unknown OpenCode error";
+        let message = "Unknown OpenCode error";
+        if (error) {
+          switch (error.name) {
+            case "ProviderAuthError":
+            case "UnknownError":
+            case "MessageAbortedError":
+            case "APIError":
+              message = error.data.message;
+              break;
+            case "MessageOutputLengthError":
+              message = "Message output length exceeded";
+              break;
+          }
+        }
         this.emitEvent({ type: "error", payload: { message } });
         this.emitEvent({ type: "turn_complete", payload: {} });
         this.resolveTurn();

--- a/src/runtime/harness/opencode-harness.ts
+++ b/src/runtime/harness/opencode-harness.ts
@@ -1,0 +1,364 @@
+import type { AgentEvent, Harness, HarnessConfig, EventCallback } from "./types";
+
+export type ClientLike = {
+  session: {
+    create: (opts: { query?: { directory?: string } }) => Promise<{ data: { id: string } }>;
+    get: (opts: { path: { id: string } }) => Promise<{ data: { id: string } }>;
+    abort: (opts: { path: { id: string } }) => Promise<{ data: boolean }>;
+    promptAsync: (opts: {
+      path: { id: string };
+      body: {
+        parts: Array<{ type: "text"; text: string }>;
+        system?: string;
+        model?: { providerID: string; modelID: string };
+      };
+      query?: { directory?: string };
+    }) => Promise<{ data: undefined }>;
+  };
+  global: {
+    event: () => Promise<{
+      stream: AsyncGenerator<SSEEvent, unknown, unknown>;
+    }>;
+  };
+};
+
+type SSEEvent = {
+  type: string;
+  properties: Record<string, unknown>;
+};
+
+type ClientFactory = (config: HarnessConfig) => Promise<ClientLike>;
+
+export class OpenCodeHarness implements Harness {
+  private callback: EventCallback = () => {};
+  private processing = false;
+  private stopped = false;
+  private sessionId: string | null = null;
+  private sessionPending: Promise<string> | null = null;
+  private config: HarnessConfig | null = null;
+  private clientFactory: ClientFactory | null = null;
+  private client: ClientLike | null = null;
+  private serverClose: (() => void) | null = null;
+  private sessionVersion = 0;
+  private eventStreamActive = false;
+  private eventStream: AsyncGenerator<SSEEvent, unknown, unknown> | null = null;
+  private accumulatedText = "";
+  private seenToolStates = new Map<string, string>();
+  private turnResolve: (() => void) | null = null;
+
+  _setClientFactory(factory: ClientFactory): void {
+    this.clientFactory = factory;
+  }
+
+  async start(config: HarnessConfig): Promise<void> {
+    this.config = config;
+    this.stopped = false;
+    this.sessionId = config.resume ?? null;
+  }
+
+  private async ensureClient(): Promise<ClientLike> {
+    if (this.client) return this.client;
+    if (!this.config) throw new Error("Harness not started");
+
+    if (this.clientFactory) {
+      this.client = await this.clientFactory(this.config);
+      return this.client;
+    }
+
+    const { createOpencode } = await import("@opencode-ai/sdk");
+
+    const model = this.config.model.includes("/")
+      ? this.config.model
+      : `anthropic/${this.config.model}`;
+
+    const { client, server } = await createOpencode({
+      config: {
+        model,
+      },
+    });
+
+    this.serverClose = server.close;
+    this.client = client as unknown as ClientLike;
+    return this.client;
+  }
+
+  private async ensureSession(): Promise<string> {
+    if (this.stopped) throw new Error("Harness is stopped");
+    if (this.sessionId) return this.sessionId;
+    if (!this.config) throw new Error("Harness not started");
+
+    if (!this.sessionPending) {
+      const version = this.sessionVersion;
+      this.sessionPending = this.createSession().then((id) => {
+        if (this.sessionVersion !== version) {
+          this.sessionPending = null;
+          return this.ensureSession();
+        }
+        if (!this.sessionId) this.sessionId = id;
+        this.sessionPending = null;
+        return id;
+      });
+    }
+    return this.sessionPending;
+  }
+
+  private async createSession(): Promise<string> {
+    const client = await this.ensureClient();
+    if (this.config?.resume) {
+      const result = await client.session.get({ path: { id: this.config.resume } });
+      return result.data.id;
+    }
+    const result = await client.session.create({
+      query: { directory: this.config?.cwd },
+    });
+    return result.data.id;
+  }
+
+  private async ensureEventStream(): Promise<void> {
+    if (this.eventStreamActive) return;
+    this.eventStreamActive = true;
+
+    const client = await this.ensureClient();
+    const { stream } = await client.global.event();
+    this.eventStream = stream;
+
+    // Process events in the background
+    (async () => {
+      try {
+        for await (const event of stream) {
+          if (this.stopped) break;
+          this.handleSSEEvent(event as SSEEvent);
+        }
+      } catch {
+        // Stream closed or errored
+      }
+    })();
+  }
+
+  async sendMessage(text: string, from?: string): Promise<void> {
+    if (!this.config) throw new Error("Harness not started");
+    if (this.stopped) return;
+
+    const content = from ? `[Message from agent "${from}"]\n${text}` : text;
+    const sessionId = await this.ensureSession();
+    await this.ensureEventStream();
+
+    this.processing = true;
+    this.accumulatedText = "";
+    this.seenToolStates.clear();
+
+    // Set up the turn completion promise BEFORE sending the prompt
+    const turnComplete = new Promise<void>((resolve) => {
+      this.turnResolve = resolve;
+    });
+
+    const [providerID, modelID] = this.parseModel(this.config.model);
+    const systemParts = [this.config.internalSystemPrompt, this.config.systemPrompt].filter(
+      Boolean,
+    );
+    const system = systemParts.length > 0 ? systemParts.join("\n\n") : undefined;
+
+    try {
+      const client = await this.ensureClient();
+      await client.session.promptAsync({
+        path: { id: sessionId },
+        body: {
+          parts: [{ type: "text", text: content }],
+          system,
+          model: { providerID, modelID },
+        },
+        query: { directory: this.config.cwd },
+      });
+
+      // Wait for session.idle or session.error to signal turn completion
+      await turnComplete;
+    } catch (err) {
+      this.turnResolve = null;
+      this.emitEvent({ type: "error", payload: { message: String(err) } });
+      this.emitEvent({ type: "turn_complete", payload: {} });
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  private handleSSEEvent(event: SSEEvent): void {
+    if (this.stopped) return;
+
+    const sessionId = (event.properties as { sessionID?: string }).sessionID;
+    // Only process events for our session
+    if (sessionId && this.sessionId && sessionId !== this.sessionId) return;
+
+    switch (event.type) {
+      case "message.part.updated": {
+        const { part, delta } = event.properties as {
+          part: { type: string; [key: string]: unknown };
+          delta?: string;
+        };
+
+        if (part.type === "text") {
+          if (delta) {
+            this.accumulatedText += delta;
+            this.emitEvent({ type: "text_delta", payload: { delta } });
+          }
+        } else if (part.type === "tool") {
+          this.handleToolPartUpdate(part as Record<string, unknown>);
+        }
+        break;
+      }
+
+      case "session.idle": {
+        if (this.accumulatedText) {
+          this.emitEvent({ type: "text", payload: { text: this.accumulatedText } });
+        }
+        this.emitEvent({
+          type: "turn_complete",
+          payload: { session_id: this.sessionId ?? undefined },
+        });
+        this.resolveTurn();
+        break;
+      }
+
+      case "session.error": {
+        const error = event.properties.error as
+          | { name: string; data: { message: string } }
+          | undefined;
+        const message = error?.data?.message ?? "Unknown OpenCode error";
+        this.emitEvent({ type: "error", payload: { message } });
+        this.emitEvent({ type: "turn_complete", payload: {} });
+        this.resolveTurn();
+        break;
+      }
+    }
+  }
+
+  private handleToolPartUpdate(part: Record<string, unknown>): void {
+    const callID = part.callID as string;
+    const tool = part.tool as string;
+    const state = part.state as { status: string; [key: string]: unknown };
+    const prevStatus = this.seenToolStates.get(callID);
+
+    if (state.status === "running" && prevStatus !== "running") {
+      this.seenToolStates.set(callID, "running");
+      this.emitEvent({
+        type: "tool_use",
+        payload: {
+          tool,
+          tool_use_id: callID,
+          input: (state.input as Record<string, unknown>) ?? {},
+          status: "started",
+        },
+      });
+    } else if (state.status === "completed" && prevStatus !== "completed") {
+      this.seenToolStates.set(callID, "completed");
+      // Emit tool_use if we haven't seen running
+      if (!prevStatus) {
+        this.emitEvent({
+          type: "tool_use",
+          payload: {
+            tool,
+            tool_use_id: callID,
+            input: (state.input as Record<string, unknown>) ?? {},
+            status: "started",
+          },
+        });
+      }
+      this.emitEvent({
+        type: "tool_result",
+        payload: {
+          tool_use_id: callID,
+          output: (state.output as string) ?? "",
+          is_error: false,
+        },
+      });
+    } else if (state.status === "error" && prevStatus !== "error") {
+      this.seenToolStates.set(callID, "error");
+      if (!prevStatus) {
+        this.emitEvent({
+          type: "tool_use",
+          payload: {
+            tool,
+            tool_use_id: callID,
+            input: (state.input as Record<string, unknown>) ?? {},
+            status: "started",
+          },
+        });
+      }
+      this.emitEvent({
+        type: "tool_result",
+        payload: {
+          tool_use_id: callID,
+          output: (state.error as string) ?? "Tool error",
+          is_error: true,
+        },
+      });
+    }
+  }
+
+  private resolveTurn(): void {
+    if (this.turnResolve) {
+      const resolve = this.turnResolve;
+      this.turnResolve = null;
+      resolve();
+    }
+  }
+
+  async clearSession(): Promise<void> {
+    this.sessionVersion++;
+    const oldSessionId = this.sessionId;
+    this.sessionId = null;
+    this.sessionPending = null;
+    this.accumulatedText = "";
+    this.seenToolStates.clear();
+    // Abort the running server-side session
+    if (oldSessionId && this.client) {
+      await this.client.session.abort({ path: { id: oldSessionId } }).catch(() => {});
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    if (!this.sessionId || !this.client) return;
+    await this.client.session.abort({ path: { id: this.sessionId } });
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.sessionId = null;
+    this.eventStreamActive = false;
+    // Resolve any in-flight turn promise so sendMessage doesn't hang
+    this.resolveTurn();
+    // Close the event stream
+    if (this.eventStream) {
+      this.eventStream.return(undefined).catch(() => {});
+      this.eventStream = null;
+    }
+    if (this.serverClose) {
+      this.serverClose();
+      this.serverClose = null;
+    }
+  }
+
+  onEvent(callback: EventCallback): void {
+    this.callback = callback;
+  }
+
+  isProcessing(): boolean {
+    return this.processing;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  private parseModel(model: string): [string, string] {
+    if (model.includes("/")) {
+      const [providerID, ...rest] = model.split("/");
+      return [providerID, rest.join("/")];
+    }
+    // Default to anthropic if no provider prefix
+    return ["anthropic", model];
+  }
+
+  private emitEvent(event: AgentEvent): void {
+    if (!this.stopped) this.callback(event);
+  }
+}

--- a/src/runtime/harness/opencode-harness.ts
+++ b/src/runtime/harness/opencode-harness.ts
@@ -1,33 +1,7 @@
+import type { OpencodeClient, GlobalEvent, Event as OpenCodeEvent } from "@opencode-ai/sdk";
 import type { AgentEvent, Harness, HarnessConfig, EventCallback } from "./types";
 
-export type ClientLike = {
-  session: {
-    create: (opts: { query?: { directory?: string } }) => Promise<{ data: { id: string } }>;
-    get: (opts: { path: { id: string } }) => Promise<{ data: { id: string } }>;
-    abort: (opts: { path: { id: string } }) => Promise<{ data: boolean }>;
-    promptAsync: (opts: {
-      path: { id: string };
-      body: {
-        parts: Array<{ type: "text"; text: string }>;
-        system?: string;
-        model?: { providerID: string; modelID: string };
-      };
-      query?: { directory?: string };
-    }) => Promise<{ data: undefined }>;
-  };
-  global: {
-    event: () => Promise<{
-      stream: AsyncGenerator<SSEEvent, unknown, unknown>;
-    }>;
-  };
-};
-
-type SSEEvent = {
-  type: string;
-  properties: Record<string, unknown>;
-};
-
-type ClientFactory = (config: HarnessConfig) => Promise<ClientLike>;
+type ClientFactory = (config: HarnessConfig) => Promise<OpencodeClient>;
 
 export class OpenCodeHarness implements Harness {
   private callback: EventCallback = () => {};
@@ -37,11 +11,11 @@ export class OpenCodeHarness implements Harness {
   private sessionPending: Promise<string> | null = null;
   private config: HarnessConfig | null = null;
   private clientFactory: ClientFactory | null = null;
-  private client: ClientLike | null = null;
+  private client: OpencodeClient | null = null;
   private serverClose: (() => void) | null = null;
   private sessionVersion = 0;
   private eventStreamActive = false;
-  private eventStream: AsyncGenerator<SSEEvent, unknown, unknown> | null = null;
+  private eventStream: AsyncGenerator<GlobalEvent, unknown, unknown> | null = null;
   private accumulatedText = "";
   private seenToolStates = new Map<string, string>();
   private turnResolve: (() => void) | null = null;
@@ -56,7 +30,7 @@ export class OpenCodeHarness implements Harness {
     this.sessionId = config.resume ?? null;
   }
 
-  private async ensureClient(): Promise<ClientLike> {
+  private async ensureClient(): Promise<OpencodeClient> {
     if (this.client) return this.client;
     if (!this.config) throw new Error("Harness not started");
 
@@ -78,7 +52,7 @@ export class OpenCodeHarness implements Harness {
     });
 
     this.serverClose = server.close;
-    this.client = client as unknown as ClientLike;
+    this.client = client;
     return this.client;
   }
 
@@ -106,12 +80,12 @@ export class OpenCodeHarness implements Harness {
     const client = await this.ensureClient();
     if (this.config?.resume) {
       const result = await client.session.get({ path: { id: this.config.resume } });
-      return result.data.id;
+      return result.data!.id;
     }
     const result = await client.session.create({
       query: { directory: this.config?.cwd },
     });
-    return result.data.id;
+    return result.data!.id;
   }
 
   private async ensureEventStream(): Promise<void> {
@@ -127,7 +101,7 @@ export class OpenCodeHarness implements Harness {
       try {
         for await (const event of stream) {
           if (this.stopped) break;
-          this.handleSSEEvent(event as SSEEvent);
+          this.handleSSEEvent(event.payload);
         }
       } catch {
         // Stream closed or errored
@@ -181,16 +155,17 @@ export class OpenCodeHarness implements Harness {
     }
   }
 
-  private handleSSEEvent(event: SSEEvent): void {
+  private handleSSEEvent(event: OpenCodeEvent): void {
     if (this.stopped) return;
 
-    const sessionId = (event.properties as { sessionID?: string }).sessionID;
+    const props = event.properties as Record<string, unknown>;
+    const sessionId = props.sessionID as string | undefined;
     // Only process events for our session
     if (sessionId && this.sessionId && sessionId !== this.sessionId) return;
 
     switch (event.type) {
       case "message.part.updated": {
-        const { part, delta } = event.properties as {
+        const { part, delta } = props as {
           part: { type: string; [key: string]: unknown };
           delta?: string;
         };
@@ -219,9 +194,7 @@ export class OpenCodeHarness implements Harness {
       }
 
       case "session.error": {
-        const error = event.properties.error as
-          | { name: string; data: { message: string } }
-          | undefined;
+        const error = props.error as { name: string; data: { message: string } } | undefined;
         const message = error?.data?.message ?? "Unknown OpenCode error";
         this.emitEvent({ type: "error", payload: { message } });
         this.emitEvent({ type: "turn_complete", payload: {} });

--- a/src/runtime/harness/pi-harness.test.ts
+++ b/src/runtime/harness/pi-harness.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, mock } from "bun:test";
-import { PiHarness, type SessionLike } from "./pi-harness";
-import type { AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+import { PiHarness } from "./pi-harness";
+import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import type { AgentEvent, HarnessConfig } from "./types";
 
 const baseConfig: HarnessConfig = {
@@ -11,12 +11,13 @@ const baseConfig: HarnessConfig = {
 
 function createMockSession(sessionId = "pi-sess-1") {
   let subscriber: ((event: AgentSessionEvent) => void) | null = null;
-  const session: SessionLike & { fireEvent: (event: AgentSessionEvent) => void } = {
+  const session = {
     get sessionId() {
       return sessionId;
     },
     subscribe: mock((cb: (event: AgentSessionEvent) => void) => {
       subscriber = cb;
+      return () => {};
     }),
     prompt: mock(async (_text: string) => {
       if (subscriber) {
@@ -36,7 +37,7 @@ function createMockSession(sessionId = "pi-sess-1") {
       if (subscriber) subscriber(event);
     },
   };
-  return session;
+  return session as typeof session & AgentSession;
 }
 
 describe("PiHarness", () => {

--- a/src/runtime/harness/pi-harness.ts
+++ b/src/runtime/harness/pi-harness.ts
@@ -1,21 +1,14 @@
-import type { AgentSessionEvent, AgentSessionEventListener } from "@mariozechner/pi-coding-agent";
+import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import type { AgentEvent, Harness, HarnessConfig, EventCallback } from "./types";
 
-export type SessionLike = {
-  subscribe: (cb: AgentSessionEventListener) => void;
-  prompt: (text: string) => Promise<void>;
-  abort: () => Promise<void>;
-  readonly sessionId: string;
-};
-
-type SessionFactory = (config: HarnessConfig) => Promise<SessionLike>;
+type SessionFactory = (config: HarnessConfig) => Promise<AgentSession>;
 
 export class PiHarness implements Harness {
   private callback: EventCallback = () => {};
   private processing = false;
   private stopped = false;
-  private session: SessionLike | null = null;
-  private sessionPending: Promise<SessionLike> | null = null;
+  private session: AgentSession | null = null;
+  private sessionPending: Promise<AgentSession> | null = null;
   private config: HarnessConfig | null = null;
   private sessionFactory: SessionFactory | null = null;
   private skipContinue = false;
@@ -30,7 +23,7 @@ export class PiHarness implements Harness {
     this.stopped = false;
   }
 
-  private async ensureSession(): Promise<SessionLike> {
+  private async ensureSession(): Promise<AgentSession> {
     if (this.stopped) throw new Error("Harness is stopped");
     if (this.session) return this.session;
     if (!this.config) throw new Error("Harness not started");
@@ -96,7 +89,7 @@ export class PiHarness implements Harness {
     return this.session?.sessionId ?? null;
   }
 
-  private async createSession(config: HarnessConfig): Promise<SessionLike> {
+  private async createSession(config: HarnessConfig): Promise<AgentSession> {
     if (this.sessionFactory) return this.sessionFactory(config);
 
     const {
@@ -163,7 +156,7 @@ export class PiHarness implements Harness {
     return session;
   }
 
-  private subscribeToSession(session: SessionLike): void {
+  private subscribeToSession(session: AgentSession): void {
     console.error("[pi-harness] subscribed to session events");
     session.subscribe((event: AgentSessionEvent) => {
       console.error(`[pi-harness] session event: ${event.type}`);


### PR DESCRIPTION
## Summary
- Add OpenCode harness (`src/runtime/harness/opencode-harness.ts`) implementing the `Harness` interface with auto-managed `opencode serve` subprocess via the `@opencode-ai/sdk`
- Map OpenCode SSE events (`message.part.updated`, `session.idle`, `session.error`) to the shared `AgentEvent` interface (text_delta, tool_use, tool_result, turn_complete)
- Support session creation, resume, interruption, and clearSession with proper server-side abort
- Add "OpenCode" option to the harness dropdown in the agent creation/edit form
- Update Zod validation, TypeScript types, and agent-manager validation across backend and frontend
- Add OpenCode section to README with install instructions and provider docs link

## Test plan
- [x] 22 unit tests in `opencode-harness.test.ts` covering lifecycle, events, tool mapping, session management, error paths, concurrency, and edge cases (promptAsync rejection, stop during in-flight send)
- [x] Full test suite passes (634 tests, 0 failures)
- [x] TypeScript strict mode passes
- [x] ESLint and Prettier pass
- [ ] Manual: create an agent with harness "OpenCode", verify streaming output

🤖 Generated with [Claude Code](https://claude.com/claude-code)