### PR TITLE
Switch fonts to Geist Sans and Geist Mono

### DIFF
--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -8,7 +8,8 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -6,7 +6,7 @@
     <title>Shire</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="./css/app.css" />
   </head>
   <body class="bg-background text-foreground antialiased">


### PR DESCRIPTION
## Summary
- Replace DM Sans with Geist Sans as the primary sans-serif font
- Add Geist Mono as the monospace font via `--font-mono` theme variable
- Both fonts loaded from Google Fonts CDN

## Test plan
- [ ] Run `bun run dev` and verify Geist Sans renders on all pages
- [ ] Check code blocks and mono text (e.g. AgentForm) render in Geist Mono
- [ ] Verify fonts load correctly in Network tab (no 404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)