### PR TITLE
Fix infinite scroll fetching all pages when scrolling up

### DIFF
--- a/src/frontend/components/ChatPanel.tsx
+++ b/src/frontend/components/ChatPanel.tsx
@@ -99,25 +99,21 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
 
   const streamingText = externalStreamingText ?? "";
 
-  // Infinite scroll sentinel
-  const sentinelRef = React.useRef<HTMLDivElement>(null);
-  React.useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasMore && !loadingMore && messages.length > 0) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [hasMore, loadingMore, fetchNextPage, messages.length]);
-
   const stickyInstance = useStickToBottom({ initial: "instant", resize: "instant" });
+
+  // Infinite scroll: fetch older messages when user scrolls near the top
+  React.useEffect(() => {
+    const scrollEl = stickyInstance.scrollRef.current;
+    if (!scrollEl) return;
+
+    const handleScroll = () => {
+      if (scrollEl.scrollTop < 50 && hasMore && !loadingMore && messages.length > 0) {
+        fetchNextPage();
+      }
+    };
+    scrollEl.addEventListener("scroll", handleScroll, { passive: true });
+    return () => scrollEl.removeEventListener("scroll", handleScroll);
+  }, [stickyInstance.scrollRef, hasMore, loadingMore, fetchNextPage, messages.length]);
 
   useTickingClock(60_000);
 
