### PR TITLE
Fix instant scroll on agent switch and use Lucide chevron icons

### DIFF
--- a/src/frontend/components/AgentChatView.tsx
+++ b/src/frontend/components/AgentChatView.tsx
@@ -122,7 +122,7 @@ export default function AgentChatView() {
       <>
         <ChatHeader agent={selectedAgent} onMenuToggle={() => setSidebarOpen(!sidebarOpen)} />
         <div className="flex-1 min-h-0">
-          <ChatPanel agent={selectedAgent} streamingText={streamingText} />
+          <ChatPanel key={selectedAgent.id} agent={selectedAgent} streamingText={streamingText} />
         </div>
       </>
     );

--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -117,7 +117,7 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
     return () => observer.disconnect();
   }, [hasMore, loadingMore, fetchNextPage, messages.length]);
 
-  const stickyInstance = useStickToBottom();
+  const stickyInstance = useStickToBottom({ initial: "instant", resize: "smooth" });
 
   useTickingClock(60_000);
 

--- a/src/frontend/components/ai-elements/conversation.tsx
+++ b/src/frontend/components/ai-elements/conversation.tsx
@@ -15,8 +15,8 @@ export type ConversationProps = ComponentProps<typeof StickToBottom>;
 export const Conversation = ({ className, ...props }: ConversationProps) => (
   <StickToBottom
     className={cn("relative flex-1 overflow-y-hidden", className)}
-    initial="smooth"
-    resize="smooth"
+    initial="instant"
+    resize="instant"
     role="log"
     {...props}
   />

--- a/src/frontend/components/chat/InterAgentMessage.tsx
+++ b/src/frontend/components/chat/InterAgentMessage.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import Markdown from "@/components/Markdown";
 import { type Message } from "./types";
 
@@ -13,7 +14,11 @@ export const InterAgentMessage = React.memo(function InterAgentMessage({ msg }: 
         aria-expanded={open}
         className="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-muted/50 rounded-lg italic"
       >
-        <span className="text-muted-foreground">{open ? "\u25BC" : "\u25B6"}</span>
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
         <span className="text-muted-foreground">Message from {msg.fromAgent}</span>
       </button>
       {open && (

--- a/src/frontend/components/chat/SystemMessage.tsx
+++ b/src/frontend/components/chat/SystemMessage.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Markdown from "@/components/Markdown";
 import { type Message } from "./types";
@@ -14,7 +15,11 @@ export const SystemMessage = React.memo(function SystemMessage({ msg }: { msg: M
         aria-expanded={open}
         className="flex w-full items-center gap-2 px-3 py-1.5 text-left italic h-auto justify-start"
       >
-        <span className="text-muted-foreground">{open ? "\u25BC" : "\u25B6"}</span>
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
         <span className="text-muted-foreground">System notification</span>
       </Button>
       {open && (

--- a/src/frontend/components/chat/ToolCallMessage.tsx
+++ b/src/frontend/components/chat/ToolCallMessage.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { CodeBlock } from "@/components/ai-elements/code-block";
 import { type Message } from "./types";
@@ -16,7 +17,11 @@ export const ToolCallMessage = React.memo(function ToolCallMessage({ msg }: { ms
         aria-expanded={open}
         className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 rounded-lg"
       >
-        <span className="text-muted-foreground">{open ? "\u25BC" : "\u25B6"}</span>
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
         <Badge variant="outline" className="font-mono text-xs">
           {msg.tool}
         </Badge>


### PR DESCRIPTION
## Summary
- Fix animated scroll on initial load and agent switch by keying ChatPanel with `agent.id` and using `initial: "instant"` on `useStickToBottom`
- Keep `resize: "smooth"` so new messages during conversation scroll smoothly
- Replace Unicode triangle arrows (`▶`/`▼`) with Lucide `ChevronRight`/`ChevronDown` in ToolCallMessage, InterAgentMessage, and SystemMessage

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 1054 tests pass
- [ ] Manual: switch agents — should snap to bottom instantly
- [ ] Manual: new messages during conversation — should scroll smoothly
- [ ] Manual: tool call / inter-agent / system messages show chevron icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)