### PR TITLE
Fix tables rendering as raw markdown in editor

### DIFF
--- a/src/frontend/components/editor/markdownTransformers.ts
+++ b/src/frontend/components/editor/markdownTransformers.ts
@@ -51,7 +51,9 @@ const TABLE: MultilineElementTransformer = {
       if (rowIndex === 0) {
         colCount = cellTexts.length;
       }
-      lines.push(`| ${cellTexts.join(" | ")} |`);
+      const normalized = cellTexts.slice(0, colCount);
+      while (normalized.length < colCount) normalized.push("");
+      lines.push(`| ${normalized.join(" | ")} |`);
       if (rowIndex === 0) {
         lines.push(`| ${cellTexts.map(() => "---").join(" | ")} |`);
       }
@@ -79,7 +81,7 @@ const TABLE: MultilineElementTransformer = {
     }
 
     if (tableLines.length < 2) {
-      return null;
+      return [false, startLineIndex];
     }
 
     const dataRows = tableLines.filter((line) => !TABLE_ROW_DIVIDER_REG_EXP.test(line));

--- a/src/frontend/components/editor/markdownTransformers.ts
+++ b/src/frontend/components/editor/markdownTransformers.ts
@@ -1,6 +1,121 @@
 import { DEFAULT_TRANSFORMERS } from "@lexical/react/LexicalMarkdownShortcutPlugin";
-import { TextMatchTransformer } from "@lexical/markdown";
+import type { MultilineElementTransformer, TextMatchTransformer } from "@lexical/markdown";
+import { $createParagraphNode, $createTextNode } from "lexical";
+import {
+  $createTableCellNode,
+  $createTableNode,
+  $createTableRowNode,
+  $isTableCellNode,
+  $isTableNode,
+  $isTableRowNode,
+  TableCellHeaderStates,
+  TableCellNode,
+  TableNode,
+  TableRowNode,
+} from "@lexical/table";
 import { $createImageNode, $isImageNode, ImageNode } from "./nodes/ImageNode";
+
+const TABLE_ROW_REG_EXP = /^\|(.+)\|\s*$/;
+const TABLE_ROW_DIVIDER_REG_EXP = /^(\| ?:?-+:? ?)+\|\s*$/;
+
+function parseCells(row: string): string[] {
+  return row
+    .trim()
+    .slice(1, -1)
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+const TABLE: MultilineElementTransformer = {
+  dependencies: [TableNode, TableRowNode, TableCellNode],
+  export: (node) => {
+    if (!$isTableNode(node)) {
+      return null;
+    }
+    const rows = node.getChildren();
+    if (rows.length === 0) {
+      return null;
+    }
+    const lines: string[] = [];
+    let colCount = 0;
+
+    for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+      const row = rows[rowIndex];
+      if (!$isTableRowNode(row)) continue;
+      const cells = row.getChildren();
+      const cellTexts: string[] = [];
+      for (const cell of cells) {
+        if (!$isTableCellNode(cell)) continue;
+        cellTexts.push(cell.getTextContent());
+      }
+      if (rowIndex === 0) {
+        colCount = cellTexts.length;
+      }
+      lines.push(`| ${cellTexts.join(" | ")} |`);
+      if (rowIndex === 0) {
+        lines.push(`| ${cellTexts.map(() => "---").join(" | ")} |`);
+      }
+    }
+
+    return colCount > 0 ? lines.join("\n") : null;
+  },
+  regExpStart: TABLE_ROW_REG_EXP,
+  regExpEnd: {
+    optional: true,
+    regExp: TABLE_ROW_REG_EXP,
+  },
+  handleImportAfterStartMatch: ({ lines, rootNode, startLineIndex }) => {
+    const tableLines: string[] = [];
+    let endIndex = startLineIndex;
+
+    for (let i = startLineIndex; i < lines.length; i++) {
+      const line = lines[i];
+      if (TABLE_ROW_REG_EXP.test(line) || TABLE_ROW_DIVIDER_REG_EXP.test(line)) {
+        tableLines.push(line);
+        endIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    if (tableLines.length < 2) {
+      return null;
+    }
+
+    const dataRows = tableLines.filter((line) => !TABLE_ROW_DIVIDER_REG_EXP.test(line));
+    if (dataRows.length === 0) {
+      return null;
+    }
+
+    const tableNode = $createTableNode();
+
+    for (let rowIndex = 0; rowIndex < dataRows.length; rowIndex++) {
+      const cells = parseCells(dataRows[rowIndex]);
+      const rowNode = $createTableRowNode();
+      const isHeader = rowIndex === 0;
+
+      for (const cellText of cells) {
+        const cellNode = $createTableCellNode(
+          isHeader ? TableCellHeaderStates.ROW : TableCellHeaderStates.NO_STATUS,
+        );
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode(cellText));
+        cellNode.append(paragraph);
+        rowNode.append(cellNode);
+      }
+
+      tableNode.append(rowNode);
+    }
+
+    rootNode.append(tableNode);
+    return [true, endIndex];
+  },
+  replace: () => {
+    // handled by handleImportAfterStartMatch
+    return false;
+  },
+  type: "multiline-element",
+};
 
 const IMAGE: TextMatchTransformer = {
   dependencies: [ImageNode],
@@ -29,4 +144,4 @@ const IMAGE: TextMatchTransformer = {
   type: "text-match",
 };
 
-export const MARKDOWN_TRANSFORMERS = [IMAGE, ...DEFAULT_TRANSFORMERS];
+export const MARKDOWN_TRANSFORMERS = [TABLE, IMAGE, ...DEFAULT_TRANSFORMERS];


### PR DESCRIPTION
## Summary
- Adds a custom `MultilineElementTransformer` for markdown table support in the Lexical editor
- Lexical's `DEFAULT_TRANSFORMERS` don't include table import/export, so pipe-delimited markdown tables were rendered as raw text
- Import: parses `| col | col |` rows into `TableNode`/`TableRowNode`/`TableCellNode`, skips separator rows, marks first row as header
- Export: converts table node tree back to pipe-delimited markdown with separator row

## Test plan
- [ ] Open a shared drive `.md` file containing a markdown table — should render as a formatted table, not raw text
- [ ] Edit a table cell, save, reopen — content should persist correctly
- [ ] Insert a new table via slash menu — should work as before
- [ ] Save a file with a table, check raw markdown on disk — should be valid pipe-delimited table

🤖 Generated with [Claude Code](https://claude.com/claude-code)