### PR TITLE
Fix sidebar tab state, image preview, and attachment URLs

### DIFF
--- a/src/frontend/components/AgentSidebar.tsx
+++ b/src/frontend/components/AgentSidebar.tsx
@@ -69,6 +69,16 @@ export default function AgentSidebar({ onNewAgent, onBrowseCatalog }: AgentSideb
     }
   }, [isSharedDrive, location.pathname, location.search]);
 
+  // Reset remembered paths when switching projects (skip initial mount)
+  const prevProjectRoot = useRef(projectRoot);
+  useEffect(() => {
+    if (prevProjectRoot.current !== projectRoot) {
+      prevProjectRoot.current = projectRoot;
+      lastAgentPath.current = projectRoot;
+      lastSharedPath.current = `${projectRoot}/shared`;
+    }
+  }, [projectRoot]);
+
   const handleTabChange = (value: string) => {
     if (value === "shared-drive") {
       navigate(lastSharedPath.current);

--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -72,7 +72,7 @@ const AttachmentDisplay = React.memo(function AttachmentDisplay({
   return (
     <div className="flex flex-wrap gap-2 mt-2">
       {attachments.map((att) => {
-        const url = `/api/projects/${projectName}/agents/${agentId}/attachments/${att.id}/${att.filename}`;
+        const url = `/api/projects/${projectName}/agents/${agentId}/attachments/${att.id}/${encodeURIComponent(att.filename)}`;
         const isImage = att.content_type.startsWith("image/");
 
         return isImage ? (

--- a/src/frontend/components/SharedDriveContentArea.tsx
+++ b/src/frontend/components/SharedDriveContentArea.tsx
@@ -160,6 +160,7 @@ export default function SharedDriveContentArea() {
   }
 
   const previewUrl = `/api/projects/${projectName}/shared-drive/preview?path=${encodeURIComponent(filePath)}`;
+  const downloadUrl = `/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(filePath)}`;
 
   return (
     <div className="flex flex-col h-full relative" {...getRootProps()}>
@@ -257,7 +258,7 @@ export default function SharedDriveContentArea() {
         {!loading && !error && type === "image" && (
           <div className="flex items-center justify-center p-4">
             <img
-              src={previewUrl}
+              src={downloadUrl}
               alt={fileName}
               loading="lazy"
               className="max-w-full max-h-[70vh] object-contain"

--- a/src/frontend/test/ChatPanel.test.tsx
+++ b/src/frontend/test/ChatPanel.test.tsx
@@ -557,6 +557,32 @@ describe("ChatPanel", () => {
     });
   });
 
+  it("encodes attachment filename with spaces in URL", async () => {
+    const msgWithSpacey: Message = {
+      id: 32,
+      role: "agent",
+      text: "",
+      ts: "2026-03-17T00:00:07Z",
+      attachments: [
+        {
+          id: "img002",
+          filename: "Screenshot 2026-04-10 at 10.30.00.png",
+          size: 4096,
+          content_type: "image/png",
+        },
+      ],
+    };
+    setMessages([msgWithSpacey]);
+    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    await waitFor(() => {
+      const img = screen.getByAltText("Screenshot 2026-04-10 at 10.30.00.png");
+      expect(img).toHaveAttribute(
+        "src",
+        "/api/projects/test-project/agents/a1/attachments/img002/Screenshot%202026-04-10%20at%2010.30.00.png",
+      );
+    });
+  });
+
   it("sets aria-expanded on tool call toggle button", async () => {
     const toolMsg: Message = {
       id: 3,

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -289,14 +289,14 @@ describe("SharedDriveContentArea", () => {
     expect(screen.getByText("Saved")).toBeInTheDocument();
   });
 
-  it("shows image preview via img tag for image files", async () => {
+  it("shows image preview via img tag using download endpoint", async () => {
     renderContentArea("/projects/test-project/shared?file=photo.png");
     await waitFor(() => {
       const img = screen.getByRole("img", { name: "photo.png" });
       expect(img).toBeInTheDocument();
       expect(img).toHaveAttribute(
         "src",
-        "/api/projects/test-project/shared-drive/preview?path=photo.png",
+        "/api/projects/test-project/shared-drive/download?path=photo.png",
       );
     });
   });

--- a/src/routes/shared-drive.test.ts
+++ b/src/routes/shared-drive.test.ts
@@ -208,7 +208,23 @@ describe("shared-drive routes", () => {
     );
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Disposition")).toContain("dl.txt");
-    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(res.headers.get("Content-Type")).toBe("text/plain");
+  });
+
+  it("GET /api/projects/:id/shared-drive/download returns correct Content-Type for images", async () => {
+    const sharedRoot = workspace.sharedDir(projectId);
+    mkdirSync(sharedRoot, { recursive: true });
+    // Write a minimal PNG header
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    writeFileSync(join(sharedRoot, "photo.png"), pngHeader);
+
+    const res = await request(
+      "GET",
+      `/api/projects/${projectId}/shared-drive/download?path=photo.png`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Content-Disposition")).toContain("inline");
   });
 
   it("GET /api/projects/:id/shared-drive/download returns 404 for missing file", async () => {

--- a/src/routes/shared-drive.ts
+++ b/src/routes/shared-drive.ts
@@ -6,6 +6,7 @@ import { join, resolve, basename, dirname } from "path";
 import * as workspace from "../services/workspace";
 import * as projectsService from "../services/projects";
 import type { AppEnv } from "../types";
+import { mimeFromPath } from "../utils/mime";
 
 function resolveProjectId(nameOrId: string): string | null {
   const byId = projectsService.getProject(nameOrId);
@@ -98,10 +99,12 @@ export const sharedDriveRoutes = new Hono<AppEnv>()
     try {
       const data = await readFile(fullPath);
       const filename = basename(fullPath);
+      const contentType = mimeFromPath(filename);
+      const isSafeImage = contentType.startsWith("image/") && contentType !== "image/svg+xml";
       return new Response(data, {
         headers: {
-          "Content-Disposition": `attachment; filename="${filename}"`,
-          "Content-Type": "application/octet-stream",
+          "Content-Disposition": `${isSafeImage ? "inline" : "attachment"}; filename="${filename.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`,
+          "Content-Type": contentType,
         },
       });
     } catch {


### PR DESCRIPTION
## Summary
- **Sidebar tab state leak**: Reset remembered tab paths when switching projects, preventing stale navigation to the wrong project's agents/files
- **Shared drive image preview**: Use the download endpoint (with proper `Content-Type`) instead of the preview endpoint (which returns JSON) for `<img>` rendering
- **Attachment URL encoding**: Encode filenames with `encodeURIComponent` so screenshots with spaces in their names display correctly

## Test plan
- [ ] Switch between two projects with agents, toggle between Agents/Files tabs — verify correct project's agents shown
- [ ] Upload an image to shared drive, select it — verify image renders in preview area
- [ ] Send a message with a screenshot attachment — verify the image thumbnail displays in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)