### PR TITLE
Fix transparent selection menu in markdown editor

### DIFF
--- a/src/frontend/components/editor/plugins/SelectionMenuPlugin.tsx
+++ b/src/frontend/components/editor/plugins/SelectionMenuPlugin.tsx
@@ -173,7 +173,7 @@ export const SelectionMenuPlugin = ({
 
   const renderFormattingMenu = () => {
     return (
-      <div className="flex flex-row border border-border rounded-lg">
+      <div className="flex flex-row border border-border rounded-lg bg-background">
         <FormatButton
           active={isBold}
           onClick={() => handleFormat("bold")}


### PR DESCRIPTION
## Summary
- Add `bg-background` to the text selection formatting toolbar in `SelectionMenuPlugin`, matching all other editor floating menus (slash menu, table menu, link editor)
- The toolbar was rendering with a transparent background, making it hard to read over content

## Test plan
- [ ] Open a shared drive markdown file, select text, verify the formatting toolbar has an opaque background
- [ ] Verify other menus (slash menu via `/`, table actions) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)