### PR TITLE
Support .mdx files in the shared drive editor

### DIFF
--- a/src/frontend/components/SharedDrive.tsx
+++ b/src/frontend/components/SharedDrive.tsx
@@ -99,7 +99,7 @@ function getFileExtension(name: string): string {
 
 function getPreviewType(name: string): PreviewType {
   const ext = getFileExtension(name);
-  if (ext === "md") return "markdown";
+  if (ext === "md" || ext === "mdx") return "markdown";
   if (TEXT_EXTENSIONS.has(ext)) return "text";
   if (IMAGE_EXTENSIONS.has(ext)) return "image";
   if (ext === "pdf") return "pdf";

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -202,6 +202,25 @@ describe("SharedDrive", () => {
       });
     });
 
+    it("renders mdx file in the rich text editor", async () => {
+      const filesWithMdx: SharedDriveFile[] = [
+        { name: "article.mdx", path: "article.mdx", type: "file", size: 512 },
+      ];
+      setFiles(filesWithMdx);
+      setPreviewResponse("# MDX Content", "article.mdx", 512);
+      renderWithProviders(<SharedDrive />, routeOpts);
+
+      await waitFor(() => {
+        expect(screen.getByText("article.mdx")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByText("article.mdx"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("textbox")).toBeInTheDocument();
+      });
+    });
+
     it("shows save status indicator for markdown editor", async () => {
       setFiles(sampleFiles);
       setPreviewResponse("# Hello World", "readme.md", 1024);


### PR DESCRIPTION
## Summary
- `.mdx` files were showing "Preview is not available for this file type"
- Treat `.mdx` the same as `.md` — open in the rich text editor

## Test plan
- [ ] Click a `.mdx` file in the shared drive — should open in the editor instead of showing unsupported message

🤖 Generated with [Claude Code](https://claude.com/claude-code)