### PR TITLE
Fix code block background in light mode

### DIFF
--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -298,6 +298,17 @@ th:focus-within .shire-table-cell-action-button {
 .shire-punctuation { color: rgb(171, 178, 191); }
 .shire-keyword { color: rgb(198, 120, 221); }
 
+/* Override Tailwind prose pre backgrounds for light/dark mode */
+.prose pre {
+  --tw-prose-pre-bg: oklch(0.97 0.003 150);
+  --tw-prose-pre-code: oklch(0.25 0.01 150);
+}
+
+.dark .prose pre {
+  --tw-prose-pre-bg: oklch(0.2 0.01 150);
+  --tw-prose-pre-code: oklch(0.9 0.005 150);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary
- Override Tailwind Typography's dark `--tw-prose-pre-bg` default with theme-appropriate oklch colors
- Light mode now uses a light gray background (`oklch(0.97 0.003 150)`) matching the theme palette
- Dark mode uses `oklch(0.2 0.01 150)` matching `--card` color

## Test plan
- [ ] Open chat with an agent that has code blocks in its responses
- [ ] Switch to light mode — code blocks should have light gray background with dark text
- [ ] Switch to dark mode — code blocks should retain dark background with light text

🤖 Generated with [Claude Code](https://claude.com/claude-code)