### PR TITLE
Fix SharedDrive preview panel layout

### DIFF
--- a/src/frontend/components/AppLayout.tsx
+++ b/src/frontend/components/AppLayout.tsx
@@ -1,9 +1,15 @@
 import * as React from "react";
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+interface AppLayoutProps {
+  children: React.ReactNode;
+  maxWidth?: "default" | "wide";
+}
+
+export default function AppLayout({ children, maxWidth = "default" }: AppLayoutProps) {
+  const widthClass = maxWidth === "wide" ? "max-w-7xl" : "max-w-5xl";
   return (
     <main className="pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] sm:pl-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] lg:pl-[max(2rem,env(safe-area-inset-left))] lg:pr-[max(2rem,env(safe-area-inset-right))]">
-      <div className="mx-auto max-w-5xl">{children}</div>
+      <div className={`mx-auto ${widthClass}`}>{children}</div>
     </main>
   );
 }

--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -235,6 +235,17 @@ export default function SharedDrive() {
   const [previewError, setPreviewError] = React.useState<string | null>(null);
   const currentPreviewPath = React.useRef<string | null>(null);
 
+  // Lock body scroll on mobile when lightbox is open
+  React.useEffect(() => {
+    if (!previewFile) return;
+    const mq = window.matchMedia("(max-width: 767px)");
+    if (!mq.matches) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [previewFile]);
+
   const navigate = (path: string) => {
     setUploadError(null);
     setPreviewFile(null);
@@ -328,7 +339,7 @@ export default function SharedDrive() {
   }
 
   return (
-    <AppLayout>
+    <AppLayout maxWidth={previewFile ? "wide" : "default"}>
       <div className="space-y-4">
         <div className="flex items-center gap-3">
           <Button
@@ -359,8 +370,10 @@ export default function SharedDrive() {
 
         {/* File Table + Preview Panel */}
         <div className="flex gap-4">
-          {/* File Table */}
-          <div className={`rounded-md border ${previewFile ? "w-1/2" : "w-full"} min-w-0`}>
+          {/* File Table — hidden on mobile when preview is open */}
+          <div
+            className={`rounded-md border ${previewFile ? "hidden md:block md:w-1/2" : "w-full"} min-w-0`}
+          >
             <Table>
               <TableHeader>
                 <TableRow>
@@ -455,9 +468,9 @@ export default function SharedDrive() {
             </Table>
           </div>
 
-          {/* Preview Panel */}
+          {/* Preview Panel: fullscreen lightbox on mobile, inline side-by-side on desktop */}
           {previewFile && (
-            <div className="w-1/2 min-w-0 rounded-md border flex flex-col max-h-[calc(100vh-12rem)]">
+            <div className="fixed inset-0 z-50 bg-background flex flex-col md:static md:inset-auto md:z-auto md:bg-transparent md:w-1/2 md:min-w-0 md:rounded-md md:border md:max-h-[calc(100vh-12rem)]">
               <div className="flex items-center justify-between border-b px-4 py-2">
                 <span className="text-sm font-medium truncate">{previewFile.name}</span>
                 <div className="flex items-center gap-1">
@@ -482,7 +495,10 @@ export default function SharedDrive() {
                     size="icon"
                     className="h-7 w-7"
                     aria-label="Close preview"
-                    onClick={() => setPreviewFile(null)}
+                    onClick={() => {
+                      setPreviewFile(null);
+                      currentPreviewPath.current = null;
+                    }}
                   >
                     <X className="h-4 w-4" />
                   </Button>

--- a/src/frontend/test/AppLayout.test.tsx
+++ b/src/frontend/test/AppLayout.test.tsx
@@ -14,4 +14,18 @@ describe("AppLayout", () => {
     expect(main.className).toContain("safe-area-inset-top");
     expect(main.className).toContain("safe-area-inset-bottom");
   });
+
+  it("uses max-w-5xl by default", () => {
+    const { container } = render(<AppLayout>content</AppLayout>);
+    const inner = container.querySelector("main > div") as HTMLElement;
+    expect(inner.className).toContain("max-w-5xl");
+    expect(inner.className).not.toContain("max-w-7xl");
+  });
+
+  it("uses max-w-7xl when maxWidth is wide", () => {
+    const { container } = render(<AppLayout maxWidth="wide">content</AppLayout>);
+    const inner = container.querySelector("main > div") as HTMLElement;
+    expect(inner.className).toContain("max-w-7xl");
+    expect(inner.className).not.toContain("max-w-5xl");
+  });
 });


### PR DESCRIPTION
## Summary
- Add `maxWidth` prop to `AppLayout` — SharedDrive uses `max-w-7xl` (1280px) when preview is open instead of `max-w-5xl` (1024px), giving each panel ~630px instead of ~500px
- On mobile (<md breakpoint), preview renders as a full-screen lightbox overlay with body scroll lock instead of an unusable side-by-side split
- Fix stale `currentPreviewPath` ref when closing preview via X button

## Test plan
- [ ] Open SharedDrive, click a file — preview panel appears side-by-side with wider container
- [ ] Resize browser to mobile width — preview shows as full-screen overlay
- [ ] Close preview via X button, reopen same file — content loads correctly
- [ ] Verify other pages using AppLayout are unaffected (default max-width unchanged)
- [ ] `bun run typecheck`, `bun run lint`, `bun test` all pass (636 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)