### PR TITLE
Convert shared drive buttons to icons

### DIFF
--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -22,7 +22,17 @@ import {
   AlertDialogTitle,
 } from "./ui/alert-dialog";
 import AppLayout from "./AppLayout";
-import { ChevronLeft, Folder, File, X, Download, Upload } from "lucide-react";
+import {
+  ChevronLeft,
+  Folder,
+  File,
+  X,
+  Download,
+  Upload,
+  FolderPlus,
+  FileText,
+  Trash2,
+} from "lucide-react";
 import { Spinner, PageLoader } from "./ui/spinner";
 import { ErrorState } from "./ui/error-state";
 import { useNavigate } from "react-router-dom";
@@ -431,14 +441,24 @@ export default function SharedDrive() {
         <div className="flex items-center justify-between">
           <Breadcrumbs path={currentPath} onNavigate={navigate} />
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={open}>
-              Upload File
+            <Button variant="outline" size="icon" aria-label="Upload File" onClick={open}>
+              <Upload className="h-4 w-4" />
             </Button>
-            <Button variant="outline" size="sm" onClick={() => setNewMarkdownOpen(true)}>
-              New Markdown
+            <Button
+              variant="outline"
+              size="icon"
+              aria-label="New Markdown"
+              onClick={() => setNewMarkdownOpen(true)}
+            >
+              <FileText className="h-4 w-4" />
             </Button>
-            <Button variant="outline" size="sm" onClick={() => setNewFolderOpen(true)}>
-              New Folder
+            <Button
+              variant="outline"
+              size="icon"
+              aria-label="New Folder"
+              onClick={() => setNewFolderOpen(true)}
+            >
+              <FolderPlus className="h-4 w-4" />
             </Button>
           </div>
         </div>
@@ -526,22 +546,24 @@ export default function SharedDrive() {
                         <TableCell className="text-right">
                           <div className="flex items-center justify-end gap-1">
                             {file.type === "file" && (
-                              <Button variant="ghost" size="sm" asChild>
+                              <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
                                 <a
                                   href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(file.path)}`}
                                   download
+                                  aria-label="Download"
                                 >
-                                  Download
+                                  <Download className="h-4 w-4" />
                                 </a>
                               </Button>
                             )}
                             <Button
                               variant="ghost"
-                              size="sm"
-                              className="text-destructive hover:text-destructive"
+                              size="icon"
+                              className="h-8 w-8 text-destructive hover:text-destructive"
+                              aria-label="Delete"
                               onClick={() => setDeleteTarget(file)}
                             >
-                              Delete
+                              <Trash2 className="h-4 w-4" />
                             </Button>
                           </div>
                         </TableCell>
@@ -559,21 +581,23 @@ export default function SharedDrive() {
               <div className="flex items-center justify-between border-b px-4 py-2">
                 <span className="text-sm font-medium truncate">{previewFile.name}</span>
                 <div className="flex items-center gap-1">
-                  <Button variant="ghost" size="sm" asChild>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" asChild>
                     <a
                       href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(previewFile.path)}`}
                       download
+                      aria-label="Download"
                     >
                       <Download className="h-4 w-4" />
                     </a>
                   </Button>
                   <Button
                     variant="ghost"
-                    size="sm"
-                    className="text-destructive hover:text-destructive"
+                    size="icon"
+                    className="h-7 w-7 text-destructive hover:text-destructive"
+                    aria-label="Delete"
                     onClick={() => setDeleteTarget(previewFile)}
                   >
-                    Delete
+                    <Trash2 className="h-4 w-4" />
                   </Button>
                   <Button
                     variant="ghost"

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -87,6 +87,15 @@ describe("SharedDrive", () => {
     expect(screen.getByText("Create a new folder in the shared drive.")).toBeInTheDocument();
   });
 
+  it("opens new markdown dialog", async () => {
+    renderWithProviders(<SharedDrive />, routeOpts);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "New Markdown" })).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByRole("button", { name: "New Markdown" }));
+    expect(screen.getByText("Create a new markdown file in the shared drive.")).toBeInTheDocument();
+  });
+
   it("creates a folder via dialog", async () => {
     let createdDir: Record<string, unknown> | undefined;
     server.use(
@@ -475,7 +484,7 @@ describe("SharedDrive", () => {
     const previewPanel = screen.getByText("readme.md", { selector: "span" }).closest("div");
     const deleteInPreview = within(previewPanel!.parentElement!)
       .getAllByRole("button")
-      .find((btn) => btn.textContent === "Delete");
+      .find((btn) => btn.getAttribute("aria-label") === "Delete" || btn.textContent === "Delete");
     if (deleteInPreview) {
       await userEvent.click(deleteInPreview);
       // Confirm deletion


### PR DESCRIPTION
## Summary
- Replace toolbar text buttons (Upload File, New Markdown, New Folder) with icon-only buttons using `Upload`, `FileText`, and `FolderPlus` lucide-react icons
- Convert table action buttons (Download, Delete) and preview panel buttons to icon-only with `Download` and `Trash2` icons
- All icon buttons include `aria-label` for accessibility
- Add missing test for New Markdown dialog

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test src/frontend/test/SharedDrive.test.tsx` — 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)