### PR TITLE
Instruct agents not to wrap shared drive paths in backticks

### DIFF
--- a/src/runtime/system-prompt.ts
+++ b/src/runtime/system-prompt.ts
@@ -60,7 +60,7 @@ Write files to \`attachments/outbox/\` to share them with the user in chat.
 
 ## Shared Drive
 All agents can read and write files in \`${sharedPath}/\`.
-When referring to shared drive files in your responses, always use the path format \`/shared/<relative-path>\` (e.g., \`/shared/reports/summary.md\`). Do not use the full filesystem path in messages.
+When referring to shared drive files in your responses, always use the path format /shared/<relative-path> (e.g., /shared/reports/summary.md). Write the path as plain text — do not wrap it in backticks or code formatting. Do not use the full filesystem path in messages.
 
 ## Project Document
 Read \`${projectDoc}\` for project context before starting tasks.


### PR DESCRIPTION
## Summary
- Update system prompt to tell agents to write `/shared/` paths as plain text, not wrapped in backticks
- The auto-link detection (remark plugin) only works on text nodes, not inside `inlineCode` nodes, so backtick-wrapped paths like `` `/shared/hello.md` `` don't become clickable links

## Test plan
- [ ] Create a new agent or restart an existing one (to pick up the prompt change)
- [ ] Ask the agent to list or reference shared drive files
- [ ] Verify the agent writes paths as plain text (e.g., /shared/hello.md) not in backticks
- [ ] Verify the paths render as clickable links in the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)