### PR TITLE
Fix Prism not defined error in build binary

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "lexical": "^0.42.0",
         "lucide-react": "^0.577.0",
         "node-schedule": "^2.1.1",
+        "prismjs": "^1.30.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-dropzone": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@lexical/table": "^0.42.0",
     "@lexical/utils": "^0.42.0",
     "use-debounce": "^10.0.0",
+    "prismjs": "^1.30.0",
     "react-hotkeys-hook": "^5.0.0",
     "zod": "^4.3.6"
   },

--- a/src/frontend/components/editor/plugins/CodeHighlightPrismPlugin.tsx
+++ b/src/frontend/components/editor/plugins/CodeHighlightPrismPlugin.tsx
@@ -1,3 +1,4 @@
+import "prismjs";
 import { $isCodeNode, $isCodeHighlightNode } from "@lexical/code";
 import {
   registerCodeHighlighting,


### PR DESCRIPTION
## Summary
- `@lexical/code-prism` accesses `globalThis.Prism` at module init time, expecting the `prismjs` side-effect import to have already set the global
- Bun's bundler was reordering imports, so `Prism` wasn't set when `@lexical/code-prism` initialized
- Added explicit `import "prismjs"` before `@lexical/code-prism` in `CodeHighlightPrismPlugin.tsx`
- Added `prismjs` as a direct dependency (was only a transitive dep via `@lexical/code-prism`)

## Test plan
- [ ] `bun run build:local` succeeds without "Prism is not defined" error
- [ ] Code blocks in the editor still show syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)