### PR TITLE
Add New Markdown button to shared drive

### DIFF
--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -30,6 +30,7 @@ import {
   useProjectId,
   useSharedDrive,
   useCreateDirectory,
+  useCreateFile,
   useDeleteSharedFile,
   useUploadSharedDriveFile,
   usePreviewFile,
@@ -216,6 +217,7 @@ export default function SharedDrive() {
   const files = data?.files ?? [];
 
   const createDirectory = useCreateDirectory(projectId ?? "");
+  const createFile = useCreateFile(projectId ?? "");
   const deleteSharedFile = useDeleteSharedFile(projectId ?? "");
   const uploadFile = useUploadSharedDriveFile(projectId ?? "");
   const [uploadProgress, setUploadProgress] = React.useState<number | null>(null);
@@ -224,6 +226,8 @@ export default function SharedDrive() {
 
   const [newFolderOpen, setNewFolderOpen] = React.useState(false);
   const [newFolderName, setNewFolderName] = React.useState("");
+  const [newMarkdownOpen, setNewMarkdownOpen] = React.useState(false);
+  const [newMarkdownName, setNewMarkdownName] = React.useState("");
   const [deleteTarget, setDeleteTarget] = React.useState<SharedDriveFile | null>(null);
   const [uploadError, setUploadError] = React.useState<string | null>(null);
 
@@ -289,6 +293,32 @@ export default function SharedDrive() {
     createDirectory.mutate({ name: newFolderName.trim(), path: currentPath });
     setNewFolderName("");
     setNewFolderOpen(false);
+  };
+
+  const handleCreateMarkdown = () => {
+    const trimmedName = newMarkdownName.trim();
+    if (!trimmedName) return;
+    setNewMarkdownName("");
+    setNewMarkdownOpen(false);
+    createFile.mutate(
+      { name: trimmedName, path: currentPath },
+      {
+        onSuccess: (data) => {
+          const filename = trimmedName.endsWith(".md") ? trimmedName : `${trimmedName}.md`;
+          const newFile: SharedDriveFile = {
+            name: filename,
+            path: data.path,
+            type: "file",
+            size: 0,
+          };
+          setPreviewFile(newFile);
+          setPreviewContent("");
+          setPreviewLoading(false);
+          setPreviewError(null);
+          currentPreviewPath.current = newFile.path;
+        },
+      },
+    );
   };
 
   const handleDelete = (file: SharedDriveFile) => {
@@ -403,6 +433,9 @@ export default function SharedDrive() {
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={open}>
               Upload File
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setNewMarkdownOpen(true)}>
+              New Markdown
             </Button>
             <Button variant="outline" size="sm" onClick={() => setNewFolderOpen(true)}>
               New Folder
@@ -594,6 +627,38 @@ export default function SharedDrive() {
               Cancel
             </Button>
             <Button onClick={handleCreateFolder} disabled={!newFolderName.trim()}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* New Markdown Dialog */}
+      <Dialog open={newMarkdownOpen} onOpenChange={setNewMarkdownOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Markdown</DialogTitle>
+            <DialogDescription>Create a new markdown file in the shared drive.</DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <Input
+              placeholder="File name"
+              value={newMarkdownName}
+              onChange={(e) => setNewMarkdownName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleCreateMarkdown();
+              }}
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground mt-2">
+              .md extension will be added automatically
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setNewMarkdownOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreateMarkdown} disabled={!newMarkdownName.trim()}>
               Create
             </Button>
           </DialogFooter>

--- a/src/frontend/hooks/activity.ts
+++ b/src/frontend/hooks/activity.ts
@@ -14,9 +14,7 @@ export function useActivity(projectId: string | undefined) {
     queryFn: async ({ pageParam }) => {
       const query: Record<string, string> = {};
       if (pageParam != null) query.before = String(pageParam);
-      return unwrap(
-        await api.projects[":id"].activity.$get({ param: { id: projectId! }, query }),
-      ) as unknown as ActivityResponse;
+      return unwrap(await api.projects[":id"].activity.$get({ param: { id: projectId! }, query }));
     },
     enabled: !!projectId,
     initialPageParam: undefined satisfies number | undefined,

--- a/src/frontend/hooks/messages.ts
+++ b/src/frontend/hooks/messages.ts
@@ -26,7 +26,7 @@ export function useMessages(projectId: string | undefined, agentId: string | und
           param: { id: projectId!, aid: agentId! },
           query,
         }),
-      ) as unknown as MessagesResponse;
+      );
     },
     enabled: !!projectId && !!agentId,
     initialPageParam: undefined satisfies number | undefined,

