### PR TITLE
Enable skill discovery in Claude Code and PI harnesses

### DIFF
--- a/src/runtime/harness/claude-code-harness.test.ts
+++ b/src/runtime/harness/claude-code-harness.test.ts
@@ -314,6 +314,19 @@ describe("ClaudeCodeHarness", () => {
     expect(String(errorEvent!.payload.message)).toContain("something went wrong");
   });
 
+  test("sendMessage() includes user and project setting sources for skill discovery", async () => {
+    const mockQuery = createMockQuery([resultSuccess("Hi", "s1")]);
+    const harness = new ClaudeCodeHarness(mockQuery);
+    harness.onEvent(() => {});
+    await harness.start(baseConfig);
+    await harness.sendMessage("Hello");
+
+    const settingSources = calls(mockQuery)[0][0].options?.settingSources as string[];
+    expect(settingSources).toContain("user");
+    expect(settingSources).toContain("project");
+    expect(settingSources.indexOf("user")).toBeLessThan(settingSources.indexOf("project"));
+  });
+
   test("sendMessage() passes pathToClaudeCodeExecutable", async () => {
     const mockQuery = createMockQuery([resultSuccess("Hi", "s1")]);
     const harness = new ClaudeCodeHarness(mockQuery);

--- a/src/runtime/harness/claude-code-harness.ts
+++ b/src/runtime/harness/claude-code-harness.ts
@@ -44,7 +44,7 @@ export class ClaudeCodeHarness implements Harness {
           cwd: this.config.cwd,
           pathToClaudeCodeExecutable: "claude",
           allowedTools: ["Bash", "Read", "Edit", "Write", "Skill"],
-          settingSources: ["project"],
+          settingSources: ["user", "project"],
           permissionMode: "bypassPermissions",
           allowDangerouslySkipPermissions: true,
           resume: resumeId,

--- a/src/runtime/harness/pi-harness.ts
+++ b/src/runtime/harness/pi-harness.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import type { AgentEvent, Harness, HarnessConfig, EventCallback } from "./types";
 
@@ -113,6 +115,7 @@ export class PiHarness implements Harness {
     });
     const loader = new DefaultResourceLoader({
       cwd: config.cwd,
+      additionalSkillPaths: [join(homedir(), ".agents", "skills")],
       settingsManager,
       systemPromptOverride: (base) => {
         const parts = [base, config.internalSystemPrompt, config.systemPrompt].filter(Boolean);


### PR DESCRIPTION
## Summary
- Add `"user"` to `settingSources` in Claude Code harness so agents discover skills from `~/.claude/`
- Add `additionalSkillPaths` to PI harness `DefaultResourceLoader` to discover skills from `~/.agents/skills/`
- Fixes agents returning "Unknown skill: X" when invoking slash commands like `/mcp` or `/use-effect-killer`

## Test plan
- [x] Typecheck passes
- [x] All 1116 tests pass
- [x] New test verifies settingSources includes both `"user"` and `"project"` with correct precedence
- [ ] Manual: start a Claude Code agent, invoke a global skill — should no longer return "Unknown skill"

🤖 Generated with [Claude Code](https://claude.com/claude-code)