### PR TITLE
Fix upload progress bar not dismissing after completion

### DIFF
--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -380,8 +380,8 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
         };
         setPendingFiles((prev) => [...prev, pending]);
 
-        uploadAttachment.mutate(
-          {
+        uploadAttachment
+          .mutateAsync({
             agentId: agent.id,
             file,
             onProgress: (percent) => {
@@ -389,23 +389,20 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
                 prev.map((f) => (f.localId === lid ? { ...f, progress: percent } : f)),
               );
             },
-          },
-          {
-            onSuccess: (result) => {
-              setPendingFiles((prev) =>
-                prev.map((f) =>
-                  f.localId === lid ? { ...f, uploadId: result.id, progress: 100 } : f,
-                ),
-              );
-            },
-            onError: (err) => {
-              const errorMsg = err instanceof Error ? err.message : "Upload failed";
-              setPendingFiles((prev) =>
-                prev.map((f) => (f.localId === lid ? { ...f, error: errorMsg, progress: 0 } : f)),
-              );
-            },
-          },
-        );
+          })
+          .then((result) => {
+            setPendingFiles((prev) =>
+              prev.map((f) =>
+                f.localId === lid ? { ...f, uploadId: result.id, progress: 100 } : f,
+              ),
+            );
+          })
+          .catch((err: unknown) => {
+            const errorMsg = err instanceof Error ? err.message : "Upload failed";
+            setPendingFiles((prev) =>
+              prev.map((f) => (f.localId === lid ? { ...f, error: errorMsg, progress: 0 } : f)),
+            );
+          });
       }
       if (fileInputRef.current) fileInputRef.current.value = "";
     },

--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -341,27 +341,24 @@ export default function SharedDrive() {
         const key = `${file.name}-${crypto.randomUUID()}`;
         fileProgressRef.current.set(key, 0);
 
-        uploadFile.mutate(
-          {
+        uploadFile
+          .mutateAsync({
             file,
             path: currentPath,
             onProgress: (percent) => {
               fileProgressRef.current.set(key, percent);
               updateAggregateProgress();
             },
-          },
-          {
-            onSuccess: () => {
-              fileProgressRef.current.delete(key);
-              updateAggregateProgress();
-            },
-            onError: (err) => {
-              fileProgressRef.current.delete(key);
-              updateAggregateProgress();
-              setUploadError(err instanceof Error ? err.message : "Upload failed");
-            },
-          },
-        );
+          })
+          .then(() => {
+            fileProgressRef.current.delete(key);
+            updateAggregateProgress();
+          })
+          .catch((err: unknown) => {
+            fileProgressRef.current.delete(key);
+            updateAggregateProgress();
+            setUploadError(err instanceof Error ? err.message : "Upload failed");
+          });
       }
     },
     [currentPath, uploadFile],

--- a/src/frontend/test/ChatPanel.test.tsx
+++ b/src/frontend/test/ChatPanel.test.tsx
@@ -750,6 +750,42 @@ describe("ChatPanel", () => {
       await screen.findByText(/File is larger than/);
     });
 
+    it("completes all concurrent uploads (not just the last one)", async () => {
+      let uploadCount = 0;
+      server.use(
+        http.post("*/api/projects/:id/agents/:aid/attachments", () => {
+          uploadCount += 1;
+          return HttpResponse.json(
+            {
+              id: `att-${uploadCount}`,
+              filename: `file${uploadCount}.txt`,
+              content_type: "text/plain",
+              size: 100,
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+
+      await waitFor(() => {
+        expect(document.querySelector('input[type="file"]')).toBeTruthy();
+      });
+
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const files = [createFile("x.txt", 10), createFile("y.txt", 20), createFile("z.txt", 30)];
+      const dt = createDataTransfer(files);
+      Object.defineProperty(input, "files", { value: dt.files, configurable: true });
+      fireEvent.change(input);
+
+      // All three files should show as completed (check icon appears for each)
+      await waitFor(() => {
+        const checks = document.querySelectorAll("svg.lucide-check");
+        expect(checks.length).toBe(3);
+      });
+    });
+
     it("preserves pending files when send fails", async () => {
       server.use(
         http.post("*/api/projects/:id/agents/:aid/message", () =>

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "bun:test";
 import { http, HttpResponse } from "msw";
@@ -341,6 +341,60 @@ describe("SharedDrive", () => {
 
       await waitFor(() => {
         expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("file upload", () => {
+    function createFile(name: string, size: number, type = "text/plain"): File {
+      const content = new Uint8Array(size);
+      return new File([content], name, { type });
+    }
+
+    function createDataTransfer(files: File[]): DataTransfer {
+      const dt = new DataTransfer();
+      for (const f of files) dt.items.add(f);
+      return dt;
+    }
+
+    it("dismisses progress bar after all concurrent uploads complete", async () => {
+      renderWithProviders(<SharedDrive />, routeOpts);
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Shared Drive" })).toBeInTheDocument();
+      });
+
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      expect(input).toBeTruthy();
+
+      const files = [createFile("a.txt", 10), createFile("b.txt", 20), createFile("c.txt", 30)];
+      const dt = createDataTransfer(files);
+      Object.defineProperty(input, "files", { value: dt.files, configurable: true });
+      fireEvent.change(input);
+
+      // Progress bar should appear then dismiss after all uploads complete
+      await waitFor(() => {
+        const progressBar = document.querySelector(".bg-primary.transition-all");
+        expect(progressBar).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows error for oversized files without blocking valid ones", async () => {
+      renderWithProviders(<SharedDrive />, routeOpts);
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Shared Drive" })).toBeInTheDocument();
+      });
+
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      const files = [createFile("ok.txt", 100), createFile("huge.bin", 129 * 1024 * 1024)];
+      const dt = createDataTransfer(files);
+      Object.defineProperty(input, "files", { value: dt.files, configurable: true });
+      fireEvent.change(input);
+
+      await waitFor(() => {
+        expect(screen.getByText(/too large/)).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
## Summary
- Fix concurrent upload progress not clearing by switching from `mutate()` to `mutateAsync()` with `.then()/.catch()`
- React Query's `mutate()` silently drops per-call `onSuccess`/`onError` callbacks when called multiple times concurrently — only the last call's callbacks fire
- Affects both ChatPanel (attachment uploads) and SharedDrive (file uploads)

## Test plan
- [ ] Upload multiple files simultaneously in SharedDrive → progress bar dismisses when all complete
- [ ] Upload multiple attachments in ChatPanel → all files show correct completion state
- [ ] All frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)