### PR TITLE
Add version check and upgrade notice in sidebar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Build binary and assets
         run: bun run scripts/build-binaries.ts --target ${{ matrix.target }}
+        env:
+          SHIRE_VERSION: ${{ github.ref_name }}
 
       - name: Set version in package.json
         shell: bash

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -17,8 +17,9 @@ const ROOT = join(import.meta.dirname, "..");
 async function buildBinary(target: Target): Promise<void> {
   const outDir = join(ROOT, "npm", target.npmDir);
   const outFile = join(outDir, target.binaryName);
+  const version = (process.env.SHIRE_VERSION || "0.1.0-dev").replace(/^v/, "");
 
-  console.log(`Building ${target.bunTarget} → npm/${target.npmDir}/${target.binaryName}`);
+  console.log(`Building ${target.bunTarget} → npm/${target.npmDir}/${target.binaryName} (v${version})`);
 
   const result = await Bun.build({
     entrypoints: [join(ROOT, "src", "cli.ts")],
@@ -29,6 +30,7 @@ async function buildBinary(target: Target): Promise<void> {
     minify: true,
     define: {
       "process.env.NODE_ENV": JSON.stringify("production"),
+      __SHIRE_VERSION__: JSON.stringify(version),
     },
     plugins: [tailwind],
   });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5,7 +5,6 @@ import { existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { logFilePath } from "./daemon";
 import { openBrowser, shouldOpenBrowser } from "./cli";
-import pkg from "../package.json";
 
 const CLI_PATH = join(import.meta.dirname, "cli.ts");
 
@@ -24,8 +23,8 @@ describe("CLI", () => {
 
   it("prints version with --version", async () => {
     const result = await $`bun run ${CLI_PATH} --version`.text();
-    expect(result.trim()).toMatch(/^shire v\d+\.\d+\.\d+$/);
-    expect(result.trim()).toBe(`shire v${pkg.version}`);
+    expect(result.trim()).toMatch(/^shire v\d+\.\d+\.\d+(-\w+)?$/);
+    expect(result.trim()).toBe("shire v0.1.0-dev");
   });
 
   it("exits with error for unknown argument", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,9 +17,9 @@ import {
   logFilePath,
 } from "./daemon";
 import { startServer } from "./index";
-import pkg from "../package.json";
 
-const VERSION = pkg.version;
+declare const __SHIRE_VERSION__: string;
+const VERSION = typeof __SHIRE_VERSION__ !== "undefined" ? __SHIRE_VERSION__ : "0.1.0-dev";
 
 interface ParsedArgs {
   command: string;

--- a/src/frontend/components/AgentSidebar.tsx
+++ b/src/frontend/components/AgentSidebar.tsx
@@ -17,11 +17,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./ui/alert-dialog";
-import { FileText, Settings, FolderOpen, Clock } from "lucide-react";
+import { FileText, Settings, FolderOpen, Clock, ArrowUpCircle, X } from "lucide-react";
 import { Spinner } from "./ui/spinner";
 import ProjectSwitcher from "./ProjectSwitcher";
 import { type AgentOverview, type AgentStatus } from "./types";
-import { useProjectId, useProjects, useAgents, useDeleteAgent } from "../hooks";
+import { useProjectId, useProjects, useAgents, useDeleteAgent, useVersionCheck } from "../hooks";
 
 function statusDotColor(status: AgentStatus): string {
   switch (status) {
@@ -35,6 +35,52 @@ function statusDotColor(status: AgentStatus): string {
     default:
       return "bg-status-idle";
   }
+}
+
+const DISMISS_KEY = "shire-upgrade-dismissed";
+
+function VersionFooter() {
+  const { data } = useVersionCheck();
+  const [dismissed, setDismissed] = React.useState(false);
+
+  if (!data) return null;
+
+  const showUpgrade =
+    data.updateAvailable && !dismissed && localStorage.getItem(DISMISS_KEY) !== data.latest;
+
+  return (
+    <>
+      {showUpgrade && (
+        <div className="border-t border-border px-3 py-2">
+          <div className="flex items-start gap-2">
+            <ArrowUpCircle className="h-4 w-4 text-primary shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-medium text-foreground">v{data.latest} available</p>
+              <code className="text-[10px] text-muted-foreground break-all">
+                {data.upgradeCommand}
+              </code>
+            </div>
+            <button
+              type="button"
+              className="shrink-0 p-0.5 rounded hover:bg-muted text-muted-foreground"
+              onClick={() => {
+                if (data.latest) {
+                  localStorage.setItem(DISMISS_KEY, data.latest);
+                }
+                setDismissed(true);
+              }}
+              aria-label="Dismiss upgrade notice"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="border-t border-border px-3 py-1.5">
+        <span className="text-[10px] text-muted-foreground">v{data.current}</span>
+      </div>
+    </>
+  );
 }
 
 interface AgentSidebarProps {
@@ -203,6 +249,8 @@ export default function AgentSidebar({ onNewAgent, onBrowseCatalog }: AgentSideb
           </Button>
         </div>
       </div>
+
+      <VersionFooter />
 
       <AlertDialog
         open={!!deleteAgent}

--- a/src/frontend/hooks/index.ts
+++ b/src/frontend/hooks/index.ts
@@ -8,3 +8,4 @@ export * from "./shared-drive";
 export * from "./uploads";
 export * from "./schedules";
 export * from "./alert-channels";
+export * from "./version";

--- a/src/frontend/hooks/version.ts
+++ b/src/frontend/hooks/version.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../lib/api";
+import { unwrap } from "./util";
+
+export function useVersionCheck() {
+  return useQuery({
+    queryKey: ["version-check"],
+    queryFn: async () => unwrap(await api.version.$get()),
+    staleTime: 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    refetchInterval: 60 * 60 * 1000,
+  });
+}

--- a/src/frontend/test/msw-handlers.ts
+++ b/src/frontend/test/msw-handlers.ts
@@ -98,6 +98,16 @@ export const defaultHandlers = [
   http.delete("*/api/projects/:id/alert-channel", () => HttpResponse.json({ ok: true })),
   http.post("*/api/projects/:id/alert-channel/test", () => HttpResponse.json({ ok: true })),
 
+  // --- Version ---
+  http.get("*/api/version", () =>
+    HttpResponse.json({
+      current: "0.1.0-dev",
+      latest: null,
+      updateAvailable: false,
+      upgradeCommand: "npm install -g agents-shire@latest",
+    }),
+  ),
+
   // --- Catalog ---
   http.get("*/api/catalog/agents", () => HttpResponse.json([])),
   http.get("*/api/catalog/categories", () => HttpResponse.json([])),

--- a/src/routes/version.test.ts
+++ b/src/routes/version.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { createTestDb } from "../test/setup";
+import { createApp } from "../server";
+import { ProjectManager } from "../runtime/project-manager";
+import { Scheduler } from "../runtime/scheduler";
+import { isNewer, CURRENT_VERSION, resetVersionCache } from "./version";
+
+let app: ReturnType<typeof createApp>;
+
+beforeEach(() => {
+  createTestDb();
+  const projectManager = new ProjectManager();
+  const scheduler = new Scheduler(projectManager);
+  app = createApp({ projectManager, scheduler });
+  resetVersionCache();
+});
+
+async function request(method: string, path: string) {
+  return app.request(path, { method, headers: { "Content-Type": "application/json" } });
+}
+
+describe("isNewer", () => {
+  it("detects newer major version", () => {
+    expect(isNewer("2.0.0", "1.0.0")).toBe(true);
+  });
+
+  it("detects newer minor version", () => {
+    expect(isNewer("1.1.0", "1.0.0")).toBe(true);
+  });
+
+  it("detects newer patch version", () => {
+    expect(isNewer("1.0.1", "1.0.0")).toBe(true);
+  });
+
+  it("returns false for same version", () => {
+    expect(isNewer("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  it("returns false for older version", () => {
+    expect(isNewer("1.0.0", "1.0.1")).toBe(false);
+  });
+
+  it("handles different length versions", () => {
+    expect(isNewer("1.0.1", "1.0")).toBe(true);
+    expect(isNewer("1.0", "1.0.1")).toBe(false);
+  });
+
+  it("returns false when current is a pre-release version", () => {
+    expect(isNewer("1.0.0", "0.1.0-dev")).toBe(false);
+    expect(isNewer("99.0.0", "1.0.0-alpha")).toBe(false);
+  });
+});
+
+describe("GET /api/version", () => {
+  it("returns current version and latest from registry", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ version: "99.0.0" }), { status: 200 })),
+    ) as unknown as typeof fetch;
+
+    try {
+      const res = await request("GET", "/api/version");
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        current: string;
+        latest: string | null;
+        updateAvailable: boolean;
+        upgradeCommand: string;
+      };
+      expect(data.current).toBe(CURRENT_VERSION);
+      expect(data.latest).toBe("99.0.0");
+      // Dev versions (containing "-") never report updateAvailable
+      expect(data.updateAvailable).toBe(!CURRENT_VERSION.includes("-"));
+      expect(data.upgradeCommand).toBe("npm install -g agents-shire@latest");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("handles npm registry failure gracefully", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("network error")),
+    ) as unknown as typeof fetch;
+
+    try {
+      const res = await request("GET", "/api/version");
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        current: string;
+        latest: string | null;
+        updateAvailable: boolean;
+      };
+      expect(data.current).toBe(CURRENT_VERSION);
+      expect(data.latest).toBeNull();
+      expect(data.updateAvailable).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns updateAvailable false when versions match", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ version: CURRENT_VERSION }), { status: 200 })),
+    ) as unknown as typeof fetch;
+
+    try {
+      const res = await request("GET", "/api/version");
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { updateAvailable: boolean };
+      expect(data.updateAvailable).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/routes/version.ts
+++ b/src/routes/version.ts
@@ -1,0 +1,55 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+
+declare const __SHIRE_VERSION__: string;
+const CURRENT_VERSION = typeof __SHIRE_VERSION__ !== "undefined" ? __SHIRE_VERSION__ : "0.1.0-dev";
+const NPM_PACKAGE = "agents-shire";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+let cached: { version: string; checkedAt: number } | null = null;
+
+function isNewer(latest: string, current: string): boolean {
+  if (current.includes("-")) return false;
+  const l = latest.split(".").map(Number);
+  const c = current.split(".").map(Number);
+  for (let i = 0; i < Math.max(l.length, c.length); i++) {
+    const lv = l[i] ?? 0;
+    const cv = c[i] ?? 0;
+    if (lv > cv) return true;
+    if (lv < cv) return false;
+  }
+  return false;
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+  if (cached && Date.now() - cached.checkedAt < CACHE_TTL_MS) {
+    return cached.version;
+  }
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE}/latest`);
+    if (!res.ok) return cached?.version ?? null;
+    const data = (await res.json()) as { version: string };
+    cached = { version: data.version, checkedAt: Date.now() };
+    return data.version;
+  } catch {
+    return cached?.version ?? null;
+  }
+}
+
+export const versionRoutes = new Hono<AppEnv>().get("/version", async (c) => {
+  const latest = await fetchLatestVersion();
+  return c.json({
+    current: CURRENT_VERSION,
+    latest,
+    updateAvailable: latest ? isNewer(latest, CURRENT_VERSION) : false,
+    upgradeCommand: "npm install -g agents-shire@latest",
+  });
+});
+
+/** Exported for testing */
+export { isNewer, CURRENT_VERSION };
+
+/** Reset the cache (for testing) */
+export function resetVersionCache(): void {
+  cached = null;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { settingsRoutes } from "./routes/settings";
 import { catalogRoutes } from "./routes/catalog";
 import { attachmentRoutes } from "./routes/attachments";
 import { alertChannelRoutes } from "./routes/alert-channels";
+import { versionRoutes } from "./routes/version";
 
 export interface AppContext {
   projectManager: ProjectManager;
@@ -45,6 +46,7 @@ export function createApp(ctx: AppContext) {
     .route("/api", catalogRoutes)
     .route("/api", attachmentRoutes)
     .route("/api", alertChannelRoutes)
+    .route("/api", versionRoutes)
     .get("/api/health", (c) => c.json({ status: "ok" }));
 
   return app;


### PR DESCRIPTION
## Summary
- Inject real app version at build time via `__SHIRE_VERSION__` define constant in `Bun.build()`, replacing the static `package.json` import
- Add `GET /api/version` endpoint that checks npm registry for latest `agents-shire` version (cached 1 hour) and returns `{ current, latest, updateAvailable, upgradeCommand }`
- Show current version at the bottom of the agent sidebar, with a dismissible upgrade notice when a newer version is available

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes  
- [x] `bun test` — all 1001 tests pass (10 new version tests)
- [ ] `bun run dev` — verify version shows at bottom of sidebar
- [ ] Verify dismiss button hides notice and persists across refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)