### PR TITLE
Add Claude Code hooks for test enforcement

### DIFF
--- a/.claude/hooks/check-coverage.sh
+++ b/.claude/hooks/check-coverage.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# PreToolUse hook: block git commit if test coverage < 90%.
+set -euo pipefail
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Run tests with coverage, disable color output for reliable parsing
+COVERAGE_OUTPUT=$(NO_COLOR=1 bun test --coverage 2>&1) || true
+
+# Strip any remaining ANSI escape codes
+CLEAN_OUTPUT=$(echo "$COVERAGE_OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
+
+# Parse the "All files" line for line coverage (first percentage)
+COVERAGE_LINE=$(echo "$CLEAN_OUTPUT" | grep "All files" || true)
+
+if [ -z "$COVERAGE_LINE" ]; then
+  echo "Could not determine test coverage. Ensure tests pass first." >&2
+  echo "" >&2
+  echo "$COVERAGE_OUTPUT" >&2
+  exit 2
+fi
+
+# Extract first percentage (line coverage): "All files | 85.71% | ..."
+LINE_COVERAGE=$(echo "$COVERAGE_LINE" | awk -F'|' '{print $2}' | tr -d ' %')
+
+# Validate that the parsed value is numeric
+if ! [[ "$LINE_COVERAGE" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "Coverage value '$LINE_COVERAGE' is not numeric." >&2
+  echo "Raw line: $COVERAGE_LINE" >&2
+  exit 2
+fi
+
+# Compare coverage against threshold (90%)
+THRESHOLD=90
+PASS=$(awk "BEGIN { print ($LINE_COVERAGE >= $THRESHOLD) ? 1 : 0 }")
+
+if [ "$PASS" -eq 0 ]; then
+  echo "Test coverage is ${LINE_COVERAGE}%, which is below the ${THRESHOLD}% threshold." >&2
+  echo "" >&2
+  echo "$CLEAN_OUTPUT" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/check-test-files.sh
+++ b/.claude/hooks/check-test-files.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Stop hook: block if any new/modified source files are missing co-located test files.
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Avoid infinite loop — if the stop hook is already active, bail out
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Collect changed/new source files (staged, unstaged, and untracked)
+CHANGED_FILES=$(
+  {
+    git diff --name-only --diff-filter=ACM HEAD 2>/dev/null || true
+    git diff --name-only --diff-filter=ACM --cached 2>/dev/null || true
+    git ls-files --others --exclude-standard 2>/dev/null || true
+  } | sort -u
+)
+
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0
+fi
+
+MISSING=()
+
+while IFS= read -r file; do
+  # Only check src/**/*.ts and src/**/*.tsx
+  [[ "$file" == src/* ]] || continue
+  [[ "$file" == *.ts || "$file" == *.tsx ]] || continue
+
+  # Skip test files
+  [[ "$file" == *.test.ts || "$file" == *.test.tsx ]] && continue
+
+  # Skip type definitions
+  [[ "$file" == *.d.ts ]] && continue
+
+  # Skip DB schema/migrations
+  [[ "$file" == src/db/* ]] && continue
+
+  # Skip shadcn UI primitives
+  [[ "$file" == src/frontend/components/ui/* ]] && continue
+
+  # Skip test setup/helpers
+  [[ "$file" == src/test/* ]] && continue
+  [[ "$file" == src/frontend/test/* ]] && continue
+
+  # Skip known entry points and config files
+  basename=$(basename "$file")
+  case "$basename" in
+    index.ts|index.tsx|cli.ts|server.ts|events.ts) continue ;;
+    types.ts|types.tsx) continue ;;
+  esac
+
+  # Determine expected co-located test file path
+  dir=$(dirname "$file")
+  name="${basename%.*}"
+  ext="${basename##*.}"
+  test_file="${dir}/${name}.test.${ext}"
+
+  if [ ! -f "$test_file" ]; then
+    MISSING+=("$file -> $test_file")
+  fi
+done <<< "$CHANGED_FILES"
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "Missing co-located test files for the following source files:" >&2
+  echo "" >&2
+  for entry in "${MISSING[@]}"; do
+    echo "  $entry" >&2
+  done
+  echo "" >&2
+  echo "Every source file needs a co-located test file (e.g. foo.ts -> foo.test.ts)." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-test-files.sh",
+            "timeout": 30,
+            "statusMessage": "Checking for missing test files..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-coverage.sh",
+            "timeout": 120,
+            "statusMessage": "Running test coverage check..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- **Stop hook** (`check-test-files.sh`): When Claude finishes responding, checks if any new/modified source files under `src/` are missing a co-located test file. Blocks with an error listing the missing tests.
- **PreToolUse hook** (`check-coverage.sh`): Before any `git commit` command, runs `bun test --coverage` and blocks if line coverage is below 90%.

Enforces co-located test convention: `foo.ts` → `foo.test.ts` in the same directory.

### Exclusions (no test required)
- Test files, type definitions (`.d.ts`), DB schema/migrations (`src/db/`)
- shadcn UI primitives (`src/frontend/components/ui/`)
- Test helpers (`src/test/`, `src/frontend/test/`)
- Entry points (`index.ts`, `cli.ts`, `server.ts`, `events.ts`)
- Type-only files (`types.ts`, `types.tsx`)

## Test plan
- [x] Stop hook passes when no source files changed
- [x] Stop hook blocks when nested source file missing test (e.g. `src/services/foo.ts`)
- [x] Stop hook blocks when frontend component missing test (e.g. `src/frontend/components/Foo.tsx`)
- [x] Stop hook skips excluded files (shadcn UI, db, test helpers)
- [x] Stop hook bails on `stop_hook_active: true` (no infinite loop)
- [x] Coverage hook correctly parses bun coverage output (with ANSI stripping)
- [x] Coverage hook blocks at 71% (below 90% threshold)
- [x] Coverage threshold comparison works for both pass/fail cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)