@@ -127,7 +123,6 @@ export default function ChatPanel({ agent, streamingText: externalStreamingText 
     <div className="flex flex-col h-full relative">
       <Conversation instance={stickyInstance}>
         <ConversationContent>
-          <div ref={sentinelRef} className="h-px" />
           {loadingMore && (
             <div className="flex justify-center py-2">
               <span className="text-xs text-muted-foreground animate-pulse">

--- a/src/frontend/test/ChatPanel.test.tsx
+++ b/src/frontend/test/ChatPanel.test.tsx
@@ -235,20 +235,8 @@ describe("ChatPanel", () => {
     expect(screen.getByText("done")).toBeInTheDocument();
   });
 
-  it("fetches next page when sentinel becomes visible", async () => {
+  it("fetches next page when scrolled to top", async () => {
     let fetchCount = 0;
-    // Capture IntersectionObserver callback
-    let observerCallback: IntersectionObserverCallback | null = null;
-    const origIO = globalThis.IntersectionObserver;
-    globalThis.IntersectionObserver = class MockIO {
-      constructor(cb: IntersectionObserverCallback) {
-        observerCallback = cb;
-      }
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof IntersectionObserver;
-
     server.use(
       http.get("*/api/projects/:id/agents/:aid/messages", ({ request }) => {
         fetchCount++;
@@ -263,37 +251,39 @@ describe("ChatPanel", () => {
         });
       }),
     );
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    const { container } = renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
 
     await waitFor(() => {
       expect(screen.getByText("Hello agent")).toBeInTheDocument();
     });
 
     const initialCount = fetchCount;
-    // Simulate sentinel becoming visible (scrolled to top)
-    observerCallback!(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
-    );
+    // The scroll listener attaches to stickyInstance.scrollRef.current.
+    // Try the rendered scroll container first, then fall back to any scrollable element.
+    const scrollContainer =
+      container.querySelector('[role="log"] > div') ?? container.querySelector('[role="log"]');
+    if (scrollContainer) {
+      Object.defineProperty(scrollContainer, "scrollTop", { value: 0, writable: true });
+      fireEvent.scroll(scrollContainer);
+    }
+
+    // Also dispatch on the mock scrollRef element (when use-stick-to-bottom is mocked,
+    // the scroll listener attaches to a detached element from the mock)
+    const stb = await import("use-stick-to-bottom");
+    if ("useStickToBottom" in stb) {
+      const instance = (stb.useStickToBottom as () => { scrollRef: { current: HTMLElement } })();
+      const mockScrollEl = instance.scrollRef.current;
+      if (mockScrollEl) {
+        Object.defineProperty(mockScrollEl, "scrollTop", { value: 0, writable: true });
+        mockScrollEl.dispatchEvent(new Event("scroll"));
+      }
+    }
 
     await waitFor(() => expect(fetchCount).toBeGreaterThan(initialCount));
-
-    globalThis.IntersectionObserver = origIO;
   });
 
   it("does not fetch next page when no messages", async () => {
     let fetchCount = 0;
-    let observerCallback: IntersectionObserverCallback | null = null;
-    const origIO = globalThis.IntersectionObserver;
-    globalThis.IntersectionObserver = class MockIO {
-      constructor(cb: IntersectionObserverCallback) {
-        observerCallback = cb;
-      }
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof IntersectionObserver;
-
     server.use(
       http.get("*/api/projects/:id/agents/:aid/messages", () => {
         fetchCount++;
@@ -303,21 +293,22 @@ describe("ChatPanel", () => {
     renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
 
     await waitForText(/Send a message to start working/);
-    // Wait for the initial messages fetch to complete
     await new Promise((r) => setTimeout(r, 200));
 
     const prevCount = fetchCount;
-    // Simulate sentinel becoming visible — should NOT trigger fetch when no messages
-    observerCallback!(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
-    );
+    // Dispatch scroll on mock scrollRef — should NOT trigger fetch when no messages
+    const stb = await import("use-stick-to-bottom");
+    if ("useStickToBottom" in stb) {
+      const instance = (stb.useStickToBottom as () => { scrollRef: { current: HTMLElement } })();
+      const mockScrollEl = instance.scrollRef.current;
+      if (mockScrollEl) {
+        Object.defineProperty(mockScrollEl, "scrollTop", { value: 0, writable: true });
+        mockScrollEl.dispatchEvent(new Event("scroll"));
+      }
+    }
 
-    // Give time for any potential fetch
     await new Promise((r) => setTimeout(r, 100));
     expect(fetchCount).toBe(prevCount);
-
-    globalThis.IntersectionObserver = origIO;
   });
 
   it("renders streaming text from props", async () => {

--- a/src/frontend/test/conversation.test.tsx
+++ b/src/frontend/test/conversation.test.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, mock } from "bun:test";
@@ -10,17 +11,38 @@ import {
 const scrollToBottom = mock(() => {});
 
 // Mock use-stick-to-bottom to control isAtBottom state
-mock.module("use-stick-to-bottom", () => ({
-  StickToBottom: ({ children, className, ...props }: Record<string, unknown>) => (
-    <div className={className as string} {...props}>
-      {children as React.ReactNode}
-    </div>
-  ),
-  useStickToBottomContext: () => ({
-    isAtBottom: false,
-    scrollToBottom,
-  }),
-}));
+mock.module("use-stick-to-bottom", () => {
+  const scrollDiv = document.createElement("div");
+  const contentDiv = document.createElement("div");
+  const scrollRef = Object.assign((_el: HTMLElement | null) => {}, {
+    current: scrollDiv,
+  }) as unknown as React.MutableRefObject<HTMLElement | null> & React.RefCallback<HTMLElement>;
+  const contentRef = Object.assign((_el: HTMLElement | null) => {}, {
+    current: contentDiv,
+  }) as unknown as React.MutableRefObject<HTMLElement | null> & React.RefCallback<HTMLElement>;
+
+  return {
+    StickToBottom: ({ children, className, ...props }: Record<string, unknown>) => (
+      <div className={className as string} {...props}>
+        {children as React.ReactNode}
+      </div>
+    ),
+    useStickToBottomContext: () => ({
+      isAtBottom: false,
+      scrollToBottom,
+    }),
+    useStickToBottom: () => ({
+      scrollRef,
+      contentRef,
+      scrollToBottom,
+      stopScroll: () => {},
+      isAtBottom: true,
+      isNearBottom: true,
+      escapedFromLock: false,
+      state: {},
+    }),
+  };
+});
 
 // Assign Content sub-component after mock is in place
 const stb = await import("use-stick-to-bottom");


### PR DESCRIPTION
## Summary
- Replace IntersectionObserver sentinel with scroll event listener on `stickyInstance.scrollRef`
- The sentinel stayed visible as older messages loaded, causing a chain reaction that fetched every page until the earliest message
- Now only triggers `fetchNextPage` when `scrollTop < 50`, matching the original pre-migration behavior

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 1054 tests pass
- [ ] Manual: scroll up to load older messages — should load one page at a time, not all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)