### PR TITLE
Fix table borders and cell action button in editor

### DIFF
--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -192,6 +192,51 @@ div[contenteditable] {
   border-width: 0 0.1em 0.1em 0;
 }
 
+/* Editor: table styles */
+.shire-content-root table {
+  width: 100%;
+  table-layout: auto;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.875rem;
+  border: 1px solid var(--border);
+  background-color: var(--background);
+}
+
+.shire-content-root th {
+  vertical-align: bottom;
+}
+
+.shire-content-root td,
+.shire-content-root th {
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  position: relative;
+  vertical-align: top;
+}
+
+.shire-content-root td h1,
+.shire-content-root td h2,
+.shire-content-root td h3,
+.shire-content-root td h4,
+.shire-content-root td h5,
+.shire-content-root td h6,
+.shire-content-root td p,
+.shire-content-root td ul,
+.shire-content-root td ol,
+.shire-content-root td pre,
+.shire-content-root th p {
+  margin: 0;
+}
+
+.shire-content-root tr:first-of-type > th,
+.shire-content-root tr:first-of-type > td {
+  background-color: var(--muted);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
 /* Editor: table cell action button */
 .shire-table-cell-action {
   position: absolute;


### PR DESCRIPTION
## Summary
- Tables were missing individual cell borders — `prose` only adds bottom borders on rows, not grid-style cell borders
- The cell hover action button (chevron to add/remove rows/columns) was invisible because `td`/`th` lacked `position: relative` needed for the absolutely-positioned button overlay
- Adds header row differentiation (muted background, semibold text)
- Resets margins on block elements inside cells to prevent extra spacing

## Test plan
- [ ] Open a shared drive `.md` file with a table — cells should have visible borders
- [ ] Hover over a table cell — chevron action button should appear in top-right corner
- [ ] Click the action button — context menu should open with add/remove row/column options
- [ ] Verify header row has distinct styling (slightly different background)
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)