### PR TITLE
Replace useEffect anti-patterns with idiomatic React

### DIFF
--- a/src/frontend/components/CatalogBrowser.tsx
+++ b/src/frontend/components/CatalogBrowser.tsx
@@ -22,12 +22,14 @@ export default function CatalogBrowser({ open, onClose, onAdd }: CatalogBrowserP
   const [search, setSearch] = React.useState("");
   const [selectedCategory, setSelectedCategory] = React.useState<string | null>(null);
 
-  React.useEffect(() => {
+  const [prevOpen, setPrevOpen] = React.useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
     if (open) {
       setSearch("");
       setSelectedCategory(null);
     }
-  }, [open]);
+  }
 
   const filteredAgents = React.useMemo(() => {
     let result = agents;

--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -266,8 +266,9 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
   const hasMore = hasNextPage ?? false;
   const loadingMore = isFetchingNextPage;
 
+  const streamingText = externalStreamingText ?? "";
+
   const [input, setInput] = React.useState("");
-  const [streamingText, setStreamingText] = React.useState("");
   const [pendingFiles, setPendingFiles] = React.useState<PendingFile[]>([]);
   const [uploadError, setUploadError] = React.useState<string | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
@@ -277,18 +278,12 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
   const prevScrollHeightRef = React.useRef(0);
   const initialScrollDone = React.useRef(false);
 
-  // Reset state when switching agents
+  // Reset scroll tracking when switching agents
   React.useEffect(() => {
-    setStreamingText("");
     initialScrollDone.current = false;
     prevMessagesLengthRef.current = 0;
     prevScrollHeightRef.current = 0;
   }, [agent.id]);
-
-  // Sync streaming text from parent (via WebSocket subscription)
-  React.useEffect(() => {
-    setStreamingText(externalStreamingText ?? "");
-  }, [externalStreamingText]);
 
   // Auto-scroll to bottom on initial load and new messages
   React.useEffect(() => {

--- a/src/frontend/components/ProjectDashboard.tsx
+++ b/src/frontend/components/ProjectDashboard.tsx
@@ -69,10 +69,6 @@ export default function ProjectDashboard() {
   const [deleteTarget, setDeleteTarget] = React.useState<Project | null>(null);
   const [restartingId, setRestartingId] = React.useState<string | null>(null);
 
-  React.useEffect(() => {
-    setRestartingId(null);
-  }, [projects]);
-
   const nameValid = PROJECT_NAME_REGEX.test(projectName);
 
   const handleCreate = () => {
@@ -163,7 +159,9 @@ export default function ProjectDashboard() {
                               disabled={restartingId === project.id}
                               onClick={() => {
                                 setRestartingId(project.id);
-                                restartProject.mutate(project.id);
+                                restartProject.mutate(project.id, {
+                                  onSettled: () => setRestartingId(null),
+                                });
                               }}
                             >
                               {restartingId === project.id ? "Restarting..." : "Restart"}

--- a/src/frontend/components/ProjectDetailsPage.tsx
+++ b/src/frontend/components/ProjectDetailsPage.tsx
@@ -21,20 +21,23 @@ export default function ProjectDetailsPage() {
   const isSavingDoc = saveDoc.isPending;
 
   const [nameValue, setNameValue] = React.useState(projectName);
+  const [prevProjectName, setPrevProjectName] = React.useState(projectName);
+  if (projectName !== prevProjectName) {
+    setPrevProjectName(projectName);
+    setNameValue(projectName);
+  }
+
   const [docValue, setDocValue] = React.useState(project_doc);
+  const [prevProjectDoc, setPrevProjectDoc] = React.useState(project_doc);
+  if (project_doc !== prevProjectDoc) {
+    setPrevProjectDoc(project_doc);
+    setDocValue(project_doc);
+  }
 
   const slugRegex = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
   const isValidSlug = nameValue.length >= 1 && nameValue.length <= 63 && slugRegex.test(nameValue);
   const nameDirty = nameValue !== projectName;
   const docDirty = docValue !== project_doc;
-
-  React.useEffect(() => {
-    setNameValue(projectName);
-  }, [projectName]);
-
-  React.useEffect(() => {
-    setDocValue(project_doc);
-  }, [project_doc]);
 
   const handleRename = () => {
     renameProject.mutate(nameValue);

--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -12,7 +12,7 @@ import {
   useCreateAgent,
   useUpdateAgent,
   useUpdateAgentCache,
-  useCatalogAgent,
+  fetchCatalogAgent,
   findDefaultAgent,
 } from "../hooks";
 import { useSubscription, type AgentListWsEvent } from "../lib/ws";
@@ -43,27 +43,25 @@ export default function ProjectLayout() {
   const [currentAgent, setCurrentAgent] = React.useState<Agent | null>(null);
   const [catalogOpen, setCatalogOpen] = React.useState(false);
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
-  const [selectedCatalogName, setSelectedCatalogName] = React.useState<string | undefined>(
-    undefined,
-  );
-
-  const { data: catalogSelectedAgent } = useCatalogAgent(selectedCatalogName);
 
   // Close mobile sidebar when agent changes
-  React.useEffect(() => {
+  const [prevSelectedAgentId, setPrevSelectedAgentId] = React.useState(selectedAgentId);
+  if (selectedAgentId !== prevSelectedAgentId) {
+    setPrevSelectedAgentId(selectedAgentId);
     setSidebarOpen(false);
-  }, [selectedAgentId]);
+  }
 
-  React.useEffect(() => {
-    if (catalogSelectedAgent) {
-      setCatalogOpen(false);
+  const handleCatalogAdd = async (name: string) => {
+    setCatalogOpen(false);
+    try {
+      const agent = await fetchCatalogAgent(name);
       setCurrentAgent({
         id: "",
-        name: catalogSelectedAgent.name,
-        description: catalogSelectedAgent.description,
-        harness: catalogSelectedAgent.harness,
-        model: catalogSelectedAgent.model,
-        systemPrompt: catalogSelectedAgent.systemPrompt,
+        name: agent.name,
+        description: agent.description,
+        harness: agent.harness,
+        model: agent.model,
+        systemPrompt: agent.systemPrompt,
         skills: [],
         status: "idle",
         busy: false,
@@ -73,9 +71,10 @@ export default function ProjectLayout() {
       setEditingAgent(null);
       setFormTitle("New Agent from Catalog");
       setFormOpen(true);
-      setSelectedCatalogName(undefined);
+    } catch {
+      setCatalogOpen(true);
     }
-  }, [catalogSelectedAgent]);
+  };
 
   // Subscribe to project-level agent list updates
   useSubscription<AgentListWsEvent>(projectId ? `project:${projectId}:agents` : null, (event) => {
@@ -177,7 +176,7 @@ export default function ProjectLayout() {
       <CatalogBrowser
         open={catalogOpen}
         onClose={() => setCatalogOpen(false)}
-        onAdd={(name) => setSelectedCatalogName(name)}
+        onAdd={handleCatalogAdd}
       />
     </div>
   );

--- a/src/frontend/hooks/catalog.ts
+++ b/src/frontend/hooks/catalog.ts
@@ -31,3 +31,9 @@ export function useCatalogAgent(name: string | undefined) {
     enabled: !!name,
   });
 }
+
+export async function fetchCatalogAgent(name: string): Promise<CatalogAgent> {
+  return unwrap(
+    await api.catalog.agents[":name"].$get({ param: { name } }),
+  ) as unknown as CatalogAgent;
+}

--- a/src/frontend/test/ProjectDashboard.test.tsx
+++ b/src/frontend/test/ProjectDashboard.test.tsx
@@ -220,6 +220,12 @@ describe("ProjectDashboard", () => {
   });
 
   it("shows Restarting... text while restart is in progress", async () => {
+    // Keep the restart request pending so onSettled doesn't fire before assertion
+    server.use(
+      http.post("*/api/projects/:id/restart", () => {
+        return new Promise(() => {});
+      }),
+    );
     setProjects([{ id: "p8", name: "restarting-proj", status: "error" }]);
     renderWithProviders(<ProjectDashboard />);
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- **ChatPanel**: remove `streamingText` state + sync effect, derive inline as `externalStreamingText ?? ""`
- **ProjectDetailsPage**: replace two prop→state sync effects with render-time "store previous props" pattern
- **ProjectDashboard**: move `setRestartingId(null)` from data-change effect to `onSettled` mutation callback
- **CatalogBrowser**: replace reset-on-open effect with render-time previous-open tracking
- **ProjectLayout**: replace `useCatalogAgent` hook + effect chain with direct async `fetchCatalogAgent` call in event handler; replace sidebar-close effect with render-time pattern

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — all 941 tests pass
- [ ] Smoke test: switch agents (streaming resets), edit project details (form syncs on external changes), restart a project (loading indicator clears), open catalog browser (search resets), add agent from catalog (form opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)