### PR TITLE
Cross-compile all platform binaries from ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,28 +12,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: macos-14
-            target: bun-darwin-arm64
+          - target: bun-darwin-arm64
             npm-dir: darwin-arm64
-            binary: shire
-          - runner: macos-15
-            target: bun-darwin-x64
+          - target: bun-darwin-x64
             npm-dir: darwin-x64
-            binary: shire
-          - runner: ubuntu-latest
-            target: bun-linux-x64
+          - target: bun-linux-x64
             npm-dir: linux-x64
-            binary: shire
-          - runner: ubuntu-24.04-arm
-            target: bun-linux-arm64
+          - target: bun-linux-arm64
             npm-dir: linux-arm64
-            binary: shire
-          - runner: windows-latest
-            target: bun-windows-x64
+          - target: bun-windows-x64
             npm-dir: win32-x64
-            binary: shire.exe
 
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +32,12 @@ jobs:
         with:
           bun-version: "1.3.11"
 
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-
+
       - uses: actions/setup-node@v4
         with:
           registry-url: "https://registry.npmjs.org"
@@ -49,7 +45,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Build binary and assets
-        run: bun run scripts/build-binaries.ts local
+        run: bun run scripts/build-binaries.ts --target ${{ matrix.target }}
 
       - name: Set version in package.json
         shell: bash

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -3,35 +3,16 @@
  * Build standalone binaries for all supported platforms.
  *
  * Usage:
- *   bun run scripts/build-binaries.ts          # Build all platforms
- *   bun run scripts/build-binaries.ts local     # Build for current platform only
+ *   bun run scripts/build-binaries.ts                          # Build all platforms
+ *   bun run scripts/build-binaries.ts local                    # Build for current platform only
+ *   bun run scripts/build-binaries.ts --target bun-windows-x64 # Build a specific target (cross-compile)
  */
 import tailwind from "bun-plugin-tailwind";
 import { cpSync, mkdirSync } from "fs";
 import { join } from "path";
+import { type Target, TARGETS, getTargetByBunTarget, getCurrentTarget } from "./build-targets";
 
 const ROOT = join(import.meta.dirname, "..");
