### PR TITLE
Add OpenAI Codex harness via @openai/codex-sdk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Shire is an AI agent orchestration platform. Users create projects, add agents (
 - **Backend**: Hono (HTTP framework) + Drizzle ORM + SQLite
 - **Frontend**: React 19 + React Router 7 + Radix UI/shadcn + Tailwind CSS 4 + TanStack Query
 - **Bundler**: Bun fullstack (dev server with HMR) + bun-plugin-tailwind
-- **Agent harnesses**: Claude Code SDK (`@anthropic-ai/claude-agent-sdk`), OpenCode SDK (`@opencode-ai/sdk`), Pi Agent SDK
+- **Agent harnesses**: Claude Code SDK (`@anthropic-ai/claude-agent-sdk`), OpenCode SDK (`@opencode-ai/sdk`), Pi Agent SDK, Codex SDK (`@openai/codex-sdk`)
 - **Testing**: Bun test + Testing Library + happy-dom + MSW (unified for backend and frontend)
 - **Validation**: Zod (API input), TypeScript strict mode throughout
 
@@ -55,7 +55,7 @@ Three-tier orchestration hierarchy:
 2. **Coordinator** — per-project: manages AgentManagers, routes inter-agent messages, maintains peers.yaml
 3. **AgentManager** — per-agent: manages harness process lifecycle, message queue (inbox/outbox), streaming, auto-restart (up to 3 times)
 
-Harnesses (`src/runtime/harness/`) are adapters for different AI backends (Claude Code, OpenCode, Pi). They implement a common interface: `start`, `sendMessage`, `interrupt`, `clearSession`, `isProcessing`.
+Harnesses (`src/runtime/harness/`) are adapters for different AI backends (Claude Code, OpenCode, Pi, Codex). They implement a common interface: `start`, `sendMessage`, `interrupt`, `clearSession`, `isProcessing`.
 
 ### Data Layer (`src/db/schema.ts`, `src/services/`)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://github.com/user-attachments/assets/04056f61-d2e7-4eb8-b0e4-48a342b298d3
 
 Most AI agent tools follow the same pattern — you give an instruction, an agent executes it, you get the output. The agent disappears. Next time, you start from scratch. Shire is different. Your agents persist between sessions. They communicate with each other autonomously. They build on yesterday's work. You give feedback, iterate, adjust direction — like working with a real team.
 
-- **Works with any model** — Not locked to one AI provider. Supports Claude Code, OpenCode, and Pi Agent. Shire is the infrastructure layer — bring whatever model fits your workflow.
+- **Works with any model** — Not locked to one AI provider. Supports Claude Code, OpenCode, Pi Agent, and Codex. Shire is the infrastructure layer — bring whatever model fits your workflow.
 - **Autonomous agent communication** — Agents discover peers and collaborate on their own — no orchestrator required. Direct messaging, shared context, real teamwork between agents.
 - **Community catalog** — Browse and deploy from a community-maintained library of pre-built agent templates. Powered by [agency-agents](https://github.com/msitarzewski/agency-agents). Get a capable team running in seconds.
 - **Shared drive** — A communal filesystem across all agents for collaborative work on shared artifacts.
@@ -36,7 +36,7 @@ Most AI agent tools follow the same pattern — you give an instruction, an agen
 | Backend         | Hono, Drizzle ORM, SQLite                                                   |
 | Frontend        | React 19, React Router 7, shadcn/ui (Radix), Tailwind CSS 4, TanStack Query |
 | Bundler         | Bun (fullstack dev server + production builds)                              |
-| Agent Harnesses | Claude Code SDK, OpenCode SDK, Pi Agent SDK                                 |
+| Agent Harnesses | Claude Code SDK, OpenCode SDK, Pi Agent SDK, Codex SDK                      |
 | Scheduling      | node-schedule (cron-based)                                                  |
 | Testing         | Bun test + Testing Library + happy-dom + MSW                                |
 | Validation      | Zod, TypeScript strict mode                                                 |
@@ -117,6 +117,20 @@ You can also store keys in `~/.pi/agent/auth.json` (takes precedence over env va
 
 See the [Pi Agent docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md) for the full list of supported providers and subscription services.
 
+#### Codex
+
+Install the [Codex CLI](https://github.com/openai/codex) and set your OpenAI API key:
+
+```bash
+# Install Codex
+npm install -g @openai/codex
+
+# Set the API key
+export OPENAI_API_KEY=sk-...
+```
+
+Codex uses OpenAI models (e.g. `o4-mini`, `gpt-4.1`, `codex-mini`). See the [Codex docs](https://developers.openai.com/codex/cli) for more details.
+
 ## Getting Started (Development)
 
 ### Prerequisites
@@ -124,6 +138,7 @@ See the [Pi Agent docs](https://github.com/badlogic/pi-mono/blob/main/packages/c
 - [Bun](https://bun.sh) (v1.3.11+)
 - [Claude Code](https://claude.ai/download) (only if using the `claude_code` harness)
 - [OpenCode](https://opencode.ai) (only if using the `opencode` harness)
+- [Codex CLI](https://github.com/openai/codex) (only if using the `codex` harness)
 
 ### Quick Start
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@hono/zod-validator": "^0.7.6",
         "@mariozechner/pi-ai": "^0.63.1",
         "@mariozechner/pi-coding-agent": "^0.63.1",
+        "@openai/codex-sdk": "^0.118.0",
         "@opencode-ai/sdk": "^1.3.13",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -359,6 +360,22 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@openai/codex": ["@openai/codex@0.118.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.118.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.118.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.118.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.118.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.118.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.118.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-oJhNOsP/Vu7DBUhodpP15z60cCZv3sKORqUn1+pepleqSTmc0zXJZSjz6fQOLzny9Ra6sRcvprFFKmQ3Q6+E6w=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.118.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sxq7Q2q9YiJN1wNrzvFRCC5oQKXPVUvu9Ejg6SI/CvyyI9YdtyLTO633wQJALGB7XQfT+3tyM5nNBivnSzLA3Q=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.118.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-iIvrqzsh1iJmVfqyYwLZBiuh0MkN1Suqniz9hBfmRmE6txMWhRVfigb9SMBiOkfCW1C4sjBwLCsCSzg11rvppQ=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.118.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-YKWmIqLBu9mmBhN3JHQNkLzk0BtAtV6LBPvhnL5eeHkNrChvA6PKrhsjy0O7wvRkiByZY/1dD14qVdAUfxcbiA=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.118.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-vzU2d/gwAmZbf/DnwVzfQiNN3Ri04XpaZiJkHElIvGoqFbdrxRQFYTtslGDISYIO3o+POADZcFZIfamFsZj9yQ=="],
+
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.118.0", "", { "dependencies": { "@openai/codex": "0.118.0" } }, "sha512-cMisxx4CGQL44yv2USqdgcPhxPOhv227+CJiF9snn2X7nL+6wary4g38OknornjlrPob7LyzdIFB7dXqjkXKxg=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.118.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-AU7GPVFqd0Ml3P2OXfy6K6TONcxfCZLUh1zjYkkoPGWJ4A3BVMkOmMP9CAdSiQsnU/RQfdV/9IGqo1xwUQDdjA=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.118.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-9vKW1ANQxIUsLpiY0VsOM+1avZjqxDZgqgxKABJHWRlLMuaSykwXexf8Hqq+BnYFfmn0d6MjxTuE1UtVvg9caw=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.3.13", "", {}, "sha512-/M6HlNnba+xf1EId6qFb2tG0cvq0db3PCQDug1glrf8wYOU57LYNF8WvHX9zoDKPTMv0F+O4pcP/8J+WvDaxHA=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@hono/zod-validator": "^0.7.6",
     "@mariozechner/pi-ai": "^0.63.1",
     "@mariozechner/pi-coding-agent": "^0.63.1",
+    "@openai/codex-sdk": "^0.118.0",
     "@opencode-ai/sdk": "^1.3.13",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/frontend/components/AgentForm.tsx
+++ b/src/frontend/components/AgentForm.tsx
@@ -160,7 +160,8 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
             <Select
               value={harness}
               onValueChange={(v) => {
-                if (v === "claude_code" || v === "pi" || v === "opencode") setHarness(v);
+                if (v === "claude_code" || v === "pi" || v === "opencode" || v === "codex")
+                  setHarness(v);
               }}
             >
               <SelectTrigger>
@@ -168,6 +169,7 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="claude_code">Claude Code</SelectItem>
+                <SelectItem value="codex">Codex</SelectItem>
                 <SelectItem value="opencode">OpenCode</SelectItem>
                 <SelectItem value="pi">Pi</SelectItem>
               </SelectContent>
@@ -182,13 +184,20 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
               placeholder={
                 harness === "opencode"
                   ? "e.g. anthropic/claude-sonnet-4-6"
-                  : "e.g. claude-sonnet-4-6"
+                  : harness === "codex"
+                    ? "e.g. o4-mini"
+                    : "e.g. claude-sonnet-4-6"
               }
             />
             {harness === "opencode" && (
               <p className="text-xs text-muted-foreground">
                 OpenCode requires provider/model format (e.g. anthropic/claude-sonnet-4-6,
                 openrouter/google/gemini-2.5-pro)
+              </p>
+            )}
+            {harness === "codex" && (
+              <p className="text-xs text-muted-foreground">
+                Codex uses OpenAI models (e.g. o4-mini, gpt-4.1, codex-mini)
               </p>
             )}
           </div>

--- a/src/frontend/components/types.ts
+++ b/src/frontend/components/types.ts
@@ -4,7 +4,7 @@ export interface Project {
   status: "starting" | "running" | "error";
 }
 
-export type HarnessType = "pi" | "claude_code" | "opencode";
+export type HarnessType = "pi" | "claude_code" | "opencode" | "codex";
 
 export type AgentStatus = "created" | "starting" | "bootstrapping" | "active" | "idle" | "crashed";
 
@@ -141,5 +141,7 @@ export const harnessLabel = (harness: HarnessType): string => {
       return "Pi";
     case "opencode":
       return "OpenCode";
+    case "codex":
+      return "Codex";
   }
 };

--- a/src/frontend/hooks/agents.ts
+++ b/src/frontend/hooks/agents.ts
@@ -56,7 +56,7 @@ export function useAgentDetail(projectId: string | undefined, agentId: string | 
 interface AgentMutationData {
   name: string;
   description?: string;
-  harness?: "claude_code" | "pi" | "opencode";
+  harness?: "claude_code" | "pi" | "opencode" | "codex";
   model?: string;
   systemPrompt?: string;
   skills?: Skill[];

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -34,7 +34,7 @@ export const agentRoutes = new Hono<AppEnv>()
       z.object({
         name: z.string(),
         description: z.string().optional(),
-        harness: z.enum(["claude_code", "pi", "opencode"]).optional(),
+        harness: z.enum(["claude_code", "pi", "opencode", "codex"]).optional(),
         model: z.string().optional(),
         systemPrompt: z.string().optional(),
         skills: z.array(skillSchema).optional(),
@@ -67,7 +67,7 @@ export const agentRoutes = new Hono<AppEnv>()
       z.object({
         name: z.string().optional(),
         description: z.string().optional(),
-        harness: z.enum(["claude_code", "pi", "opencode"]).optional(),
+        harness: z.enum(["claude_code", "pi", "opencode", "codex"]).optional(),
         model: z.string().optional(),
         systemPrompt: z.string().optional(),
         skills: z.array(skillSchema).optional(),

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -296,7 +296,10 @@ export class AgentManager {
     if (!agent) throw new Error("Agent not found in DB");
 
     const harnessType: HarnessType =
-      agent.harness === "pi" || agent.harness === "claude_code" || agent.harness === "opencode"
+      agent.harness === "pi" ||
+      agent.harness === "claude_code" ||
+      agent.harness === "opencode" ||
+      agent.harness === "codex"
         ? agent.harness
         : "claude_code";
     const model = agent.model ?? "claude-sonnet-4-6";

--- a/src/runtime/harness/codex-harness.test.ts
+++ b/src/runtime/harness/codex-harness.test.ts
@@ -1,0 +1,661 @@
+import { describe, test, expect, mock } from "bun:test";
+import { CodexHarness } from "./codex-harness";
+import type { AgentEvent, HarnessConfig } from "./types";
+import type { Codex, ThreadEvent, ThreadOptions } from "@openai/codex-sdk";
+
+const baseConfig: HarnessConfig = {
+  model: "o4-mini",
+  systemPrompt: "You are a helpful assistant.",
+  cwd: "/workspace",
+};
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/** Build a mock Thread whose runStreamed yields the given events. */
+function createMockThread(eventsByTurn: ThreadEvent[][]) {
+  let turnIndex = 0;
+  const runStreamed = mock(async (_input: unknown, _opts?: unknown) => {
+    const events = eventsByTurn[turnIndex] ?? [];
+    turnIndex++;
+    return {
+      events: (async function* () {
+        for (const e of events) yield e;
+      })(),
+    };
+  });
+  return {
+    runStreamed,
+    get id() {
+      return "thread-abc";
+    },
+  };
+}
+
+type MockThread = ReturnType<typeof createMockThread>;
+
+/** Build a mock Codex whose startThread / resumeThread return the given thread. */
+function createMockCodex(thread: MockThread) {
+  const startThread = mock((_opts?: ThreadOptions) => thread);
+  const resumeThread = mock((_id: string, _opts?: ThreadOptions) => thread);
+  return { startThread, resumeThread };
+}
+
+type MockCodex = ReturnType<typeof createMockCodex>;
+
+type CodexFactory = ConstructorParameters<typeof CodexHarness>[0];
+
+function factory(codex: MockCodex): NonNullable<CodexFactory> {
+  return () => codex as unknown as Codex;
+}
+
+// ---------------------------------------------------------------------------
+// Event builders
+// ---------------------------------------------------------------------------
+
+function threadStarted(id = "thread-abc"): ThreadEvent {
+  return { type: "thread.started", thread_id: id };
+}
+
+function turnStarted(): ThreadEvent {
+  return { type: "turn.started" };
+}
+
+function turnCompleted(tokens = 100): ThreadEvent {
+  return {
+    type: "turn.completed",
+    usage: { input_tokens: tokens, cached_input_tokens: 0, output_tokens: tokens },
+  };
+}
+
+function turnFailed(message = "something went wrong"): ThreadEvent {
+  return { type: "turn.failed", error: { message } };
+}
+
+function agentMessage(text: string, id = "msg-1"): ThreadEvent {
+  return { type: "item.completed", item: { id, type: "agent_message", text } };
+}
+
+function commandStarted(command: string, id = "cmd-1"): ThreadEvent {
+  return {
+    type: "item.started",
+    item: {
+      id,
+      type: "command_execution",
+      command,
+      aggregated_output: "",
+      status: "in_progress",
+    },
+  };
+}
+
+function commandCompleted(
+  command: string,
+  output: string,
+  exitCode = 0,
+  id = "cmd-1",
+): ThreadEvent {
+  return {
+    type: "item.completed",
+    item: {
+      id,
+      type: "command_execution",
+      command,
+      aggregated_output: output,
+      exit_code: exitCode,
+      status: exitCode === 0 ? "completed" : "failed",
+    },
+  };
+}
+
+function fileChangeStarted(id = "fc-1"): ThreadEvent {
+  return {
+    type: "item.started",
+    item: { id, type: "file_change", changes: [], status: "completed" },
+  };
+}
+
+function fileChangeCompleted(
+  changes: Array<{ path: string; kind: "add" | "delete" | "update" }>,
+  id = "fc-1",
+): ThreadEvent {
+  return {
+    type: "item.completed",
+    item: { id, type: "file_change", changes, status: "completed" },
+  };
+}
+
+function mcpToolStarted(server: string, tool: string, id = "mcp-1"): ThreadEvent {
+  return {
+    type: "item.started",
+    item: {
+      id,
+      type: "mcp_tool_call",
+      server,
+      tool,
+      arguments: {},
+      status: "in_progress",
+    },
+  };
+}
+
+function mcpToolCompleted(server: string, tool: string, result: string, id = "mcp-1"): ThreadEvent {
+  return {
+    type: "item.completed",
+    item: {
+      id,
+      type: "mcp_tool_call",
+      server,
+      tool,
+      arguments: {},
+      result: {
+        content: [{ type: "text", text: result }],
+        structured_content: null,
+      },
+      status: "completed",
+    },
+  };
+}
+
+function errorItem(message: string, id = "err-1"): ThreadEvent {
+  return { type: "item.completed", item: { id, type: "error", message } };
+}
+
+function streamError(message: string): ThreadEvent {
+  return { type: "error", message };
+}
+
+/** A basic successful turn: thread started, turn started, agent message, turn completed. */
+function basicTurnEvents(text = "Hello", threadId = "thread-abc"): ThreadEvent[] {
+  return [threadStarted(threadId), turnStarted(), agentMessage(text), turnCompleted()];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CodexHarness", () => {
+  // -- Lifecycle --
+
+  test("getSessionId() returns null before any message", async () => {
+    const thread = createMockThread([]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    await harness.start(baseConfig);
+    expect(harness.getSessionId()).toBeNull();
+  });
+
+  test("getSessionId() returns resume id after start", async () => {
+    const thread = createMockThread([]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    await harness.start({ ...baseConfig, resume: "thread-existing" });
+    expect(harness.getSessionId()).toBe("thread-existing");
+  });
+
+  test("isProcessing() returns false initially", () => {
+    const thread = createMockThread([]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    expect(harness.isProcessing()).toBe(false);
+  });
+
+  // -- sendMessage basics --
+
+  test("sendMessage() creates thread with correct options", async () => {
+    const thread = createMockThread([basicTurnEvents()]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hello");
+
+    expect(codex.startThread).toHaveBeenCalledTimes(1);
+    const opts = (codex.startThread as ReturnType<typeof mock>).mock.calls[0][0] as ThreadOptions;
+    expect(opts.model).toBe("o4-mini");
+    expect(opts.workingDirectory).toBe("/workspace");
+    expect(opts.sandboxMode).toBe("danger-full-access");
+    expect(opts.skipGitRepoCheck).toBe(true);
+  });
+
+  test("sendMessage() passes prompt text to runStreamed", async () => {
+    const thread = createMockThread([basicTurnEvents()]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hello");
+
+    const call = (thread.runStreamed as ReturnType<typeof mock>).mock.calls[0];
+    const prompt = call[0] as string;
+    expect(prompt).toContain("Hello");
+  });
+
+  test("sendMessage() prefixes from agent name", async () => {
+    const thread = createMockThread([basicTurnEvents()]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hello", "agent-1");
+
+    const call = (thread.runStreamed as ReturnType<typeof mock>).mock.calls[0];
+    const prompt = call[0] as string;
+    expect(prompt).toContain('[Message from agent "agent-1"]');
+    expect(prompt).toContain("Hello");
+  });
+
+  // -- Text events --
+
+  test("sendMessage() emits text_delta for agent_message items", async () => {
+    const thread = createMockThread([basicTurnEvents("Hello world")]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const delta = events.find((e) => e.type === "text_delta");
+    expect(delta).toBeDefined();
+    expect(delta!.payload.delta).toBe("Hello world");
+  });
+
+  test("sendMessage() emits text and turn_complete on turn.completed", async () => {
+    const thread = createMockThread([basicTurnEvents("Full response")]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain("text");
+    expect(types).toContain("turn_complete");
+  });
+
+  test("sendMessage() captures thread_id as session_id in turn_complete", async () => {
+    const thread = createMockThread([basicTurnEvents("Hi")]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const tc = events.find((e) => e.type === "turn_complete");
+    expect(tc!.payload.session_id).toBe("thread-abc");
+  });
+
+  test("getSessionId() returns thread_id after sendMessage", async () => {
+    const thread = createMockThread([basicTurnEvents()]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    expect(harness.getSessionId()).toBe("thread-abc");
+  });
+
+  // -- Tool events --
+
+  test("sendMessage() emits tool_use started for command_execution", async () => {
+    const evts: ThreadEvent[] = [
+      threadStarted(),
+      turnStarted(),
+      commandStarted("ls -la"),
+      commandCompleted("ls -la", "file1\nfile2"),
+      agentMessage("Listed files"),
+      turnCompleted(),
+    ];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("run ls");
+
+    const toolStart = events.find((e) => e.type === "tool_use" && e.payload.status === "started");
+    expect(toolStart).toBeDefined();
+    expect(toolStart!.type).toBe("tool_use");
+    if (toolStart!.type === "tool_use") {
+      expect(toolStart!.payload.tool).toBe("command_execution");
+      expect(toolStart!.payload.tool_use_id).toBe("cmd-1");
+    }
+  });
+
+  test("sendMessage() emits tool_result for completed command_execution", async () => {
+    const evts: ThreadEvent[] = [
+      threadStarted(),
+      turnStarted(),
+      commandStarted("echo hello"),
+      commandCompleted("echo hello", "hello\n", 0),
+      agentMessage("Done"),
+      turnCompleted(),
+    ];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const result = events.find((e) => e.type === "tool_result");
+    expect(result).toBeDefined();
+    expect(result!.payload.tool_use_id).toBe("cmd-1");
+    expect(result!.payload.output).toBe("hello\n");
+    expect(result!.payload.is_error).toBe(false);
+  });
+
+  test("sendMessage() marks failed command as is_error", async () => {
+    const evts: ThreadEvent[] = [
+      threadStarted(),
+      turnStarted(),
+      commandStarted("bad-cmd"),
+      commandCompleted("bad-cmd", "not found", 127),
+      agentMessage("Command failed"),
+      turnCompleted(),
+    ];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const result = events.find((e) => e.type === "tool_result");
+    expect(result!.payload.is_error).toBe(true);
+  });
+
+  test("sendMessage() emits tool_use for mcp_tool_call", async () => {
+    const evts: ThreadEvent[] = [
+      threadStarted(),
+      turnStarted(),
+      mcpToolStarted("fs", "readFile"),
+      mcpToolCompleted("fs", "readFile", "file contents"),
+      agentMessage("Read the file"),
+      turnCompleted(),
+    ];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const toolStart = events.find((e) => e.type === "tool_use" && e.payload.status === "started");
+    expect(toolStart!.type).toBe("tool_use");
+    if (toolStart!.type === "tool_use") {
+      expect(toolStart!.payload.tool).toBe("readFile");
+      expect(toolStart!.payload.tool_use_id).toBe("mcp-1");
+    }
+  });
+
+  test("sendMessage() emits tool_result for completed mcp_tool_call", async () => {
+    const evts: ThreadEvent[] = [
+      threadStarted(),
+      turnStarted(),
+      mcpToolStarted("fs", "readFile"),
+      mcpToolCompleted("fs", "readFile", "file contents"),
+      agentMessage("Done"),
+      turnCompleted(),
+    ];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const result = events.find((e) => e.type === "tool_result");
+    expect(result!.payload.output).toBe("file contents");
+    expect(result!.payload.is_error).toBe(false);
+  });
+
+  test("sendMessage() emits tool_use and tool_result for file_change", async () => {
+    const evts: ThreadEvent[] = [
+      threadStarted(),
+      turnStarted(),
+      fileChangeStarted(),
+      fileChangeCompleted([{ path: "src/index.ts", kind: "update" }]),
+      agentMessage("Updated file"),
+      turnCompleted(),
+    ];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const toolStart = events.find((e) => e.type === "tool_use" && e.payload.status === "started");
+    expect(toolStart).toBeDefined();
+    if (toolStart!.type === "tool_use") {
+      expect(toolStart!.payload.tool).toBe("file_change");
+      expect(toolStart!.payload.tool_use_id).toBe("fc-1");
+    }
+    const result = events.find((e) => e.type === "tool_result");
+    expect(result!.payload.tool_use_id).toBe("fc-1");
+    expect(result!.payload.output).toContain("src/index.ts");
+  });
+
+  // -- Error events --
+
+  test("sendMessage() emits error from turn.failed", async () => {
+    const evts: ThreadEvent[] = [threadStarted(), turnStarted(), turnFailed("API error")];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const err = events.find((e) => e.type === "error");
+    expect(err!.payload.message).toContain("API error");
+    const tc = events.find((e) => e.type === "turn_complete");
+    expect(tc).toBeDefined();
+  });
+
+  test("sendMessage() emits error and turn_complete from stream error event", async () => {
+    const evts: ThreadEvent[] = [threadStarted(), streamError("connection lost")];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const err = events.find((e) => e.type === "error");
+    expect(err!.payload.message).toContain("connection lost");
+    const tc = events.find((e) => e.type === "turn_complete");
+    expect(tc).toBeDefined();
+  });
+
+  test("sendMessage() emits error and turn_complete on thrown exception", async () => {
+    const thread = createMockThread([]);
+    // Override runStreamed to throw
+    thread.runStreamed = mock(async () => {
+      throw new Error("SDK crash");
+    });
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain("error");
+    expect(types).toContain("turn_complete");
+    const errorIdx = types.indexOf("error");
+    const tcIdx = types.indexOf("turn_complete");
+    expect(tcIdx).toBeGreaterThan(errorIdx);
+  });
+
+  test("sendMessage() emits error item as AgentEvent error", async () => {
+    const evts: ThreadEvent[] = [
+      threadStarted(),
+      turnStarted(),
+      errorItem("rate limit exceeded"),
+      turnCompleted(),
+    ];
+    const thread = createMockThread([evts]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.sendMessage("test");
+
+    const err = events.find((e) => e.type === "error");
+    expect(err!.payload.message).toBe("rate limit exceeded");
+  });
+
+  // -- Session management --
+
+  test("thread is reused across multiple sendMessage calls", async () => {
+    const thread = createMockThread([basicTurnEvents("First"), basicTurnEvents("Second")]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    await harness.sendMessage("First");
+    await harness.sendMessage("Second");
+
+    expect(codex.startThread).toHaveBeenCalledTimes(1);
+    expect(thread.runStreamed).toHaveBeenCalledTimes(2);
+  });
+
+  test("resume uses resumeThread with threadId", async () => {
+    const thread = createMockThread([basicTurnEvents()]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start({ ...baseConfig, resume: "thread-old" });
+    await harness.sendMessage("Continue");
+
+    expect(codex.resumeThread).toHaveBeenCalledTimes(1);
+    expect(codex.startThread).not.toHaveBeenCalled();
+    const args = (codex.resumeThread as ReturnType<typeof mock>).mock.calls[0];
+    expect(args[0]).toBe("thread-old");
+  });
+
+  test("clearSession() causes a new thread on next sendMessage", async () => {
+    const thread = createMockThread([basicTurnEvents("First"), basicTurnEvents("Fresh")]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start({ ...baseConfig, resume: "thread-old" });
+    await harness.sendMessage("First");
+    await harness.clearSession();
+
+    expect(harness.getSessionId()).toBeNull();
+
+    await harness.sendMessage("Fresh start");
+    // Should have called startThread (not resumeThread) for the second message
+    expect(codex.startThread).toHaveBeenCalledTimes(1);
+  });
+
+  // -- Stop --
+
+  test("stop() suppresses further event emission", async () => {
+    const thread = createMockThread([basicTurnEvents()]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    const events: AgentEvent[] = [];
+    harness.onEvent((e) => events.push(e));
+    await harness.start(baseConfig);
+    await harness.stop();
+    await harness.sendMessage("should not emit");
+    expect(events).toHaveLength(0);
+  });
+
+  // -- Interrupt --
+
+  test("interrupt() aborts the active turn via AbortController", async () => {
+    const blocker: { resolve: (() => void) | null } = { resolve: null };
+    const thread = createMockThread([]);
+    const _originalRunStreamed = thread.runStreamed;
+    thread.runStreamed = mock(async (_input: unknown, _opts?: unknown) => {
+      const opts = _opts as { signal?: AbortSignal } | undefined;
+      const signal = opts?.signal;
+      return {
+        events: (async function* () {
+          yield threadStarted();
+          yield turnStarted();
+          // Block until resolved or aborted
+          await new Promise<void>((resolve) => {
+            blocker.resolve = resolve;
+            signal?.addEventListener("abort", () => resolve());
+          });
+          yield turnCompleted();
+        })(),
+      };
+    }) as typeof _originalRunStreamed;
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    const sendPromise = harness.sendMessage("test");
+
+    // Give the async generator time to start
+    await new Promise((r) => setTimeout(r, 10));
+
+    await harness.interrupt();
+
+    // Unblock and await completion
+    blocker.resolve?.();
+    await sendPromise;
+
+    expect(harness.isProcessing()).toBe(false);
+  });
+
+  // -- System prompt --
+
+  test("sendMessage() prepends system prompt to first message", async () => {
+    const thread = createMockThread([basicTurnEvents()]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start({
+      ...baseConfig,
+      systemPrompt: "You are a helper.",
+      internalSystemPrompt: "Internal instructions here.",
+    });
+    await harness.sendMessage("Hello");
+
+    const call = (thread.runStreamed as ReturnType<typeof mock>).mock.calls[0];
+    const prompt = call[0] as string;
+    expect(prompt).toContain("Internal instructions here.");
+    expect(prompt).toContain("You are a helper.");
+    expect(prompt).toContain("Hello");
+  });
+
+  test("sendMessage() does not prepend system prompt on subsequent messages", async () => {
+    const thread = createMockThread([basicTurnEvents("First"), basicTurnEvents("Second")]);
+    const codex = createMockCodex(thread);
+    const harness = new CodexHarness(factory(codex));
+    harness.onEvent(() => {});
+    await harness.start({
+      ...baseConfig,
+      systemPrompt: "You are a helper.",
+    });
+    await harness.sendMessage("First");
+    await harness.sendMessage("Second");
+
+    const secondCall = (thread.runStreamed as ReturnType<typeof mock>).mock.calls[1];
+    const prompt = secondCall[0] as string;
+    expect(prompt).toBe("Second");
+  });
+});

--- a/src/runtime/harness/codex-harness.ts
+++ b/src/runtime/harness/codex-harness.ts
@@ -1,0 +1,279 @@
+import { Codex, type ThreadEvent, type ThreadOptions } from "@openai/codex-sdk";
+import type { AgentEvent, EventCallback, Harness, HarnessConfig } from "./types";
+
+type CodexFactory = () => Codex;
+
+type CodexThread = ReturnType<Codex["startThread"]>;
+
+export class CodexHarness implements Harness {
+  private callback: EventCallback = () => {};
+  private processing = false;
+  private stopped = false;
+  private config: HarnessConfig | null = null;
+  private codex: Codex | null = null;
+  private codexFactory: CodexFactory;
+  private thread: CodexThread | null = null;
+  private threadId: string | null = null;
+  private abortController: AbortController | null = null;
+  private accumulatedText = "";
+  private firstMessage = true;
+
+  constructor(codexFactory?: CodexFactory) {
+    this.codexFactory = codexFactory ?? (() => new Codex());
+  }
+
+  async start(config: HarnessConfig): Promise<void> {
+    this.config = config;
+    this.stopped = false;
+    this.threadId = config.resume ?? null;
+  }
+
+  async sendMessage(text: string, from?: string): Promise<void> {
+    if (!this.config) throw new Error("Harness not started");
+    if (this.stopped) return;
+
+    let content = from ? `[Message from agent "${from}"]\n${text}` : text;
+
+    // Codex SDK ThreadOptions has no instructions parameter, so prepend system prompt
+    // to the first message in the thread to establish agent context
+    if (this.firstMessage) {
+      this.firstMessage = false;
+      const systemPrompt = [this.config.internalSystemPrompt, this.config.systemPrompt]
+        .filter(Boolean)
+        .join("\n\n");
+      if (systemPrompt) {
+        content = `[System Instructions]\n${systemPrompt}\n\n[User Message]\n${content}`;
+      }
+    }
+
+    this.processing = true;
+    this.accumulatedText = "";
+    this.abortController = new AbortController();
+
+    try {
+      this.ensureThread();
+      const { events } = await this.thread!.runStreamed(content, {
+        signal: this.abortController.signal,
+      });
+
+      for await (const event of events) {
+        if (this.stopped) break;
+        this.handleEvent(event);
+      }
+    } catch (err) {
+      if (!this.stopped) {
+        this.emitEvent({ type: "error", payload: { message: String(err) } });
+        this.emitEvent({ type: "turn_complete", payload: {} });
+      }
+    } finally {
+      this.processing = false;
+      this.abortController = null;
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+  }
+
+  async clearSession(): Promise<void> {
+    this.thread = null;
+    this.threadId = null;
+    this.firstMessage = true;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.thread = null;
+    this.codex = null;
+  }
+
+  onEvent(callback: EventCallback): void {
+    this.callback = callback;
+  }
+
+  isProcessing(): boolean {
+    return this.processing;
+  }
+
+  getSessionId(): string | null {
+    return this.threadId;
+  }
+
+  // --- Private helpers ---
+
+  private ensureThread(): void {
+    if (!this.config) throw new Error("Harness not started");
+
+    if (!this.codex) {
+      this.codex = this.codexFactory();
+    }
+
+    if (!this.thread) {
+      const threadOpts: ThreadOptions = {
+        model: this.config.model,
+        workingDirectory: this.config.cwd,
+        sandboxMode: "danger-full-access",
+        skipGitRepoCheck: true,
+        approvalPolicy: "never",
+      };
+
+      if (this.threadId) {
+        this.thread = this.codex.resumeThread(this.threadId, threadOpts);
+      } else {
+        this.thread = this.codex.startThread(threadOpts);
+      }
+    }
+  }
+
+  private handleEvent(event: ThreadEvent): void {
+    switch (event.type) {
+      case "thread.started": {
+        this.threadId = event.thread_id;
+        break;
+      }
+
+      case "item.started": {
+        const item = event.item;
+        if (item.type === "command_execution") {
+          this.emitEvent({
+            type: "tool_use",
+            payload: {
+              tool: "command_execution",
+              tool_use_id: item.id,
+              input: { command: item.command },
+              status: "started",
+            },
+          });
+        } else if (item.type === "file_change") {
+          this.emitEvent({
+            type: "tool_use",
+            payload: {
+              tool: "file_change",
+              tool_use_id: item.id,
+              input: {},
+              status: "started",
+            },
+          });
+        } else if (item.type === "mcp_tool_call") {
+          const args =
+            typeof item.arguments === "object" && item.arguments !== null
+              ? (item.arguments as Record<string, unknown>)
+              : {};
+          this.emitEvent({
+            type: "tool_use",
+            payload: {
+              tool: item.tool,
+              tool_use_id: item.id,
+              input: args,
+              status: "started",
+            },
+          });
+        }
+        break;
+      }
+
+      case "item.completed": {
+        const item = event.item;
+        if (item.type === "agent_message") {
+          this.accumulatedText += item.text;
+          this.emitEvent({
+            type: "text_delta",
+            payload: { delta: item.text },
+          });
+        } else if (item.type === "command_execution") {
+          this.emitEvent({
+            type: "tool_result",
+            payload: {
+              tool_use_id: item.id,
+              output: item.aggregated_output.slice(0, 2000),
+              is_error: item.exit_code !== undefined && item.exit_code !== 0,
+            },
+          });
+        } else if (item.type === "file_change") {
+          const summary = item.changes.map((c) => `${c.kind}: ${c.path}`).join(", ");
+          this.emitEvent({
+            type: "tool_result",
+            payload: {
+              tool_use_id: item.id,
+              output: summary,
+              is_error: item.status === "failed",
+            },
+          });
+        } else if (item.type === "mcp_tool_call") {
+          let output = "";
+          if (item.result?.content) {
+            output = item.result.content
+              .filter(
+                (c): c is { type: "text"; text: string } =>
+                  typeof c === "object" && c !== null && "type" in c && c.type === "text",
+              )
+              .map((c) => c.text)
+              .join("\n");
+          }
+          if (item.error) {
+            output = item.error.message;
+          }
+          this.emitEvent({
+            type: "tool_result",
+            payload: {
+              tool_use_id: item.id,
+              output: output.slice(0, 2000),
+              is_error: item.status === "failed",
+            },
+          });
+        } else if (item.type === "error") {
+          this.emitEvent({
+            type: "error",
+            payload: { message: item.message },
+          });
+        }
+        break;
+      }
+
+      case "turn.completed": {
+        if (this.accumulatedText) {
+          this.emitEvent({
+            type: "text",
+            payload: { text: this.accumulatedText },
+          });
+        }
+        this.emitEvent({
+          type: "turn_complete",
+          payload: { session_id: this.threadId ?? undefined },
+        });
+        break;
+      }
+
+      case "turn.failed": {
+        this.emitEvent({
+          type: "error",
+          payload: { message: event.error.message },
+        });
+        this.emitEvent({ type: "turn_complete", payload: {} });
+        break;
+      }
+
+      case "error": {
+        this.emitEvent({
+          type: "error",
+          payload: { message: event.message },
+        });
+        this.emitEvent({ type: "turn_complete", payload: {} });
+        break;
+      }
+
+      // turn.started, item.updated — no mapping needed
+    }
+  }
+
+  private emitEvent(event: AgentEvent): void {
+    if (!this.stopped) {
+      this.callback(event);
+    }
+  }
+}

--- a/src/runtime/harness/index.ts
+++ b/src/runtime/harness/index.ts
@@ -3,8 +3,9 @@ import type { Harness } from "./types";
 import { PiHarness } from "./pi-harness";
 import { ClaudeCodeHarness } from "./claude-code-harness";
 import { OpenCodeHarness } from "./opencode-harness";
+import { CodexHarness } from "./codex-harness";
 
-export type HarnessType = "pi" | "claude_code" | "opencode";
+export type HarnessType = "pi" | "claude_code" | "opencode" | "codex";
 
 export { type Harness, type HarnessConfig, type AgentEvent, type EventCallback } from "./types";
 
@@ -16,6 +17,8 @@ export function createHarness(type: HarnessType): Harness {
       return new ClaudeCodeHarness();
     case "opencode":
       return new OpenCodeHarness();
+    case "codex":
+      return new CodexHarness();
     default:
       throw new Error(`Unknown harness type: ${type}`);
   }


### PR DESCRIPTION
## Summary
- Add `"codex"` as a fourth harness type powered by `@openai/codex-sdk`
- `CodexHarness` uses thread-based streaming (`runStreamed`), maps SDK events (`item.started/completed`, `turn.completed/failed`) to the existing `AgentEvent` types
- System prompt prepended to first message (SDK `ThreadOptions` has no instructions parameter)
- Interrupt via `AbortController` signal, session resume via `codex.resumeThread()`
- 27 unit tests covering lifecycle, text/tool events, session management, error handling

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes  
- [x] `bun test` — all 968 tests pass (27 new + 941 existing)
- [ ] Manual: create agent with Codex harness in UI, verify form shows correct options
- [ ] Manual: send message to Codex-powered agent (requires `codex` CLI installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)