### PR TITLE
Fix Prism not defined in build binary (v2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "@types/bun": "^1.2.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node-schedule": "^2.1.7",
+        "@types/prismjs": "^1.26.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
@@ -702,6 +703,8 @@
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/node-schedule": ["@types/node-schedule@2.1.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-k00g6Yj/oUg/CDC+MeLHUzu0+OFxWbIqrFfDiLi6OPKxTujvpv29mHGM8GtKr7B+9Vv92FcK/8mRqi1DK5f3hA=="],
+
+    "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/bun": "^1.2.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node-schedule": "^2.1.7",
+    "@types/prismjs": "^1.26.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.57.0",

--- a/src/frontend/components/editor/plugins/CodeHighlightPrismPlugin.tsx
+++ b/src/frontend/components/editor/plugins/CodeHighlightPrismPlugin.tsx
@@ -1,4 +1,4 @@
-import "prismjs";
+import "./setup-prism";
 import { $isCodeNode, $isCodeHighlightNode } from "@lexical/code";
 import {
   registerCodeHighlighting,

--- a/src/frontend/components/editor/plugins/setup-prism.ts
+++ b/src/frontend/components/editor/plugins/setup-prism.ts
@@ -1,0 +1,9 @@
+// @lexical/code-prism reads `globalThis.Prism` at module init time.
+// Bun's bundler can reorder bare side-effect imports, so we explicitly
+// import the Prism default export and assign it to globalThis before
+// @lexical/code-prism is imported.
+import Prism from "prismjs";
+
+if (typeof globalThis !== "undefined") {
+  (globalThis as Record<string, unknown>).Prism = Prism;
+}


### PR DESCRIPTION
## Summary
- The previous fix (`import "prismjs"`) didn't work because Bun's bundler reorders bare side-effect imports
- `@lexical/code-prism` reads `globalThis.Prism` at the top level of the module (`const Prism$1 = globalThis.Prism || window.Prism`), so the global must be set before the module initializes
- New approach: a dedicated `setup-prism.ts` module that imports Prism's default export and explicitly assigns it to `globalThis.Prism`, then is imported before `@lexical/code-prism`
- Added `@types/prismjs` for type safety

## Test plan
- [ ] `bun run build:local` succeeds without "Prism is not defined" error
- [ ] Run the built binary — code blocks render with syntax highlighting
- [ ] `bun run dev` still works with code highlighting in the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)