### PR TITLE
Add tests for catalog, settings, and scheduler

### DIFF
--- a/.claude/hooks/check-coverage.sh
+++ b/.claude/hooks/check-coverage.sh
@@ -20,8 +20,8 @@ if [ -z "$COVERAGE_LINE" ]; then
   exit 2
 fi
 
-# Extract first percentage (line coverage): "All files | 85.71% | ..."
-LINE_COVERAGE=$(echo "$COVERAGE_LINE" | awk -F'|' '{print $2}' | tr -d ' %')
+# Extract line coverage (third column): "All files | % Funcs | % Lines | ..."
+LINE_COVERAGE=$(echo "$COVERAGE_LINE" | awk -F'|' '{print $3}' | tr -d ' %')
 
 # Validate that the parsed value is numeric
 if ! [[ "$LINE_COVERAGE" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then

--- a/src/routes/catalog.test.ts
+++ b/src/routes/catalog.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createTestDb } from "../test/setup";
+import { createApp } from "../server";
+import { ProjectManager } from "../runtime/project-manager";
+import { Scheduler } from "../runtime/scheduler";
+
+let app: ReturnType<typeof createApp>;
+
+beforeEach(() => {
+  createTestDb();
+  const projectManager = new ProjectManager();
+  const scheduler = new Scheduler(projectManager);
+  app = createApp({ projectManager, scheduler });
+});
+
+async function request(method: string, path: string) {
+  return app.request(path, { method, headers: { "Content-Type": "application/json" } });
+}
+
+describe("GET /api/catalog/categories", () => {
+  it("returns a list of categories", async () => {
+    const res = await request("GET", "/api/catalog/categories");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThan(0);
+
+    const first = data[0];
+    expect(first.id).toBeDefined();
+    expect(first.name).toBeDefined();
+    expect(first.description).toBeDefined();
+  });
+
+  it("includes known categories", async () => {
+    const res = await request("GET", "/api/catalog/categories");
+    const data = (await res.json()) as Array<{ id: string; name: string; description: string }>;
+    const ids = data.map((c) => c.id);
+    expect(ids).toContain("engineering");
+    expect(ids).toContain("design");
+  });
+});
+
+describe("GET /api/catalog/agents", () => {
+  it("returns all agents", async () => {
+    const res = await request("GET", "/api/catalog/agents");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThan(0);
+  });
+
+  it("returns agents with expected shape", async () => {
+    const res = await request("GET", "/api/catalog/agents");
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    const agent = data[0];
+    expect(agent.name).toBeDefined();
+    expect(typeof agent.name).toBe("string");
+    expect(agent.displayName).toBeDefined();
+    expect(agent.description).toBeDefined();
+    expect(agent.category).toBeDefined();
+    expect(agent.harness).toBeDefined();
+    expect(Array.isArray(agent.tags)).toBe(true);
+  });
+
+  it("filters by category", async () => {
+    const res = await request("GET", "/api/catalog/agents?category=engineering");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Array<{ category: string }>;
+    expect(data.length).toBeGreaterThan(0);
+    for (const agent of data) {
+      expect(agent.category).toBe("engineering");
+    }
+  });
+
+  it("returns empty array for unknown category", async () => {
+    const res = await request("GET", "/api/catalog/agents?category=nonexistent");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    expect(data).toEqual([]);
+  });
+});
+
+describe("GET /api/catalog/agents/:name", () => {
+  it("returns a specific agent by name", async () => {
+    const res = await request("GET", "/api/catalog/agents/ai-engineer");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Record<string, unknown>;
+    expect(data.name).toBe("ai-engineer");
+    expect(data.displayName).toBe("AI Engineer");
+    expect(data.category).toBe("engineering");
+    expect(data.harness).toBe("claude_code");
+  });
+
+  it("returns 404 for unknown agent", async () => {
+    const res = await request("GET", "/api/catalog/agents/this-agent-does-not-exist");
+    expect(res.status).toBe(404);
+    const data = (await res.json()) as Record<string, unknown>;
+    expect(data.error).toBe("Agent not found");
+  });
+});

--- a/src/routes/settings.test.ts
+++ b/src/routes/settings.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createTestDb } from "../test/setup";
+import { createApp } from "../server";
+import { ProjectManager } from "../runtime/project-manager";
+import { Scheduler } from "../runtime/scheduler";
+import * as projects from "../services/projects";
+import * as workspace from "../services/workspace";
+import { rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let app: ReturnType<typeof createApp>;
+let testDir: string;
+let projectId: string;
+let projectName: string;
+
+beforeEach(async () => {
+  createTestDb();
+  testDir = join(
+    tmpdir(),
+    `settings_route_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+  );
+  process.env.SHIRE_PROJECTS_DIR = testDir;
+
+  mock.module("../runtime/harness", () => ({
+    createHarness: () => ({
+      start: async () => {},
+      sendMessage: async () => {},
+      interrupt: async () => {},
+      clearSession: async () => {},
+      stop: async () => {},
+      onEvent: () => {},
+      isProcessing: () => false,
+      getSessionId: () => null,
+    }),
+  }));
+
+  const projectManager = new ProjectManager();
+  const scheduler = new Scheduler(projectManager);
+  app = createApp({ projectManager, scheduler });
+
+  projectName = "settings-test-project";
+  const project = projects.createProject(projectName);
+  projectId = project.id;
+  await workspace.ensureProjectDirs(projectId);
+  await projectManager.boot();
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+async function request(method: string, path: string, body?: unknown) {
+  const opts: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (body) opts.body = JSON.stringify(body);
+  return app.request(path, opts);
+}
+
+describe("GET /api/projects/:id/settings/project-doc", () => {
+  it("returns empty string when PROJECT.md does not exist", async () => {
+    const res = await request("GET", `/api/projects/${projectId}/settings/project-doc`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { content: string };
+    expect(data.content).toBe("");
+  });
+
+  it("returns content when PROJECT.md exists", async () => {
+    await request("PUT", `/api/projects/${projectId}/settings/project-doc`, {
+      content: "# My Project\nSome documentation here.",
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/settings/project-doc`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { content: string };
+    expect(data.content).toBe("# My Project\nSome documentation here.");
+  });
+
+  it("resolves project by name", async () => {
+    await request("PUT", `/api/projects/${projectName}/settings/project-doc`, {
+      content: "resolved by name",
+    });
+
+    const res = await request("GET", `/api/projects/${projectName}/settings/project-doc`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { content: string };
+    expect(data.content).toBe("resolved by name");
+  });
+
+  it("returns 404 for non-existent project", async () => {
+    const res = await request("GET", `/api/projects/nonexistent-id/settings/project-doc`);
+    expect(res.status).toBe(404);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe("Project not found");
+  });
+});
+
+describe("PUT /api/projects/:id/settings/project-doc", () => {
+  it("writes content successfully", async () => {
+    const res = await request("PUT", `/api/projects/${projectId}/settings/project-doc`, {
+      content: "Hello, world!",
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { ok: boolean };
+    expect(data.ok).toBe(true);
+
+    // Verify by reading back
+    const getRes = await request("GET", `/api/projects/${projectId}/settings/project-doc`);
+    const getData = (await getRes.json()) as { content: string };
+    expect(getData.content).toBe("Hello, world!");
+  });
+
+  it("overwrites existing content", async () => {
+    await request("PUT", `/api/projects/${projectId}/settings/project-doc`, {
+      content: "original content",
+    });
+    await request("PUT", `/api/projects/${projectId}/settings/project-doc`, {
+      content: "updated content",
+    });
+
+    const res = await request("GET", `/api/projects/${projectId}/settings/project-doc`);
+    const data = (await res.json()) as { content: string };
+    expect(data.content).toBe("updated content");
+  });
+
+  it("writes empty string content", async () => {
+    await request("PUT", `/api/projects/${projectId}/settings/project-doc`, {
+      content: "some content",
+    });
+    const res = await request("PUT", `/api/projects/${projectId}/settings/project-doc`, {
+      content: "",
+    });
+    expect(res.status).toBe(200);
+
+    const getRes = await request("GET", `/api/projects/${projectId}/settings/project-doc`);
+    const data = (await getRes.json()) as { content: string };
+    expect(data.content).toBe("");
+  });
+
+  it("rejects missing content field", async () => {
+    const res = await request("PUT", `/api/projects/${projectId}/settings/project-doc`, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing body", async () => {
+    const res = await request("PUT", `/api/projects/${projectId}/settings/project-doc`);
+    expect(res.status).toBe(400);
+  });
+
+  it("resolves project by name", async () => {
+    const res = await request("PUT", `/api/projects/${projectName}/settings/project-doc`, {
+      content: "written by name",
+    });
+    expect(res.status).toBe(200);
+
+    // Verify via project ID
+    const getRes = await request("GET", `/api/projects/${projectId}/settings/project-doc`);
+    const data = (await getRes.json()) as { content: string };
+    expect(data.content).toBe("written by name");
+  });
+
+  it("returns 404 for non-existent project", async () => {
+    const res = await request("PUT", `/api/projects/nonexistent-id/settings/project-doc`, {
+      content: "test",
+    });
+    expect(res.status).toBe(404);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toBe("Project not found");
+  });
+});

--- a/src/runtime/scheduler.test.ts
+++ b/src/runtime/scheduler.test.ts
@@ -1,0 +1,498 @@
+import { describe, it, expect, beforeEach, mock, spyOn } from "bun:test";
+import { createTestDb } from "../test/setup";
+import { Scheduler } from "./scheduler";
+import * as projects from "../services/projects";
+import * as agentsService from "../services/agents";
+import * as schedulesService from "../services/schedules";
+import { bus, type BusEvent } from "../events";
+import type { ProjectManager } from "./project-manager";
+import type { Coordinator } from "./coordinator";
+import type { AgentManager } from "./agent-manager";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeMockAgent(overrides?: Partial<AgentManager>): AgentManager {
+  return {
+    sendMessage: mock(() => Promise.resolve({ ok: true })),
+    ...overrides,
+  } as unknown as AgentManager;
+}
+
+function makeMockCoordinator(agents: Map<string, AgentManager> = new Map()): Coordinator {
+  return {
+    getAgent: (id: string) => agents.get(id),
+  } as unknown as Coordinator;
+}
+
+function makeMockProjectManager(
+  coordinators: Map<string, Coordinator> = new Map(),
+): ProjectManager {
+  return {
+    getCoordinator: (id: string) => coordinators.get(id),
+  } as unknown as ProjectManager;
+}
+
+function collectEvents(topic: string): { events: BusEvent[]; unsub: () => void } {
+  const events: BusEvent[] = [];
+  const unsub = bus.on(topic, (e) => events.push(e));
+  return { events, unsub };
+}
+
+interface TaskInput {
+  id?: string;
+  projectId?: string;
+  agentId?: string;
+  label?: string;
+  message?: string;
+  scheduleType?: "once" | "recurring";
+  cronExpression?: string | null;
+  scheduledAt?: string | null;
+  enabled?: boolean;
+}
+
+function makeTask(overrides: TaskInput = {}) {
+  return {
+    id: overrides.id ?? "task-1",
+    projectId: overrides.projectId ?? "proj-1",
+    agentId: overrides.agentId ?? "agent-1",
+    label: overrides.label ?? "Test Task",
+    message: overrides.message ?? "do something",
+    scheduleType: overrides.scheduleType ?? ("recurring" as const),
+    cronExpression: overrides.cronExpression ?? "*/5 * * * *",
+    scheduledAt: overrides.scheduledAt ?? null,
+    enabled: overrides.enabled ?? true,
+  };
+}
+
+// ── Mock node-schedule ───────────────────────────────────────────────────────
+
+const mockJobs = new Map<string, { cancel: ReturnType<typeof mock> }>();
+
+mock.module("node-schedule", () => ({
+  default: {
+    scheduleJob: mock((_spec: unknown, callback: () => void) => {
+      const job = { cancel: mock(() => {}), _callback: callback };
+      // Store by a key so tests can inspect; we'll also capture the callback
+      const key = `job-${mockJobs.size}`;
+      mockJobs.set(key, job);
+      return job;
+    }),
+  },
+}));
+
+// Re-import after mocking
+const nodeSchedule = (await import("node-schedule")).default;
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+let projectId: string;
+let agentId: string;
+
+beforeEach(() => {
+  createTestDb();
+  mockJobs.clear();
+  (nodeSchedule.scheduleJob as ReturnType<typeof mock>).mockClear();
+
+  const project = projects.createProject("sched-test");
+  projectId = project.id;
+  const agent = agentsService.createAgent(projectId, { name: "sched-agent" });
+  agentId = agent.id;
+});
+
+describe("Scheduler", () => {
+  describe("boot", () => {
+    it("loads enabled tasks from the database", () => {
+      // Create two enabled tasks and one disabled
+      schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "Task A",
+        message: "run A",
+        scheduleType: "recurring",
+        cronExpression: "*/10 * * * *",
+        enabled: true,
+      });
+      schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "Task B",
+        message: "run B",
+        scheduleType: "recurring",
+        cronExpression: "0 * * * *",
+        enabled: true,
+      });
+      schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "Disabled",
+        message: "nope",
+        scheduleType: "recurring",
+        cronExpression: "0 0 * * *",
+        enabled: false,
+      });
+
+      const scheduler = new Scheduler(makeMockProjectManager());
+      scheduler.boot();
+
+      // Two enabled tasks should have produced two scheduleJob calls
+      expect(nodeSchedule.scheduleJob).toHaveBeenCalledTimes(2);
+    });
+
+    it("loads zero tasks when none are enabled", () => {
+      schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "Off",
+        message: "off",
+        scheduleType: "recurring",
+        cronExpression: "0 0 * * *",
+        enabled: false,
+      });
+
+      const scheduler = new Scheduler(makeMockProjectManager());
+      scheduler.boot();
+
+      expect(nodeSchedule.scheduleJob).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("scheduleTask", () => {
+    it("registers a recurring task with cron expression", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+      const task = makeTask({
+        scheduleType: "recurring",
+        cronExpression: "*/5 * * * *",
+        enabled: true,
+      });
+
+      scheduler.scheduleTask(task);
+
+      expect(nodeSchedule.scheduleJob).toHaveBeenCalledTimes(1);
+      const call = (nodeSchedule.scheduleJob as ReturnType<typeof mock>).mock.calls[0];
+      expect(call[0]).toEqual({ rule: "*/5 * * * *", tz: "Etc/UTC" });
+    });
+
+    it("registers a one-time task with a future date", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+      const futureDate = new Date(Date.now() + 60_000).toISOString();
+      const task = makeTask({
+        scheduleType: "once",
+        cronExpression: null,
+        scheduledAt: futureDate,
+        enabled: true,
+      });
+
+      scheduler.scheduleTask(task);
+
+      expect(nodeSchedule.scheduleJob).toHaveBeenCalledTimes(1);
+      const call = (nodeSchedule.scheduleJob as ReturnType<typeof mock>).mock.calls[0];
+      // For "once" tasks, the first arg is a Date
+      expect(call[0] instanceof Date).toBe(true);
+    });
+
+    it("does not register a one-time task with a past date", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+      const pastDate = new Date(Date.now() - 60_000).toISOString();
+      const task = makeTask({
+        scheduleType: "once",
+        cronExpression: null,
+        scheduledAt: pastDate,
+        enabled: true,
+      });
+
+      scheduler.scheduleTask(task);
+
+      expect(nodeSchedule.scheduleJob).toHaveBeenCalledTimes(0);
+    });
+
+    it("does not register a disabled task", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+      const task = makeTask({ enabled: false });
+
+      scheduler.scheduleTask(task);
+
+      expect(nodeSchedule.scheduleJob).toHaveBeenCalledTimes(0);
+    });
+
+    it("cancels existing job before rescheduling same task id", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+      const task = makeTask({ id: "task-resched", enabled: true });
+
+      scheduler.scheduleTask(task);
+      const firstJob = [...mockJobs.values()][0];
+
+      scheduler.scheduleTask(task);
+
+      // The first job should have been cancelled
+      expect(firstJob.cancel).toHaveBeenCalledTimes(1);
+      // Two scheduleJob calls total (first + rescheduled)
+      expect(nodeSchedule.scheduleJob).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("cancelTask", () => {
+    it("cancels and removes a scheduled job", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+      const task = makeTask({ id: "cancel-me" });
+
+      scheduler.scheduleTask(task);
+      const job = [...mockJobs.values()][0];
+
+      scheduler.cancelTask("cancel-me");
+
+      expect(job.cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op for unknown task ids", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+      // Should not throw
+      scheduler.cancelTask("nonexistent");
+    });
+  });
+
+  describe("cancelAll", () => {
+    it("cancels all scheduled jobs and clears the map", () => {
+      const scheduler = new Scheduler(makeMockProjectManager());
+
+      scheduler.scheduleTask(makeTask({ id: "t1" }));
+      scheduler.scheduleTask(makeTask({ id: "t2" }));
+      scheduler.scheduleTask(makeTask({ id: "t3" }));
+
+      const allJobs = [...mockJobs.values()];
+
+      scheduler.cancelAll();
+
+      for (const job of allJobs) {
+        expect(job.cancel).toHaveBeenCalled();
+      }
+
+      // After cancelAll, cancelling individual tasks should be a no-op (jobs already removed)
+      scheduler.cancelTask("t1");
+      // No additional cancel calls on the already-cancelled jobs
+    });
+  });
+
+  describe("fireTask", () => {
+    it("sends message to agent and emits schedule_fired event", () => {
+      const mockAgent = makeMockAgent();
+      const agents = new Map<string, AgentManager>();
+      agents.set(agentId, mockAgent);
+      const coord = makeMockCoordinator(agents);
+      const coordinators = new Map<string, Coordinator>();
+      coordinators.set(projectId, coord);
+      const pm = makeMockProjectManager(coordinators);
+
+      // We need a real task in DB for markRun/toggleScheduledTask
+      const dbTask = schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "Fire Test",
+        message: "hello scheduled",
+        scheduleType: "recurring",
+        cronExpression: "*/5 * * * *",
+        enabled: true,
+      });
+
+      const scheduler = new Scheduler(pm);
+      const task = makeTask({
+        id: dbTask.id,
+        projectId,
+        agentId,
+        label: "Fire Test",
+        message: "hello scheduled",
+        scheduleType: "recurring",
+      });
+
+      // Capture the callback by scheduling the task
+      scheduler.scheduleTask(task);
+      const job = [...mockJobs.values()][0];
+      const callback = (job as unknown as Record<string, () => void>)._callback;
+
+      const { events, unsub } = collectEvents(`project:${projectId}:schedules`);
+
+      // Fire the task by invoking the callback
+      callback();
+      unsub();
+
+      // Agent should have received the message
+      expect(mockAgent.sendMessage).toHaveBeenCalledTimes(1);
+      const sentMsg = (mockAgent.sendMessage as ReturnType<typeof mock>).mock.calls[0][0];
+      expect(sentMsg).toContain("[Scheduled: Fire Test]");
+      expect(sentMsg).toContain("hello scheduled");
+
+      // Should have emitted schedule_fired event
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe("schedule_fired");
+      expect((events[0] as { payload: { taskId: string } }).payload.taskId).toBe(dbTask.id);
+    });
+
+    it("persists a system message in the database when task fires", () => {
+      const mockAgent = makeMockAgent();
+      const agents = new Map<string, AgentManager>();
+      agents.set(agentId, mockAgent);
+      const coord = makeMockCoordinator(agents);
+      const coordinators = new Map<string, Coordinator>();
+      coordinators.set(projectId, coord);
+      const pm = makeMockProjectManager(coordinators);
+
+      const dbTask = schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "Persist Test",
+        message: "persist me",
+        scheduleType: "recurring",
+        cronExpression: "*/5 * * * *",
+        enabled: true,
+      });
+
+      const scheduler = new Scheduler(pm);
+      const task = makeTask({
+        id: dbTask.id,
+        projectId,
+        agentId,
+        label: "Persist Test",
+        message: "persist me",
+        scheduleType: "recurring",
+      });
+
+      scheduler.scheduleTask(task);
+      const job = [...mockJobs.values()][0];
+      const callback = (job as unknown as Record<string, () => void>)._callback;
+      callback();
+
+      // Check that a system message was persisted
+      const { messages } = agentsService.listMessages(projectId, agentId);
+      const systemMsgs = messages.filter((m) => m.role === "system");
+      expect(systemMsgs.length).toBe(1);
+      const content = systemMsgs[0].content as Record<string, unknown>;
+      expect(content.trigger).toBe("scheduled_task");
+      expect(content.taskLabel).toBe("Persist Test");
+    });
+
+    it("marks lastRunAt on the task after firing", () => {
+      const mockAgent = makeMockAgent();
+      const agents = new Map<string, AgentManager>();
+      agents.set(agentId, mockAgent);
+      const coord = makeMockCoordinator(agents);
+      const coordinators = new Map<string, Coordinator>();
+      coordinators.set(projectId, coord);
+      const pm = makeMockProjectManager(coordinators);
+
+      const dbTask = schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "Run Mark",
+        message: "mark me",
+        scheduleType: "recurring",
+        cronExpression: "*/5 * * * *",
+        enabled: true,
+      });
+
+      const scheduler = new Scheduler(pm);
+      const task = makeTask({
+        id: dbTask.id,
+        projectId,
+        agentId,
+        label: "Run Mark",
+        message: "mark me",
+        scheduleType: "recurring",
+      });
+
+      scheduler.scheduleTask(task);
+      const job = [...mockJobs.values()][0];
+      const callback = (job as unknown as Record<string, () => void>)._callback;
+      callback();
+
+      const updated = schedulesService.getScheduledTask(dbTask.id);
+      expect(updated).toBeDefined();
+      expect(updated!.scheduled_tasks.lastRunAt).not.toBeNull();
+    });
+
+    it("disables and cancels a one-time task after firing", () => {
+      const mockAgent = makeMockAgent();
+      const agents = new Map<string, AgentManager>();
+      agents.set(agentId, mockAgent);
+      const coord = makeMockCoordinator(agents);
+      const coordinators = new Map<string, Coordinator>();
+      coordinators.set(projectId, coord);
+      const pm = makeMockProjectManager(coordinators);
+
+      const futureDate = new Date(Date.now() + 60_000).toISOString();
+      const dbTask = schedulesService.createScheduledTask({
+        projectId,
+        agentId,
+        label: "One Shot",
+        message: "once only",
+        scheduleType: "once",
+        scheduledAt: futureDate,
+        enabled: true,
+      });
+
+      const scheduler = new Scheduler(pm);
+      const task = makeTask({
+        id: dbTask.id,
+        projectId,
+        agentId,
+        label: "One Shot",
+        message: "once only",
+        scheduleType: "once",
+        scheduledAt: futureDate,
+      });
+
+      scheduler.scheduleTask(task);
+      const job = [...mockJobs.values()][0];
+      const callback = (job as unknown as Record<string, () => void>)._callback;
+      callback();
+
+      // Task should be disabled in DB
+      const updated = schedulesService.getScheduledTask(dbTask.id);
+      expect(updated!.scheduled_tasks.enabled).toBe(false);
+
+      // Job should have been cancelled (cancelTask called for one-time tasks)
+      expect(job.cancel).toHaveBeenCalled();
+    });
+
+    it("warns but does not throw when coordinator is missing", () => {
+      const pm = makeMockProjectManager(new Map());
+      const scheduler = new Scheduler(pm);
+      const task = makeTask({ projectId: "nonexistent-proj" });
+
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+      scheduler.scheduleTask(task);
+      const job = [...mockJobs.values()][0];
+      const callback = (job as unknown as Record<string, () => void>)._callback;
+
+      // Should not throw
+      callback();
+
+      expect(warnSpy).toHaveBeenCalled();
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toContain("no coordinator");
+      warnSpy.mockRestore();
+    });
+
+    it("warns but does not throw when agent is missing", () => {
+      const coord = makeMockCoordinator(new Map()); // no agents
+      const coordinators = new Map<string, Coordinator>();
+      coordinators.set(projectId, coord);
+      const pm = makeMockProjectManager(coordinators);
+
+      const scheduler = new Scheduler(pm);
+      const task = makeTask({ projectId, agentId: "nonexistent-agent" });
+
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+      scheduler.scheduleTask(task);
+      const job = [...mockJobs.values()][0];
+      const callback = (job as unknown as Record<string, () => void>)._callback;
+
+      callback();
+
+      expect(warnSpy).toHaveBeenCalled();
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toContain("not found");
+      warnSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add route tests for catalog endpoints (categories listing, agents listing/filtering, agent lookup by name, 404 handling)
- Add route tests for settings endpoints (project-doc GET/PUT, project resolution by name, validation)
- Add runtime tests for Scheduler (boot, scheduleTask, cancelTask, cancelAll, fireTask with message persistence and event emission)
- Fix coverage hook to extract line coverage instead of function coverage

## Test plan
- [x] All 723 tests pass (0 failures)
- [x] Line coverage at 90.10%
- [x] Lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)