### PR TITLE
Replace Isolated VMs copy with Shared Drive on welcome screen

### DIFF
--- a/src/frontend/components/WelcomePanel.tsx
+++ b/src/frontend/components/WelcomePanel.tsx
@@ -1,4 +1,4 @@
-import { Menu, MessageSquare, Users, Zap } from "lucide-react";
+import { FolderOpen, Menu, MessageSquare, Users } from "lucide-react";
 import { Button } from "./ui/button";
 
 interface WelcomePanelProps {
@@ -55,9 +55,9 @@ export default function WelcomePanel({
               </div>
               <div className="flex flex-col items-center text-center gap-2 p-3">
                 <div className="rounded-full bg-primary/10 p-2.5">
-                  <Zap className="h-5 w-5 text-primary" />
+                  <FolderOpen className="h-5 w-5 text-primary" />
                 </div>
-                <p className="text-sm text-muted-foreground">Isolated VMs per project</p>
+                <p className="text-sm text-muted-foreground">Shared drive for files</p>
               </div>
             </div>
 

--- a/src/frontend/test/AgentDashboard.test.tsx
+++ b/src/frontend/test/AgentDashboard.test.tsx
@@ -104,6 +104,16 @@ describe("ProjectLayout + AgentChatView", () => {
     expect(screen.getByText("Create a new agent to get started.")).toBeInTheDocument();
   });
 
+  it("shows feature highlights in welcome panel when no agents", async () => {
+    setAgents([]);
+    renderWithLayout();
+    await waitFor(() => {
+      expect(screen.getByText("Chat with agents directly")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Agents collaborate autonomously")).toBeInTheDocument();
+    expect(screen.getByText("Shared drive for files")).toBeInTheDocument();
+  });
+
   it("renders menu toggle button in welcome panel when no agents", async () => {
     setAgents([]);
     renderWithLayout();


### PR DESCRIPTION
## Summary
- Replaced "Isolated VMs per project" feature card with "Shared drive for files" on the welcome panel — the shared drive is an actual feature agents use for file collaboration
- Swapped `Zap` icon for `FolderOpen` to match the new copy
- Added test asserting all three feature highlights render correctly

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] All 12 AgentDashboard tests pass (including the new one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)