### PR TITLE
Move test coverage check to pre-commit hook and CI

### DIFF
--- a/.claude/hooks/check-coverage.sh
+++ b/.claude/hooks/check-coverage.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# PreToolUse hook: block git commit if coverage thresholds are not met.
+# Enforce test coverage thresholds (used by pre-commit hook, CI, and Claude hooks).
 # - Overall function and line coverage must be >= 80%
 # - Per-file line coverage must be >= 80% (except skipped files)
 set -euo pipefail
 
-cd "$CLAUDE_PROJECT_DIR"
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 
 THRESHOLD=80
 
@@ -28,7 +28,7 @@ trap 'rm -f "$TMPFILE"' EXIT
 NO_COLOR=1 bun test --coverage > "$TMPFILE" 2>&1 || true
 
 # Strip ANSI escape codes
-sed -i '' 's/\x1b\[[0-9;]*m//g' "$TMPFILE" 2>/dev/null || sed -i 's/\x1b\[[0-9;]*m//g' "$TMPFILE"
+perl -pi -e 's/\x1b\[[0-9;]*m//g' "$TMPFILE"
 
 # Verify the coverage table exists
 if ! grep -q "All files" "$TMPFILE"; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,20 +12,6 @@
           }
         ]
       }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "if": "Bash(git commit*)",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-coverage.sh",
-            "timeout": 120,
-            "statusMessage": "Running test coverage check..."
-          }
-        ]
-      }
     ]
   }
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Git pre-commit hook: enforce test coverage thresholds
+exec "$(git rev-parse --show-toplevel)/.claude/hooks/check-coverage.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
 
       - run: bun run typecheck
 
-      - run: bun test
+      - name: Run tests with coverage check
+        run: bash .claude/hooks/check-coverage.sh
 
       - name: Verify binary compilation
         run: bun build src/cli.ts --compile --outfile /tmp/shire-test

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:migrate": "bunx drizzle-kit migrate",
     "db:studio": "bunx drizzle-kit studio",
     "catalog:sync": "bun run src/scripts/catalog-sync.ts",
+    "prepare": "git config core.hooksPath .githooks",
     "test": "bun test",
     "test:watch": "bun test --watch src/",
     "lint": "eslint src/",


### PR DESCRIPTION
## Summary
- Moved test coverage enforcement from a Claude Code `PreToolUse` hook to a git pre-commit hook (`.githooks/pre-commit`) and CI workflow
- Made `check-coverage.sh` portable across macOS and Linux (env var fallback, `perl` instead of `sed -i`)
- Added `prepare` script in `package.json` to auto-configure `core.hooksPath` on `bun install`
- Coverage is now enforced for all developers, not just Claude Code users

## Test plan
- [x] `check-coverage.sh` runs successfully standalone
- [x] All lint, format, and typecheck pass
- [ ] CI runs coverage check (replaces bare `bun test`)
- [ ] Pre-commit hook triggers on `git commit` after `bun install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)