### PR TITLE
Fix Prism not defined: init global at build entry point

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.85",
         "@hono/zod-validator": "^0.7.6",
         "@lexical/code": "^0.42.0",
+        "@lexical/code-prism": "^0.42.0",
         "@lexical/link": "^0.42.0",
         "@lexical/list": "^0.42.0",
         "@lexical/markdown": "^0.42.0",
@@ -39,6 +40,7 @@
         "lexical": "^0.42.0",
         "lucide-react": "^0.577.0",
         "node-schedule": "^2.1.1",
+        "prismjs": "^1.30.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-dropzone": "^15.0.0",
@@ -61,6 +63,7 @@
         "@types/bun": "^1.2.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node-schedule": "^2.1.7",
+        "@types/prismjs": "^1.26.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
@@ -700,6 +703,8 @@
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/node-schedule": ["@types/node-schedule@2.1.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-k00g6Yj/oUg/CDC+MeLHUzu0+OFxWbIqrFfDiLi6OPKxTujvpv29mHGM8GtKr7B+9Vv92FcK/8mRqi1DK5f3hA=="],
+
+    "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "yaml": "^2.8.2",
     "lexical": "^0.42.0",
     "@lexical/code": "^0.42.0",
+    "@lexical/code-prism": "^0.42.0",
     "@lexical/link": "^0.42.0",
     "@lexical/list": "^0.42.0",
     "@lexical/markdown": "^0.42.0",
@@ -69,6 +70,7 @@
     "@lexical/table": "^0.42.0",
     "@lexical/utils": "^0.42.0",
     "use-debounce": "^10.0.0",
+    "prismjs": "^1.30.0",
     "react-hotkeys-hook": "^5.0.0",
     "zod": "^4.3.6"
   },
@@ -79,6 +81,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.2.0",
     "@types/js-yaml": "^4.0.9",
+    "@types/prismjs": "^1.26.6",
     "@types/node-schedule": "^2.1.7",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env bun
+
+// Must run before @lexical/code-prism is loaded (it reads globalThis.Prism at init time)
+import Prism from "prismjs";
+(globalThis as Record<string, unknown>).Prism = Prism;
+
 import { spawn } from "child_process";
 import { mkdirSync, openSync } from "fs";
 import {

--- a/src/frontend/components/editor/SharedDriveEditor.tsx
+++ b/src/frontend/components/editor/SharedDriveEditor.tsx
@@ -10,7 +10,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { AutoLinkNode, LinkNode } from "@lexical/link";
 import { ListNode, ListItemNode } from "@lexical/list";
 import { TableNode, TableCellNode, TableRowNode } from "@lexical/table";
-import { CodeNode } from "@lexical/code";
+import { CodeHighlightNode, CodeNode } from "@lexical/code";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
 import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
@@ -32,6 +32,7 @@ import { InsertTableMenuPlugin } from "./plugins/InsertTableMenuPlugin";
 import { InsertImagePlugin } from "./plugins/InsertImagePlugin";
 import { TableActionMenuPlugin } from "./plugins/TableActionMenuPlugin";
 import { TableCellActionPlugin } from "./plugins/TableCellActionPlugin";
+import CodeHighlightPrismPlugin from "./plugins/CodeHighlightPrismPlugin";
 import { MARKDOWN_TRANSFORMERS } from "./markdownTransformers";
 import { ImageNode } from "./nodes/ImageNode";
 import { TableCellActionNode } from "./nodes/TableCellActionNode";
@@ -54,6 +55,41 @@ const editorTheme = {
     bold: "font-semibold",
     italic: "italic",
     underline: "underline",
+  },
+  codeHighlight: {
+    atrule: "shire-keyword",
+    attr: "shire-attr",
+    "attr-name": "shire-property",
+    "attr-value": "shire-attr",
+    boolean: "shire-property",
+    builtin: "shire-attr",
+    cdata: "shire-comment",
+    char: "shire-attr",
+    class: "shire-function",
+    "class-name": "shire-function",
+    comment: "shire-comment",
+    constant: "shire-property",
+    deleted: "shire-property",
+    doctype: "shire-comment",
+    entity: "shire-operator",
+    function: "shire-function",
+    important: "shire-variable",
+    inserted: "shire-attr",
+    keyword: "shire-keyword",
+    namespace: "shire-variable",
+    number: "shire-property",
+    operator: "shire-operator",
+    prolog: "shire-comment",
+    property: "shire-property",
+    punctuation: "shire-punctuation",
+    regex: "shire-variable",
+    selector: "shire-selector",
+    string: "shire-attr",
+    symbol: "shire-property",
+    tag: "shire-selector",
+    url: "shire-operator",
+    variable: "shire-variable",
+    def: "shire-property",
   },
 };
 