--- a/src/frontend/hooks/schedules.ts
+++ b/src/frontend/hooks/schedules.ts
@@ -7,9 +7,7 @@ export function useSchedules(projectId: string | undefined) {
   return useQuery<ScheduledTask[]>({
     queryKey: ["schedules", projectId],
     queryFn: async () =>
-      unwrap(
-        await api.projects[":id"].schedules.$get({ param: { id: projectId! } }),
-      ) as unknown as Promise<ScheduledTask[]>,
+      unwrap(await api.projects[":id"].schedules.$get({ param: { id: projectId! } })),
     enabled: !!projectId,
   });
 }

--- a/src/frontend/hooks/shared-drive.ts
+++ b/src/frontend/hooks/shared-drive.ts
@@ -23,7 +23,7 @@ export function useSharedDrive(projectId: string | undefined, path: string) {
           param: { id: projectId! },
           query: { path },
         }),
-      ) as unknown as SharedDriveResponse,
+      ),
     enabled: !!projectId,
   });
 }
@@ -51,7 +51,7 @@ export function useCreateFile(projectId: string) {
           param: { id: projectId },
           json: { name, path },
         }),
-      ) as unknown as { ok: boolean; path: string },
+      ),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
   });
 }

--- a/src/frontend/hooks/shared-drive.ts
+++ b/src/frontend/hooks/shared-drive.ts
@@ -42,6 +42,20 @@ export function useCreateDirectory(projectId: string) {
   });
 }
 
