### PR TITLE
Add clickable shared drive file paths in agent messages

### DIFF
--- a/src/frontend/components/Markdown.tsx
+++ b/src/frontend/components/Markdown.tsx
@@ -1,4 +1,5 @@
 import { MessageResponse } from "@/components/ai-elements/message-response";
+import { useProjectLayout } from "@/providers/ProjectLayoutProvider";
 
 interface MarkdownProps {
   children: string;
@@ -6,9 +7,10 @@ interface MarkdownProps {
 }
 
 export default function Markdown({ children, className }: MarkdownProps) {
+  const { projectName } = useProjectLayout();
   return (
     <div className={`prose prose-sm max-w-none dark:prose-invert break-words ${className ?? ""}`}>
-      <MessageResponse>{children}</MessageResponse>
+      <MessageResponse projectName={projectName}>{children}</MessageResponse>
     </div>
   );
 }

--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -144,6 +144,7 @@ export default function ProjectLayout() {
 
   const contextValue: ProjectLayoutContextValue = {
     projectId,
+    projectName: projectName ?? "",
     sidebarOpen,
     setSidebarOpen,
     onNewAgent: handleNew,

--- a/src/frontend/components/ai-elements/message-response.tsx
+++ b/src/frontend/components/ai-elements/message-response.tsx
@@ -6,23 +6,54 @@
 import { cn } from "@/components/lib/utils";
 import { code } from "@streamdown/code";
 import type { ComponentProps } from "react";
-import { memo } from "react";
-import { Streamdown } from "streamdown";
+import { memo, useMemo } from "react";
+import { Streamdown, type Components } from "streamdown";
+import remarkSharedLinks from "@/lib/remark-shared-links";
+import { SharedDriveLink } from "@/components/chat/SharedDriveLink";
+import type { Pluggable } from "unified";
 
-export type MessageResponseProps = ComponentProps<typeof Streamdown>;
+export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
+  projectName?: string;
+};
 
 const streamdownPlugins = { code };
+const sharedLinksPlugins: Pluggable[] = [remarkSharedLinks];
 
 export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
-    <Streamdown
-      className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
-      plugins={streamdownPlugins}
-      {...props}
-    />
-  ),
+  ({
+    className,
+    projectName,
+    remarkPlugins,
+    components: componentsProp,
+    ...props
+  }: MessageResponseProps) => {
+    const components = useMemo<Components | undefined>(() => {
+      if (!projectName) return componentsProp;
+      return {
+        ...componentsProp,
+        a: (linkProps) => <SharedDriveLink {...linkProps} projectName={projectName} />,
+      };
+    }, [projectName, componentsProp]);
+
+    const mergedRemarkPlugins = useMemo(() => {
+      if (!projectName) return remarkPlugins;
+      return remarkPlugins ? [...sharedLinksPlugins, ...remarkPlugins] : sharedLinksPlugins;
+    }, [projectName, remarkPlugins]);
+
+    return (
+      <Streamdown
+        className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
+        plugins={streamdownPlugins}
+        remarkPlugins={mergedRemarkPlugins}
+        components={components}
+        {...props}
+      />
+    );
+  },
   (prevProps, nextProps) =>
-    prevProps.children === nextProps.children && nextProps.isAnimating === prevProps.isAnimating,
+    prevProps.children === nextProps.children &&
+    nextProps.isAnimating === prevProps.isAnimating &&
+    prevProps.projectName === nextProps.projectName,
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/src/frontend/components/chat/SharedDriveLink.tsx
+++ b/src/frontend/components/chat/SharedDriveLink.tsx
@@ -1,0 +1,32 @@
+import type { AnchorHTMLAttributes } from "react";
+import { Link } from "react-router-dom";
+import type { Element } from "hast";
+
+interface SharedDriveLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  projectName: string;
+  node?: Element;
+}
+
+export function SharedDriveLink({
+  href,
+  children,
+  projectName,
+  node: _,
+  ...rest
+}: SharedDriveLinkProps) {
+  if (href?.startsWith("/shared/")) {
+    const filePath = href.slice("/shared".length);
+    const to = `/projects/${projectName}/shared?file=${encodeURIComponent(filePath)}`;
+    return (
+      <Link to={to} className="text-primary underline" {...rest}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
+      {children}
+    </a>
+  );
+}

--- a/src/frontend/lib/remark-shared-links.ts
+++ b/src/frontend/lib/remark-shared-links.ts
@@ -1,0 +1,24 @@
+import { findAndReplace } from "mdast-util-find-and-replace";
+import type { Root, PhrasingContent } from "mdast";
+
+function stripTrailingPunctuation(path: string): string {
+  return path.replace(/[.,;:]+$/, "");
+}
+
+export default function remarkSharedLinks() {
+  return (tree: Root) => {
+    findAndReplace(tree, [
+      [
+        /\/shared\/[^\s)}\]"'`,;!]+/g,
+        (match: string): PhrasingContent => {
+          const cleanPath = stripTrailingPunctuation(match);
+          return {
+            type: "link",
+            url: cleanPath,
+            children: [{ type: "text", value: cleanPath }],
+          };
+        },
+      ],
+    ]);
+  };
+}