-
-interface Target {
-  bunTarget: string;
-  npmDir: string;
-  binaryName: string;
-}
-
-const TARGETS: Target[] = [
-  { bunTarget: "bun-darwin-arm64", npmDir: "darwin-arm64", binaryName: "shire" },
-  { bunTarget: "bun-darwin-x64", npmDir: "darwin-x64", binaryName: "shire" },
-  { bunTarget: "bun-linux-x64", npmDir: "linux-x64", binaryName: "shire" },
-  { bunTarget: "bun-linux-arm64", npmDir: "linux-arm64", binaryName: "shire" },
-  { bunTarget: "bun-windows-x64", npmDir: "win32-x64", binaryName: "shire.exe" },
-];
-
-function getCurrentTarget(): Target | undefined {
-  const platform = process.platform;
-  const arch = process.arch;
-  const key = `${platform}-${arch}`;
-  return TARGETS.find((t) => t.npmDir === key);
-}
 
 async function buildBinary(target: Target): Promise<void> {
   const outDir = join(ROOT, "npm", target.npmDir);
@@ -72,9 +53,23 @@ async function buildBinary(target: Target): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  const targetIndex = process.argv.indexOf("--target");
   const localOnly = process.argv.includes("local");
 
-  if (localOnly) {
+  if (targetIndex !== -1) {
+    const bunTarget = process.argv[targetIndex + 1];
+    if (!bunTarget) {
+      console.error("Missing value for --target");
+      process.exit(1);
+    }
+    const target = getTargetByBunTarget(bunTarget);
+    if (!target) {
+      console.error(`Unknown target: ${bunTarget}`);
+      console.error(`Valid targets: ${TARGETS.map((t) => t.bunTarget).join(", ")}`);
+      process.exit(1);
+    }
+    await buildBinary(target);
+  } else if (localOnly) {
     const current = getCurrentTarget();
     if (!current) {
       console.error(`No target for current platform: ${process.platform}-${process.arch}`);

--- a/scripts/build-targets.ts
+++ b/scripts/build-targets.ts
@@ -1,0 +1,22 @@
+export interface Target {
+  bunTarget: string;
+  npmDir: string;
+  binaryName: string;
+}
+
+export const TARGETS: Target[] = [
+  { bunTarget: "bun-darwin-arm64", npmDir: "darwin-arm64", binaryName: "shire" },
+  { bunTarget: "bun-darwin-x64", npmDir: "darwin-x64", binaryName: "shire" },
+  { bunTarget: "bun-linux-x64", npmDir: "linux-x64", binaryName: "shire" },
+  { bunTarget: "bun-linux-arm64", npmDir: "linux-arm64", binaryName: "shire" },
+  { bunTarget: "bun-windows-x64", npmDir: "win32-x64", binaryName: "shire.exe" },
+];
+
+export function getTargetByBunTarget(bunTarget: string): Target | undefined {
+  return TARGETS.find((t) => t.bunTarget === bunTarget);
+}
+
+export function getCurrentTarget(): Target | undefined {
+  const key = `${process.platform}-${process.arch}`;
+  return TARGETS.find((t) => t.npmDir === key);
+}

--- a/src/scripts/build-binaries.test.ts
+++ b/src/scripts/build-binaries.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "bun:test";
+import { TARGETS, getTargetByBunTarget } from "../../scripts/build-targets";
+
+describe("build-binaries target resolution", () => {
+  describe("--target flag", () => {
+    it("resolves bun-windows-x64", () => {
+      const target = getTargetByBunTarget("bun-windows-x64");
+      expect(target).toBeDefined();
+      expect(target!.npmDir).toBe("win32-x64");
+      expect(target!.binaryName).toBe("shire.exe");
+    });
+
+    it("resolves bun-darwin-arm64", () => {
+      const target = getTargetByBunTarget("bun-darwin-arm64");
+      expect(target).toBeDefined();
+      expect(target!.npmDir).toBe("darwin-arm64");
+      expect(target!.binaryName).toBe("shire");
+    });
+
+    it("resolves bun-linux-x64", () => {
+      const target = getTargetByBunTarget("bun-linux-x64");
+      expect(target).toBeDefined();
+      expect(target!.npmDir).toBe("linux-x64");
+    });
+
+    it("resolves bun-linux-arm64", () => {
+      const target = getTargetByBunTarget("bun-linux-arm64");
+      expect(target).toBeDefined();
+      expect(target!.npmDir).toBe("linux-arm64");
+    });
+
+    it("resolves bun-darwin-x64", () => {
+      const target = getTargetByBunTarget("bun-darwin-x64");
+      expect(target).toBeDefined();
+      expect(target!.npmDir).toBe("darwin-x64");
+    });
+
+    it("returns undefined for unknown targets", () => {
+      expect(getTargetByBunTarget("bun-freebsd-x64")).toBeUndefined();
+    });
+  });
+
+  describe("all targets are valid", () => {
+    it("has 5 platform targets", () => {
+      expect(TARGETS).toHaveLength(5);
+    });
+
+    it("only windows target has .exe extension", () => {
+      for (const target of TARGETS) {
+        if (target.bunTarget.includes("windows")) {
+          expect(target.binaryName).toEndWith(".exe");
+        } else {
+          expect(target.binaryName).not.toEndWith(".exe");
+        }
+      }
+    });
+
+    it("every bunTarget starts with bun-", () => {
+      for (const target of TARGETS) {
+        expect(target.bunTarget).toStartWith("bun-");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Switch all 5 release build runners from native (macOS/Windows/ARM) to `ubuntu-latest` using Bun's cross-compilation
- Add `--target` flag to `scripts/build-binaries.ts` for building specific cross-compilation targets
- Extract target definitions into shared `scripts/build-targets.ts` module
- Add Bun dependency caching to speed up `bun install`

## Motivation
The Windows `windows-latest` runner was the release workflow bottleneck (P0). macOS runners also cost 10x more than Linux. Bun has supported cross-compilation since v1.1.5, so native runners are unnecessary.

## Test plan
- [x] All 928 tests pass
- [x] Typecheck, lint, format all clean
- [x] New tests for target resolution logic
- [ ] Verify cross-compiled binaries are produced correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)