### PR TITLE
Add copy buttons and bun alternative to upgrade popover

### DIFF
--- a/src/frontend/components/AgentSidebar.test.tsx
+++ b/src/frontend/components/AgentSidebar.test.tsx
@@ -15,57 +15,42 @@ const defaultProps = {
   onBrowseCatalog: mock(() => {}),
 };
 
-function setVersionResponse(response: {
-  current: string;
-  latest: string | null;
-  updateAvailable: boolean;
-  upgradeCommand: string;
-}) {
-  server.use(http.get("*/api/version", () => HttpResponse.json(response)));
-}
-
 describe("VersionFooter", () => {
   it("shows current version in the sidebar", async () => {
-    setVersionResponse({
-      current: "1.0.20",
-      latest: null,
-      updateAvailable: false,
-      upgradeCommand: "npm install -g agents-shire@latest",
-    });
     renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
 
     await waitFor(() => {
-      expect(screen.getByText("v1.0.20")).toBeInTheDocument();
+      expect(screen.getByText(/^v\d/)).toBeInTheDocument();
     });
   });
 
-  it("shows upgrade indicator when update is available", async () => {
-    setVersionResponse({
-      current: "1.0.20",
-      latest: "1.0.22",
-      updateAvailable: true,
-      upgradeCommand: "npm install -g agents-shire@latest",
-    });
+  it("shows upgrade button when update is available", async () => {
+    server.use(
+      http.get("*/api/version", () =>
+        HttpResponse.json({
+          current: "1.0.20",
+          latest: "1.0.22",
+          updateAvailable: true,
+          upgradeCommands: [
+            "npm install -g agents-shire@latest",
+            "bun install -g agents-shire@latest",
+          ],
+        }),
+      ),
+    );
     renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
 
     await waitFor(() => {
-      expect(screen.getByText("v1.0.20")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Update Available/ })).toBeInTheDocument();
     });
-    expect(screen.getByText("Update Available")).toBeInTheDocument();
   });
 
-  it("does not show upgrade indicator when no update available", async () => {
-    setVersionResponse({
-      current: "1.0.22",
-      latest: "1.0.22",
-      updateAvailable: false,
-      upgradeCommand: "npm install -g agents-shire@latest",
-    });
+  it("does not show upgrade button when no update available", async () => {
     renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
 
     await waitFor(() => {
-      expect(screen.getByText("v1.0.22")).toBeInTheDocument();
+      expect(screen.getByText(/^v\d/)).toBeInTheDocument();
     });
-    expect(screen.queryByText("Update Available")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Update Available/ })).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/components/AgentSidebar.tsx
+++ b/src/frontend/components/AgentSidebar.tsx
@@ -18,6 +18,7 @@ import {
   AlertDialogTitle,
 } from "./ui/alert-dialog";
 import { FileText, Settings, FolderOpen, Clock, ArrowUpCircle } from "lucide-react";
+import { CopyButton } from "./CopyButton";
 import { Spinner } from "./ui/spinner";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import ProjectSwitcher from "./ProjectSwitcher";
@@ -52,9 +53,15 @@ function VersionFooter() {
             <ArrowUpCircle className="h-3 w-3" />
             Update Available
           </PopoverTrigger>
-          <PopoverContent side="top" align="end" className="w-auto p-2.5 text-[10px]">
+          <PopoverContent side="top" align="end" className="w-auto p-3 text-xs space-y-2">
             <p className="font-medium">v{data.latest} available</p>
-            <code className="text-muted-foreground">{data.upgradeCommand}</code>
+            {data.upgradeCommands.map((cmd, i) => (
+              <div key={cmd} className="flex items-center gap-1.5">
+                {i > 0 && <span className="text-muted-foreground text-[10px]">or</span>}
+                <code className="text-muted-foreground text-[10px]">{cmd}</code>
+                <CopyButton text={cmd} />
+              </div>
+            ))}
           </PopoverContent>
         </Popover>
       )}

--- a/src/frontend/test/msw-handlers.ts
+++ b/src/frontend/test/msw-handlers.ts
@@ -104,7 +104,7 @@ export const defaultHandlers = [
       current: "0.1.0-dev",
       latest: null,
       updateAvailable: false,
-      upgradeCommand: "npm install -g agents-shire@latest",
+      upgradeCommands: ["npm install -g agents-shire@latest", "bun install -g agents-shire@latest"],
     }),
   ),
 

--- a/src/routes/version.test.ts
+++ b/src/routes/version.test.ts
@@ -65,13 +65,16 @@ describe("GET /api/version", () => {
         current: string;
         latest: string | null;
         updateAvailable: boolean;
-        upgradeCommand: string;
+        upgradeCommands: string[];
       };
       expect(data.current).toBe(CURRENT_VERSION);
       expect(data.latest).toBe("99.0.0");
       // Dev versions (containing "-") never report updateAvailable
       expect(data.updateAvailable).toBe(!CURRENT_VERSION.includes("-"));
-      expect(data.upgradeCommand).toBe("npm install -g agents-shire@latest");
+      expect(data.upgradeCommands).toEqual([
+        "npm install -g agents-shire@latest",
+        "bun install -g agents-shire@latest",
+      ]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/routes/version.ts
+++ b/src/routes/version.ts
@@ -42,7 +42,7 @@ export const versionRoutes = new Hono<AppEnv>().get("/version", async (c) => {
     current: CURRENT_VERSION,
     latest,
     updateAvailable: latest ? isNewer(latest, CURRENT_VERSION) : false,
-    upgradeCommand: "npm install -g agents-shire@latest",
+    upgradeCommands: ["npm install -g agents-shire@latest", "bun install -g agents-shire@latest"],
   });
 });
 


### PR DESCRIPTION
## Summary
- Backend returns `upgradeCommands` array instead of single `upgradeCommand` string
- Popover shows both `npm install -g agents-shire@latest` and `bun install -g agents-shire@latest` separated by "or"
- Each command has a copy button (reuses existing `CopyButton` component)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — all 1004 tests pass
- [ ] Click "Update Available", verify both commands shown with copy buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)