### PR TITLE
Simplify upgrade notice to compact single-line

### DIFF
--- a/src/frontend/components/AgentSidebar.test.tsx
+++ b/src/frontend/components/AgentSidebar.test.tsx
@@ -1,0 +1,72 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, mock } from "bun:test";
+import { http, HttpResponse } from "msw";
+import { server } from "../test/msw-server";
+import AgentSidebar from "./AgentSidebar";
+import { renderWithProviders } from "../test/test-utils";
+
+const routeOpts = {
+  route: "/projects/test-project",
+  routePath: "/projects/:projectName",
+};
+
+const defaultProps = {
+  onNewAgent: mock(() => {}),
+  onBrowseCatalog: mock(() => {}),
+};
+
+function setVersionResponse(response: {
+  current: string;
+  latest: string | null;
+  updateAvailable: boolean;
+  upgradeCommand: string;
+}) {
+  server.use(http.get("*/api/version", () => HttpResponse.json(response)));
+}
+
+describe("VersionFooter", () => {
+  it("shows current version in the sidebar", async () => {
+    setVersionResponse({
+      current: "1.0.20",
+      latest: null,
+      updateAvailable: false,
+      upgradeCommand: "npm install -g agents-shire@latest",
+    });
+    renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
+
+    await waitFor(() => {
+      expect(screen.getByText("v1.0.20")).toBeInTheDocument();
+    });
+  });
+
+  it("shows upgrade indicator when update is available", async () => {
+    setVersionResponse({
+      current: "1.0.20",
+      latest: "1.0.22",
+      updateAvailable: true,
+      upgradeCommand: "npm install -g agents-shire@latest",
+    });
+    renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
+
+    await waitFor(() => {
+      expect(screen.getByText("v1.0.20")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/v1\.0\.22/)).toBeInTheDocument();
+  });
+
+  it("does not show upgrade indicator when no update available", async () => {
+    setVersionResponse({
+      current: "1.0.22",
+      latest: "1.0.22",
+      updateAvailable: false,
+      upgradeCommand: "npm install -g agents-shire@latest",
+    });
+    renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
+
+    await waitFor(() => {
+      expect(screen.getByText("v1.0.22")).toBeInTheDocument();
+    });
+    // Only one version element should exist (the current version)
+    expect(screen.queryByTitle("npm install -g agents-shire@latest")).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/AgentSidebar.tsx
+++ b/src/frontend/components/AgentSidebar.tsx
@@ -17,7 +17,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "./ui/alert-dialog";
-import { FileText, Settings, FolderOpen, Clock, ArrowUpCircle, X } from "lucide-react";
+import { FileText, Settings, FolderOpen, Clock, ArrowUpCircle } from "lucide-react";
 import { Spinner } from "./ui/spinner";
 import ProjectSwitcher from "./ProjectSwitcher";
 import { type AgentOverview, type AgentStatus } from "./types";
@@ -37,49 +37,23 @@ function statusDotColor(status: AgentStatus): string {
   }
 }
 
-const DISMISS_KEY = "shire-upgrade-dismissed";
-
 function VersionFooter() {
   const { data } = useVersionCheck();
-  const [dismissed, setDismissed] = React.useState(false);
 
   if (!data) return null;
 
-  const showUpgrade =
-    data.updateAvailable && !dismissed && localStorage.getItem(DISMISS_KEY) !== data.latest;
-
   return (
-    <>
-      {showUpgrade && (
-        <div className="border-t border-border px-3 py-2">
-          <div className="flex items-start gap-2">
-            <ArrowUpCircle className="h-4 w-4 text-primary shrink-0 mt-0.5" />
-            <div className="flex-1 min-w-0">
-              <p className="text-xs font-medium text-foreground">v{data.latest} available</p>
-              <code className="text-[10px] text-muted-foreground break-all">
-                {data.upgradeCommand}
-              </code>
-            </div>
-            <button
-              type="button"
-              className="shrink-0 p-0.5 rounded hover:bg-muted text-muted-foreground"
-              onClick={() => {
-                if (data.latest) {
-                  localStorage.setItem(DISMISS_KEY, data.latest);
-                }
-                setDismissed(true);
-              }}
-              aria-label="Dismiss upgrade notice"
-            >
-              <X className="h-3 w-3" />
-            </button>
-          </div>
-        </div>
+    <div className="border-t border-border px-3 py-1.5 flex items-center gap-1.5">
+      <span className="text-[10px] text-muted-foreground">v{data.current}</span>
+      {data.updateAvailable && (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] text-amber-500 cursor-default"
+          title={data.upgradeCommand}
+        >
+          <ArrowUpCircle className="h-3 w-3" />v{data.latest}
+        </span>
       )}
-      <div className="border-t border-border px-3 py-1.5">
-        <span className="text-[10px] text-muted-foreground">v{data.current}</span>
-      </div>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replace bulky upgrade banner (icon + text + code block + dismiss button) with a minimal single-line footer
- Shows `v0.1.0-dev` always, with a small `↑ v1.0.22` indicator when an update is available
- Upgrade command accessible via hover tooltip (title attribute)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — all 1001 tests pass
- [ ] Visual check — version footer is compact and unobtrusive

🤖 Generated with [Claude Code](https://claude.com/claude-code)