--- a/src/frontend/providers/ProjectLayoutProvider.tsx
+++ b/src/frontend/providers/ProjectLayoutProvider.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "../components/ui/spinner";
 
 export interface ProjectLayoutContextValue {
   projectId: string | undefined;
+  projectName: string;
   sidebarOpen: boolean;
   setSidebarOpen: (open: boolean) => void;
   onNewAgent: () => void;

--- a/src/frontend/test/ChatPanel.test.tsx
+++ b/src/frontend/test/ChatPanel.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "./msw-server";
 import ChatPanel, { type Message } from "../components/ChatPanel";
 import { type AgentOverview } from "../components/types";
+import { ProjectLayoutProvider } from "../providers/ProjectLayoutProvider";
 import { renderWithProviders, waitForText } from "./test-utils";
 
 mock.module("../lib/ws", () => ({
@@ -28,6 +29,24 @@ const routeOpts = {
   route: "/projects/test-project",
   routePath: "/projects/:projectName",
 };
+
+const layoutValue = {
+  projectId: "p1",
+  projectName: "test-project",
+  sidebarOpen: false,
+  setSidebarOpen: () => {},
+  onNewAgent: () => {},
+  onBrowseCatalog: () => {},
+};
+
+function renderChat(agent: AgentOverview, extra?: { streamingText?: string }) {
+  return renderWithProviders(
+    <ProjectLayoutProvider value={layoutValue}>
+      <ChatPanel agent={agent} {...extra} />
+    </ProjectLayoutProvider>,
+    routeOpts,
+  );
+}
 
 /** Helper to build API-format messages that transformMessages() in the component will process */
 function apiMessage(msg: Message): Record<string, unknown> {
@@ -74,14 +93,14 @@ function createDataTransfer(files: File[]): DataTransfer {
 
 describe("ChatPanel", () => {
   it("renders empty state when no messages", async () => {
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText(/Send a message to start working/)).toBeInTheDocument();
     });
   });
 
   it("shows suggestion chips in empty state for active agent", async () => {
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitForText("What can you help me with?");
     await userEvent.click(screen.getByText("What can you help me with?"));
     // After clicking, the chip triggers a message send — component should react
@@ -90,7 +109,7 @@ describe("ChatPanel", () => {
 
   it("renders messages", async () => {
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Hello agent")).toBeInTheDocument();
     });
@@ -99,7 +118,7 @@ describe("ChatPanel", () => {
 
   it("shows input bar when agent is active", async () => {
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Type a message...")).toBeInTheDocument();
     });
@@ -108,7 +127,7 @@ describe("ChatPanel", () => {
 
   it("hides input bar when agent is not active", async () => {
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={createdAgent} />, routeOpts);
+    renderChat(createdAgent);
     await waitFor(() => {
       expect(screen.getByText("Hello agent")).toBeInTheDocument();
     });
@@ -124,7 +143,7 @@ describe("ChatPanel", () => {
       }),
     );
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Type a message...")).toBeInTheDocument();
@@ -150,7 +169,7 @@ describe("ChatPanel", () => {
       }),
     );
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Type a message...")).toBeInTheDocument();
@@ -176,7 +195,7 @@ describe("ChatPanel", () => {
       }),
     );
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Type a message...")).toBeInTheDocument();
@@ -204,7 +223,7 @@ describe("ChatPanel", () => {
       }),
     );
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
 
     await waitFor(() => {
       expect(screen.getByText("Send")).toBeInTheDocument();
@@ -228,7 +247,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:02Z",
     };
     setMessages([toolMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("read_file")).toBeInTheDocument();
     });
@@ -251,7 +270,7 @@ describe("ChatPanel", () => {
         });
       }),
     );
-    const { container } = renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    const { container } = renderChat(activeAgent);
 
     await waitFor(() => {
       expect(screen.getByText("Hello agent")).toBeInTheDocument();
@@ -290,7 +309,7 @@ describe("ChatPanel", () => {
         return HttpResponse.json({ messages: [], hasMore: true });
       }),
     );
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
 
     await waitForText(/Send a message to start working/);
     await new Promise((r) => setTimeout(r, 200));
@@ -313,19 +332,24 @@ describe("ChatPanel", () => {
 
   it("renders streaming text from props", async () => {
     setMessages(messages);
-    const { rerender } = renderWithProviders(
-      <ChatPanel agent={activeAgent} streamingText="Hello " />,
-      routeOpts,
-    );
+    const { rerender } = renderChat(activeAgent, { streamingText: "Hello " });
 
     await waitFor(() => {
       expect(screen.getByText("Hello")).toBeInTheDocument();
     });
 
-    rerender(<ChatPanel agent={activeAgent} streamingText="Hello world!" />);
+    rerender(
+      <ProjectLayoutProvider value={layoutValue}>
+        <ChatPanel agent={activeAgent} streamingText="Hello world!" />
+      </ProjectLayoutProvider>,
+    );
     expect(screen.getByText("Hello world!")).toBeInTheDocument();
 
-    rerender(<ChatPanel agent={activeAgent} streamingText="" />);
+    rerender(
+      <ProjectLayoutProvider value={layoutValue}>
+        <ChatPanel agent={activeAgent} streamingText="" />
+      </ProjectLayoutProvider>,
+    );
     expect(screen.queryByText("Hello world!")).not.toBeInTheDocument();
   });
 
@@ -338,7 +362,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:03Z",
     };
     setMessages([interAgentMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Message from researcher")).toBeInTheDocument();
     });
@@ -354,7 +378,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:03Z",
     };
     setMessages([interAgentMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Message from researcher")).toBeInTheDocument();
     });
@@ -371,7 +395,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:03Z",
     };
     setMessages([interAgentMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Message from researcher")).toBeInTheDocument();
     });
@@ -390,7 +414,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:04Z",
     };
     setMessages([sysMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("System notification")).toBeInTheDocument();
     });
@@ -405,7 +429,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:04Z",
     };
     setMessages([sysMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("System notification")).toBeInTheDocument();
     });
@@ -421,7 +445,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:04Z",
     };
     setMessages([sysMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("System notification")).toBeInTheDocument();
     });
@@ -435,7 +459,7 @@ describe("ChatPanel", () => {
   it("shows stop button when agent is busy", async () => {
     const busyAgent = { ...activeAgent, busy: true };
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={busyAgent} />, routeOpts);
+    renderChat(busyAgent);
     await waitFor(() => {
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
@@ -452,7 +476,7 @@ describe("ChatPanel", () => {
     );
     const busyAgent = { ...activeAgent, busy: true };
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={busyAgent} />, routeOpts);
+    renderChat(busyAgent);
     await waitFor(() => {
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
@@ -462,7 +486,7 @@ describe("ChatPanel", () => {
 
   it("shows send button when agent is not busy", async () => {
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Send")).toBeInTheDocument();
     });
@@ -472,7 +496,7 @@ describe("ChatPanel", () => {
   it("shows thinking indicator when agent is busy and not streaming", async () => {
     const busyAgent = { ...activeAgent, busy: true };
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={busyAgent} />, routeOpts);
+    renderChat(busyAgent);
     await waitFor(() => {
       expect(screen.getByText("Thinking...")).toBeInTheDocument();
     });
@@ -481,7 +505,7 @@ describe("ChatPanel", () => {
   it("hides thinking indicator when agent is busy but streaming", async () => {
     const busyAgent = { ...activeAgent, busy: true };
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={busyAgent} streamingText="streaming..." />, routeOpts);
+    renderChat(busyAgent, { streamingText: "streaming..." });
 
     await waitFor(() => {
       expect(screen.getByText("streaming...")).toBeInTheDocument();
@@ -491,7 +515,7 @@ describe("ChatPanel", () => {
 
   it("does not show thinking indicator when agent is not busy", async () => {
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Hello agent")).toBeInTheDocument();
     });
@@ -501,7 +525,7 @@ describe("ChatPanel", () => {
   it("shows idle message and restart button when agent is idle", async () => {
     const idleAgent: AgentOverview = { ...activeAgent, status: "idle" };
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={idleAgent} />, routeOpts);
+    renderChat(idleAgent);
     await waitFor(() => {
       expect(screen.getByText(/Agent is idle/)).toBeInTheDocument();
     });
@@ -519,7 +543,7 @@ describe("ChatPanel", () => {
     );
     const idleAgent: AgentOverview = { ...activeAgent, status: "idle" };
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={idleAgent} />, routeOpts);
+    renderChat(idleAgent);
     await waitFor(() => {
       expect(screen.getByText("Restart")).toBeInTheDocument();
     });
@@ -529,7 +553,7 @@ describe("ChatPanel", () => {
 
   it("shows attach button when agent is active", async () => {
     setMessages(messages);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByLabelText("Attach file")).toBeInTheDocument();
     });
@@ -546,7 +570,7 @@ describe("ChatPanel", () => {
       ],
     };
     setMessages([msgWithAtt]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("report.pdf")).toBeInTheDocument();
     });
@@ -568,7 +592,7 @@ describe("ChatPanel", () => {
       ],
     };
     setMessages([msgWithImg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       const img = screen.getByAltText("screenshot.png");
       expect(img).toHaveAttribute(
@@ -594,7 +618,7 @@ describe("ChatPanel", () => {
       ],
     };
     setMessages([msgWithSpacey]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       const img = screen.getByAltText("Screenshot 2026-04-10 at 10.30.00.png");
       expect(img).toHaveAttribute(
@@ -616,7 +640,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:02Z",
     };
     setMessages([toolMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("read_file")).toBeInTheDocument();
     });
@@ -635,7 +659,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:03Z",
     };
     setMessages([interAgentMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Message from researcher")).toBeInTheDocument();
     });
@@ -653,7 +677,7 @@ describe("ChatPanel", () => {
       ts: "2026-03-17T00:00:04Z",
     };
     setMessages([sysMsg]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("System notification")).toBeInTheDocument();
     });
@@ -672,7 +696,7 @@ describe("ChatPanel", () => {
       attachments: [{ id: "def456", filename: "data.csv", size: 512, content_type: "text/csv" }],
     };
     setMessages([userMsgWithAtt]);
-    renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+    renderChat(activeAgent);
     await waitFor(() => {
       expect(screen.getByText("Check this file")).toBeInTheDocument();
     });
@@ -700,7 +724,7 @@ describe("ChatPanel", () => {
         { id: 2, role: "agent", text: "Hello", ts: new Date(NOW - 60_000).toISOString() },
       ];
       setMessages(todayMsgs);
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         expect(screen.getByText("Today")).toBeInTheDocument();
       });
@@ -717,7 +741,7 @@ describe("ChatPanel", () => {
         { id: 2, role: "agent", text: "Reply", ts: new Date(NOW - 60_000).toISOString() },
       ];
       setMessages(multiDayMsgs);
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         expect(screen.getByText("Today")).toBeInTheDocument();
       });
@@ -732,7 +756,7 @@ describe("ChatPanel", () => {
         { id: 2, role: "agent", text: "Hello", ts: new Date(NOW - 60_000).toISOString() },
       ];
       setMessages(recentMsgs);
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         expect(screen.getByText("Hi")).toBeInTheDocument();
       });
@@ -752,7 +776,7 @@ describe("ChatPanel", () => {
         ts: new Date(NOW - 60_000).toISOString(),
       };
       setMessages([toolMsg]);
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         expect(screen.getByText("read_file")).toBeInTheDocument();
       });
@@ -762,7 +786,7 @@ describe("ChatPanel", () => {
 
   describe("multi-file upload", () => {
     it("adds multiple files to pending list via file input", async () => {
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
 
       await waitFor(() => {
         expect(document.querySelector('input[type="file"]')).toBeTruthy();
@@ -781,7 +805,7 @@ describe("ChatPanel", () => {
     });
 
     it("shows error when file exceeds 128 MB limit", async () => {
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
 
       await waitFor(() => {
         expect(document.querySelector('input[type="file"]')).toBeTruthy();
@@ -814,7 +838,7 @@ describe("ChatPanel", () => {
         }),
       );
 
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
 
       await waitFor(() => {
         expect(document.querySelector('input[type="file"]')).toBeTruthy();
@@ -839,7 +863,7 @@ describe("ChatPanel", () => {
           HttpResponse.json({ error: "Network error" }, { status: 500 }),
         ),
       );
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
 
       await waitFor(() => {
         expect(document.querySelector('input[type="file"]')).toBeTruthy();
@@ -864,7 +888,7 @@ describe("ChatPanel", () => {
 
   describe("file input", () => {
     it("renders hidden file input with multiple attribute", async () => {
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         const input = document.querySelector('input[type="file"]') as HTMLInputElement;
         expect(input).toBeTruthy();
@@ -873,7 +897,7 @@ describe("ChatPanel", () => {
     });
 
     it("processes files selected via file input", async () => {
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
 
       await waitFor(() => {
         expect(document.querySelector('input[type="file"]')).toBeTruthy();
@@ -904,7 +928,7 @@ describe("ChatPanel", () => {
 
     it("shows copy button on agent messages", async () => {
       setMessages(messages);
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         expect(screen.getByLabelText("Copy message")).toBeInTheDocument();
       });
@@ -915,7 +939,7 @@ describe("ChatPanel", () => {
         { id: 1, role: "user", text: "Hello", ts: "2026-03-17T00:00:00Z" },
       ];
       setMessages(userOnly);
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         expect(screen.getByText("Hello")).toBeInTheDocument();
       });
@@ -924,7 +948,7 @@ describe("ChatPanel", () => {
 
     it("copies agent message text on click", async () => {
       setMessages(messages);
-      renderWithProviders(<ChatPanel agent={activeAgent} />, routeOpts);
+      renderChat(activeAgent);
       await waitFor(() => {
         expect(screen.getByLabelText("Copy message")).toBeInTheDocument();
       });

--- a/src/frontend/test/Markdown.test.tsx
+++ b/src/frontend/test/Markdown.test.tsx
@@ -1,10 +1,31 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "bun:test";
+import { MemoryRouter } from "react-router-dom";
+import { ProjectLayoutProvider } from "../providers/ProjectLayoutProvider";
 import Markdown from "../components/Markdown";
+
+const layoutValue = {
+  projectId: "p1",
+  projectName: "test-project",
+  sidebarOpen: false,
+  setSidebarOpen: () => {},
+  onNewAgent: () => {},
+  onBrowseCatalog: () => {},
+};
+
+function renderMarkdown(children: string) {
+  return render(
+    <MemoryRouter>
+      <ProjectLayoutProvider value={layoutValue}>
+        <Markdown>{children}</Markdown>
+      </ProjectLayoutProvider>
+    </MemoryRouter>,
+  );
+}
 
 describe("Markdown", () => {
   it("renders code blocks", () => {
-    const { container } = render(<Markdown>{"```js\nconsole.log('hello');\n```"}</Markdown>);
+    const { container } = renderMarkdown("```js\nconsole.log('hello');\n```");
     const pre = container.querySelector("pre");
     expect(pre).toBeInTheDocument();
     const code = container.querySelector("pre code");
@@ -13,26 +34,35 @@ describe("Markdown", () => {
   });
 
   it("renders inline code", () => {
-    const { container } = render(<Markdown>{"Use `myVar` here"}</Markdown>);
+    const { container } = renderMarkdown("Use `myVar` here");
     const code = container.querySelector("code");
     expect(code).toBeInTheDocument();
     expect(code?.textContent).toBe("myVar");
   });
 
   it("renders plain text", () => {
-    render(<Markdown>{"Hello world"}</Markdown>);
+    renderMarkdown("Hello world");
     expect(screen.getByText("Hello world")).toBeInTheDocument();
   });
 
   it("applies prose classes to container", () => {
-    const { container } = render(<Markdown>{"Test"}</Markdown>);
+    const { container } = renderMarkdown("Test");
     const wrapper = container.firstElementChild;
     expect(wrapper?.className).toContain("prose");
     expect(wrapper?.className).toContain("dark:prose-invert");
   });
 
   it("renders links", () => {
-    render(<Markdown>{"[link](https://example.com)"}</Markdown>);
+    renderMarkdown("[link](https://example.com)");
     expect(screen.getByText("link")).toBeInTheDocument();
+  });
+
+  it("renders shared drive paths as clickable links", () => {
+    renderMarkdown("See /shared/docs/report.md for details");
+    const link = screen.getByText("/shared/docs/report.md");
+    expect(link.tagName).toBe("A");
+    expect(link.getAttribute("href")).toBe(
+      "/projects/test-project/shared?file=%2Fdocs%2Freport.md",
+    );
   });
 });

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -43,6 +43,7 @@ function renderContentArea(route = "/projects/test-project/shared") {
     <ProjectLayoutProvider
       value={{
         projectId: "p1",
+        projectName: "test-project",
         sidebarOpen: false,
         setSidebarOpen: () => {},
         onNewAgent: () => {},

--- a/src/frontend/test/SharedDriveLink.test.tsx
+++ b/src/frontend/test/SharedDriveLink.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { SharedDriveLink } from "../components/chat/SharedDriveLink";
+
+function renderLink(href: string, text: string, projectName = "my-project") {
+  return render(
+    <MemoryRouter>
+      <SharedDriveLink href={href} projectName={projectName}>
+        {text}
+      </SharedDriveLink>
+    </MemoryRouter>,
+  );
+}
+
+describe("SharedDriveLink", () => {
+  it("renders shared drive paths as internal links", () => {
+    renderLink("/shared/docs/report.md", "/shared/docs/report.md");
+    const link = screen.getByText("/shared/docs/report.md");
+    expect(link.tagName).toBe("A");
+    expect(link.getAttribute("href")).toBe("/projects/my-project/shared?file=%2Fdocs%2Freport.md");
+    expect(link.getAttribute("target")).toBeNull();
+  });
+
+  it("renders external links with target=_blank", () => {
+    renderLink("https://example.com", "Example");
+    const link = screen.getByText("Example");
+    expect(link.tagName).toBe("A");
+    expect(link.getAttribute("href")).toBe("https://example.com");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("encodes the file path in the URL", () => {
+    renderLink("/shared/my folder/file name.md", "test");
+    const link = screen.getByText("test");
+    expect(link.getAttribute("href")).toBe(
+      "/projects/my-project/shared?file=%2Fmy%20folder%2Ffile%20name.md",
+    );
+  });
+});

--- a/src/frontend/test/remark-shared-links.test.ts
+++ b/src/frontend/test/remark-shared-links.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import remarkSharedLinks from "../lib/remark-shared-links";
+
+function process(markdown: string): string {
+  return String(
+    unified().use(remarkParse).use(remarkSharedLinks).use(remarkStringify).processSync(markdown),
+  );
+}
+
+describe("remarkSharedLinks", () => {
+  it("converts /shared/ paths to links", () => {
+    const result = process("See /shared/docs/report.md for details.");
+    expect(result).toContain("[/shared/docs/report.md](/shared/docs/report.md)");
+  });
+
+  it("strips trailing punctuation from paths", () => {
+    const result = process("Check /shared/file.txt.");
+    expect(result).toContain("[/shared/file.txt](/shared/file.txt)");
+    expect(result).not.toContain("file.txt.");
+  });
+
+  it("handles paths with nested directories", () => {
+    const result = process("Saved to /shared/a/b/c/file.json");
+    expect(result).toContain("[/shared/a/b/c/file.json](/shared/a/b/c/file.json)");
+  });
+
+  it("does not match paths without /shared/ prefix", () => {
+    const result = process("See /other/path/file.txt for details.");
+    expect(result).not.toContain("[");
+  });
+
+  it("handles multiple paths in the same text", () => {
+    const result = process("See /shared/a.md and /shared/b.md");
+    expect(result).toContain("[/shared/a.md](/shared/a.md)");
+    expect(result).toContain("[/shared/b.md](/shared/b.md)");
+  });
+
+  it("does not match inside inline code", () => {
+    const result = process("Run `cat /shared/file.txt` to see it.");
+    expect(result).toContain("`cat /shared/file.txt`");
+    // The path inside inline code should NOT be a link
+    expect(result).not.toContain("[/shared/file.txt]");
+  });
+
+  it("does not match inside fenced code blocks", () => {
+    const result = process("```\n/shared/file.txt\n```");
+    expect(result).not.toContain("[/shared/file.txt]");
+  });
+});

--- a/src/runtime/system-prompt.ts
+++ b/src/runtime/system-prompt.ts
@@ -60,6 +60,7 @@ Write files to \`attachments/outbox/\` to share them with the user in chat.
 
 ## Shared Drive
 All agents can read and write files in \`${sharedPath}/\`.
+When referring to shared drive files in your responses, always use the path format \`/shared/<relative-path>\` (e.g., \`/shared/reports/summary.md\`). Do not use the full filesystem path in messages.
 
 ## Project Document
 Read \`${projectDoc}\` for project context before starting tasks.


### PR DESCRIPTION
## Summary
- Shared drive paths (`/shared/...`) in agent chat messages are now automatically detected and rendered as clickable links
- Clicking a path navigates to the file preview/editor in the shared drive
- System prompt updated to instruct agents to use `/shared/<path>` format when referencing files

## Changes
- **Remark plugin** (`remark-shared-links.ts`): Walks markdown AST to find `/shared/...` paths in text nodes and converts them to link nodes (skips code blocks automatically)
- **SharedDriveLink component**: Custom `<a>` renderer for Streamdown that uses React Router `<Link>` for shared drive paths
- **ProjectLayoutProvider**: Added `projectName` to context so Markdown rendering can construct correct routes
- **System prompt**: Added instruction for agents to reference shared drive files with `/shared/` prefix

## Test plan
- [x] New unit tests for remark plugin (7 tests: basic paths, trailing punctuation, nested dirs, no false matches, multiple paths, code blocks)
- [x] New unit tests for SharedDriveLink component (3 tests: internal links, external links, URL encoding)
- [x] New integration test in Markdown suite for shared drive path rendering
- [x] All existing tests updated and passing (1065 pass)
- [ ] Manual test: send agent a message asking to create a file in shared drive, verify path in response is clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)