### PR TITLE
Change preview split ratio to 1/3 : 2/3

### DIFF
--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -372,7 +372,7 @@ export default function SharedDrive() {
         <div className="flex gap-4">
           {/* File Table — hidden on mobile when preview is open */}
           <div
-            className={`rounded-md border ${previewFile ? "hidden md:block md:w-1/2" : "w-full"} min-w-0`}
+            className={`rounded-md border ${previewFile ? "hidden md:block md:w-1/3" : "w-full"} min-w-0`}
           >
             <Table>
               <TableHeader>
@@ -470,7 +470,7 @@ export default function SharedDrive() {
 
           {/* Preview Panel: fullscreen lightbox on mobile, inline side-by-side on desktop */}
           {previewFile && (
-            <div className="fixed inset-0 z-50 bg-background flex flex-col md:static md:inset-auto md:z-auto md:bg-transparent md:w-1/2 md:min-w-0 md:rounded-md md:border md:max-h-[calc(100vh-12rem)]">
+            <div className="fixed inset-0 z-50 bg-background flex flex-col md:static md:inset-auto md:z-auto md:bg-transparent md:w-2/3 md:min-w-0 md:rounded-md md:border md:max-h-[calc(100vh-12rem)]">
               <div className="flex items-center justify-between border-b px-4 py-2">
                 <span className="text-sm font-medium truncate">{previewFile.name}</span>
                 <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- File list takes 1/3 width, preview pane takes 2/3 when preview is open
- Gives preview content more room while file list stays compact (names + sizes)

## Test plan
- [ ] Open SharedDrive, click a file — file list is narrow, preview is wider
- [ ] `bun test` passes (636 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)