### PR TITLE
Enable GFM table rendering in agent chat messages

### DIFF
--- a/src/frontend/components/ai-elements/message-response.tsx
+++ b/src/frontend/components/ai-elements/message-response.tsx
@@ -8,6 +8,7 @@ import { code } from "@streamdown/code";
 import type { ComponentProps } from "react";
 import { memo, useMemo } from "react";
 import { Streamdown, type Components } from "streamdown";
+import remarkGfm from "remark-gfm";
 import remarkSharedLinks from "@/lib/remark-shared-links";
 import { SharedDriveLink } from "@/components/chat/SharedDriveLink";
 import type { Pluggable } from "unified";
@@ -17,7 +18,7 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
 };
 
 const streamdownPlugins = { code };
-const sharedLinksPlugins: Pluggable[] = [remarkSharedLinks];
+const baseRemarkPlugins: Pluggable[] = [remarkGfm, remarkSharedLinks];
 
 export const MessageResponse = memo(
   ({
@@ -36,9 +37,8 @@ export const MessageResponse = memo(
     }, [projectName, componentsProp]);
 
     const mergedRemarkPlugins = useMemo(() => {
-      if (!projectName) return remarkPlugins;
-      return remarkPlugins ? [...sharedLinksPlugins, ...remarkPlugins] : sharedLinksPlugins;
-    }, [projectName, remarkPlugins]);
+      return remarkPlugins ? [...baseRemarkPlugins, ...remarkPlugins] : baseRemarkPlugins;
+    }, [remarkPlugins]);
 
     return (
       <Streamdown


### PR DESCRIPTION
## Summary
- Add `remark-gfm` plugin to the Streamdown markdown renderer
- Agent responses containing markdown tables now render as proper HTML tables instead of flat pipe-delimited text
- Also enables other GFM features: strikethrough, task lists, autolinks

## Test plan
- [ ] Ask an agent to output a markdown table — verify it renders as a proper table with borders and columns
- [ ] Verify existing markdown rendering (code blocks, lists, links) still works
- [ ] Verify shared drive links still render as clickable links

🤖 Generated with [Claude Code](https://claude.com/claude-code)