+export function useCreateFile(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ name, path }: { name: string; path: string }) =>
+      unwrap(
+        await api.projects[":id"]["shared-drive"].file.$post({
+          param: { id: projectId },
+          json: { name, path },
+        }),
+      ) as unknown as { ok: boolean; path: string },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["shared-drive", projectId] }),
+  });
+}
+
 export function useDeleteSharedFile(projectId: string) {
   const qc = useQueryClient();
   return useMutation({

--- a/src/frontend/test/hooks/shared-drive.test.ts
+++ b/src/frontend/test/hooks/shared-drive.test.ts
@@ -3,7 +3,12 @@ import { http, HttpResponse } from "msw";
 import { waitFor, act } from "@testing-library/react";
 import { server } from "../msw-server";
 import { renderHookWithProviders } from "../test-utils";
-import { useSharedDrive, useCreateDirectory, useDeleteSharedFile } from "../../hooks/shared-drive";
+import {
+  useSharedDrive,
+  useCreateDirectory,
+  useCreateFile,
+  useDeleteSharedFile,
+} from "../../hooks/shared-drive";
 
 const sharedDriveResponse = {
   files: [
@@ -38,6 +43,15 @@ describe("useCreateDirectory", () => {
     const { result } = renderHookWithProviders(() => useCreateDirectory("p1"));
     act(() => result.current.mutate({ name: "new-dir", path: "/" }));
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("useCreateFile", () => {
+  it("succeeds and returns path", async () => {
+    const { result } = renderHookWithProviders(() => useCreateFile("p1"));
+    act(() => result.current.mutate({ name: "notes", path: "/" }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toMatchObject({ ok: true, path: "/test.md" });
   });
 });
 

--- a/src/frontend/test/msw-handlers.ts
+++ b/src/frontend/test/msw-handlers.ts
@@ -80,6 +80,9 @@ export const defaultHandlers = [
   http.post("*/api/projects/:id/shared-drive/directory", () =>
     HttpResponse.json({ ok: true }, { status: 201 }),
   ),
+  http.post("*/api/projects/:id/shared-drive/file", () =>
+    HttpResponse.json({ ok: true, path: "/test.md" }, { status: 201 }),
+  ),
   http.post("*/api/projects/:id/shared-drive/upload", () =>
     HttpResponse.json({ ok: true }, { status: 201 }),
   ),

--- a/src/routes/shared-drive.test.ts
+++ b/src/routes/shared-drive.test.ts
@@ -419,6 +419,90 @@ describe("shared-drive routes", () => {
     expect(res.status).toBe(404);
   });
 
+  it("POST /api/projects/:id/shared-drive/file creates a markdown file", async () => {
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "notes",
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { ok: boolean; path: string };
+    expect(data.ok).toBe(true);
+    expect(data.path).toBe("/notes.md");
+
+    // Verify file appears in listing
+    const listRes = await request("GET", `/api/projects/${projectId}/shared-drive`);
+    const list = (await listRes.json()) as { files: Array<{ name: string; type: string }> };
+    expect(list.files.some((f) => f.name === "notes.md" && f.type === "file")).toBe(true);
+  });
+
+  it("POST /api/projects/:id/shared-drive/file auto-appends .md extension", async () => {
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "readme",
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { ok: boolean; path: string };
+    expect(data.path).toBe("/readme.md");
+  });
+
+  it("POST /api/projects/:id/shared-drive/file preserves .md if already present", async () => {
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "readme.md",
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { ok: boolean; path: string };
+    expect(data.path).toBe("/readme.md");
+  });
+
+  it("POST /api/projects/:id/shared-drive/file creates in subdirectory", async () => {
+    // Create subdirectory first
+    await request("POST", `/api/projects/${projectId}/shared-drive/directory`, {
+      name: "docs",
+    });
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "guide",
+      path: "/docs",
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { ok: boolean; path: string };
+    expect(data.path).toBe("/docs/guide.md");
+  });
+
+  it("POST /api/projects/:id/shared-drive/file returns 409 if file already exists", async () => {
+    await request("POST", `/api/projects/${projectId}/shared-drive/file`, { name: "dup" });
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "dup",
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("POST /api/projects/:id/shared-drive/file returns 400 for traversal", async () => {
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "evil",
+      path: "../../../tmp",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/projects/:id/shared-drive/file returns 400 for empty name", async () => {
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/projects/:id/shared-drive/file returns 400 for name with slashes", async () => {
+    const res = await request("POST", `/api/projects/${projectId}/shared-drive/file`, {
+      name: "../../etc/passwd",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/projects/:id/shared-drive/file returns 404 for unknown project", async () => {
+    const res = await request("POST", "/api/projects/nonexistent/shared-drive/file", {
+      name: "test",
+    });
+    expect(res.status).toBe(404);
+  });
+
   it("resolves project by name as well as by id", async () => {
     const res = await request("GET", "/api/projects/sd-test/shared-drive");
     expect(res.status).toBe(200);

--- a/src/routes/shared-drive.ts
+++ b/src/routes/shared-drive.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { readdir, stat, readFile, mkdir, unlink, rm, writeFile } from "fs/promises";
-import { join, resolve, basename } from "path";
+import { readdir, stat, readFile, mkdir, unlink, rm, writeFile, access } from "fs/promises";
+import { join, resolve, basename, dirname } from "path";
 import * as workspace from "../services/workspace";
 import * as projectsService from "../services/projects";
 import type { AppEnv } from "../types";
@@ -122,6 +122,39 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
 
       await mkdir(fullPath, { recursive: true });
       return c.json({ ok: true }, 201);
+    },
+  )
+  .post(
+    "/projects/:id/shared-drive/file",
+    zValidator(
+      "json",
+      z.object({
+        name: z
+          .string()
+          .min(1)
+          .regex(/^[^/\\]+$/, "Name must not contain path separators"),
+        path: z.string().optional(),
+      }),
+    ),
+    async (c) => {
+      const projectId = resolveProjectId(c.req.param("id"));
+      if (!projectId) return c.json({ error: "Project not found" }, 404);
+
+      const sharedRoot = workspace.sharedDir(projectId);
+      const { name, path: parentPath } = c.req.valid("json");
+      const filename = name.endsWith(".md") ? name : `${name}.md`;
+      const relPath = join(parentPath ?? "/", filename);
+      const fullPath = safePath(sharedRoot, relPath);
+      if (!fullPath) return c.json({ error: "Invalid path" }, 400);
+
+      const exists = await access(fullPath)
+        .then(() => true)
+        .catch(() => false);
+      if (exists) return c.json({ error: "File already exists" }, 409);
+
+      await mkdir(dirname(fullPath), { recursive: true });
+      await writeFile(fullPath, "", "utf-8");
+      return c.json({ ok: true, path: relPath }, 201);
     },
   )
   .post("/projects/:id/shared-drive/upload", async (c) => {


### PR DESCRIPTION
## Summary
- Adds a "New Markdown" button to the shared drive toolbar that creates a new `.md` file and opens it directly in the rich text editor
- New backend endpoint `POST /api/projects/:id/shared-drive/file` with Zod validation (name sanitization, path traversal protection, duplicate detection)
- Frontend dialog follows existing "New Folder" pattern with auto `.md` extension

## Test plan
- [x] Backend: 9 new tests covering happy path, subdirectory creation, `.md` auto-append, duplicate detection (409), path traversal rejection, empty name, slash-in-name validation, unknown project
- [x] Frontend: 1 new hook test for `useCreateFile`
- [x] Full suite: 987 tests pass, typecheck clean, lint clean
- [ ] Manual: open shared drive → click "New Markdown" → enter name → verify file appears and editor opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)