@@ -165,6 +201,7 @@ export default function SharedDriveEditor({
               CodeNode,
               HeadingNode,
               QuoteNode,
+              CodeHighlightNode,
               ImageNode,
             ],
             theme: editorTheme,
@@ -210,6 +247,7 @@ export default function SharedDriveEditor({
           <TableCellActionPlugin />
           <TableActionMenuPlugin anchorElement={anchorElement} />
           <LinkPlugin />
+          <CodeHighlightPrismPlugin anchorElement={anchorElement} />
           <HorizontalRulePlugin />
           <ClickableLinkPlugin />
         </LexicalComposer>

--- a/src/frontend/components/editor/plugins/CodeHighlightPrismPlugin.tsx
+++ b/src/frontend/components/editor/plugins/CodeHighlightPrismPlugin.tsx
@@ -1,0 +1,129 @@
+import { $isCodeNode, $isCodeHighlightNode } from "@lexical/code";
+import {
+  registerCodeHighlighting,
+  getCodeLanguages,
+  normalizeCodeLanguage,
+  getLanguageFriendlyName,
+} from "@lexical/code-prism";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { mergeRegister } from "@lexical/utils";
+import { $getNodeByKey, $getSelection, $isRangeSelection, LexicalNode } from "lexical";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const getNearestCodeNode = (selectionNode: LexicalNode) => {
+  let current: LexicalNode | null = selectionNode;
+  while (current) {
+    if ($isCodeNode(current)) {
+      return current;
+    }
+    current = current.getParent();
+  }
+  return null;
+};
+
+interface CodeHighlightPrismPluginProps {
+  anchorElement: HTMLDivElement | null;
+}
+
+export default function CodeHighlightPrismPlugin({ anchorElement }: CodeHighlightPrismPluginProps) {
+  const [position, setPosition] = useState<{ top: number; left: number; width: number } | null>(
+    null,
+  );
+  const [isOpen, setIsOpen] = useState(false);
+  const [codeLanguage, setCodeLanguage] = useState<string | null>(null);
+  const [editor] = useLexicalComposerContext();
+  const codeNodeKeyRef = useRef<string | null>(null);
+
+  const codeLanguageOptions = useMemo(() => {
+    if (!isOpen) return [];
+    return Array.from(new Set(getCodeLanguages().map(normalizeCodeLanguage))).map((language) => ({
+      label: getLanguageFriendlyName(language),
+      value: language,
+    }));
+  }, [isOpen]);
+
+  useEffect(() => {
+    return mergeRegister(
+      registerCodeHighlighting(editor),
+      editor.registerUpdateListener(() => {
+        editor.read(() => {
+          const selection = $getSelection();
+          if (!selection || !$isRangeSelection(selection)) {
+            setIsOpen(false);
+            return;
+          }
+          const selectionNode = selection.anchor.getNode();
+          if (!$isCodeNode(selectionNode) && !$isCodeHighlightNode(selectionNode)) {
+            setIsOpen(false);
+            return;
+          }
+          const codeNode = getNearestCodeNode(selectionNode);
+          if (!codeNode) {
+            setIsOpen(false);
+            return;
+          }
+          codeNodeKeyRef.current = codeNode.getKey();
+          const currentLanguage = codeNode.getLanguage();
+          setCodeLanguage(currentLanguage ? normalizeCodeLanguage(currentLanguage) : null);
+          const codeElement = editor.getElementByKey(codeNode.getKey());
+          if (!codeElement || !anchorElement) {
+            setIsOpen(false);
+            return;
+          }
+          const codeElementRect = codeElement.getBoundingClientRect();
+          const anchorRect = anchorElement.getBoundingClientRect();
+          setPosition({
+            top: codeElementRect.y + codeElementRect.height - anchorRect.y,
+            left: codeElementRect.x - anchorRect.x,
+            width: codeElementRect.width,
+          });
+          setIsOpen(true);
+        });
+      }),
+    );
+  }, [anchorElement, editor]);
+
+  if (!isOpen || !anchorElement) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="h-0 mt-2 font-sans flex flex-row justify-center overflow-visible"
+      style={{
+        position: "absolute",
+        top: position?.top,
+        left: position?.left,
+        width: position?.width,
+      }}
+    >
+      <select
+        className="min-w-40 rounded-md border border-border bg-background px-2 py-1 text-sm"
+        value={codeLanguage || ""}
+        onChange={(e) => {
+          const key = e.target.value;
+          if (!key) return;
+          setCodeLanguage(key);
+          if (codeNodeKeyRef.current) {
+            editor.update(() => {
+              const node = $getNodeByKey(codeNodeKeyRef.current!);
+              if ($isCodeNode(node)) {
+                node.setLanguage(key);
+              }
+            });
+          }
+        }}
+        aria-label="Code Language"
+      >
+        <option value="">Select language</option>
+        {codeLanguageOptions.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>,
+    anchorElement,
+  );
+}

--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -288,6 +288,15 @@ th:focus-within .shire-table-cell-action-button {
   background-color: rgb(255 255 255 / 0.2);
 }
 
+.shire-attr { color: rgb(152, 195, 121); }
+.shire-property { color: rgb(209, 154, 102); }
+.shire-selector { color: rgb(224, 108, 117); }
+.shire-function { color: rgb(97, 175, 239); }
+.shire-comment { color: rgb(92, 99, 112); }
+.shire-variable { color: rgb(198, 120, 221); }
+.shire-operator { color: rgb(97, 175, 239); }
+.shire-punctuation { color: rgb(171, 178, 191); }
+.shire-keyword { color: rgb(198, 120, 221); }
 
 @layer base {
   * {


### PR DESCRIPTION
## Summary
- Root cause: `@lexical/code` re-exports `@lexical/code-prism`, which reads `globalThis.Prism` at module init time — so even importing `CodeNode` triggers the error
- Previous fixes (import ordering, setup module) didn't work because Bun's bundler flattens all modules into one scope
- Fix: import `prismjs` and assign to `globalThis.Prism` at the top of `src/cli.ts` — the build entry point — guaranteeing it runs before any bundled module init code
- Restores `CodeHighlightPrismPlugin`, syntax highlighting theme, and token CSS classes

## Test plan
- [ ] `bun run build:local` succeeds without "Prism is not defined"
- [ ] Built binary starts: `./npm/darwin-arm64/shire --help`
- [ ] Code blocks in the editor show syntax highlighting with colored tokens
- [ ] Language selector dropdown appears when clicking into a code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)