### PR TITLE
Fix editor text invisible in dark mode

### DIFF
--- a/src/frontend/components/editor/SharedDriveEditor.tsx
+++ b/src/frontend/components/editor/SharedDriveEditor.tsx
@@ -216,7 +216,10 @@ export default function SharedDriveEditor({
           <EditorRefCapture editorRef={editorRef} />
           <RichTextPlugin
             contentEditable={
-              <div className="prose prose-sm max-w-none relative p-4" ref={setAnchorElement}>
+              <div
+                className="prose prose-sm dark:prose-invert max-w-none relative p-4"
+                ref={setAnchorElement}
+              >
                 <ContentEditable
                   aria-placeholder="Start writing..."
                   className="shire-content-root outline-none"


### PR DESCRIPTION
## Summary
- Add `dark:prose-invert` to the shared drive editor's prose wrapper
- Fixes black text on dark background when editing markdown files in dark mode

## Test plan
- [ ] Open shared drive, click a `.md` file in dark mode → text is readable (light on dark)
- [ ] Light mode still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)