### PR TITLE
Add file-type-specific icons to shared drive and file displays

### DIFF
--- a/src/frontend/components/FilePreviewPanel.tsx
+++ b/src/frontend/components/FilePreviewPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { X, Maximize2, File } from "lucide-react";
+import { X, Maximize2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "./ui/button";
 import { Spinner } from "./ui/spinner";
@@ -7,7 +7,7 @@ import { SharedDriveEditor } from "./editor";
 import CodeEditor from "./editor/CodeEditor";
 import CsvEditor from "./editor/CsvEditor";
 import { useFileContent } from "../hooks/shared-drive";
-import { getPreviewType } from "../lib/file-utils";
+import { getFileIcon, getPreviewType } from "../lib/file-utils";
 import { useSubscription, type SharedDriveWsEvent } from "../lib/ws";
 
 interface FilePreviewPanelProps {
@@ -179,12 +179,18 @@ export default function FilePreviewPanel({
           />
         )}
 
-        {!loading && !error && type === "unsupported" && (
-          <div className="flex flex-col items-center justify-center py-12 gap-4 text-muted-foreground">
-            <File className="h-12 w-12" />
-            <p className="text-sm">Preview is not available for this file type.</p>
-          </div>
-        )}
+        {!loading &&
+          !error &&
+          type === "unsupported" &&
+          (() => {
+            const UnsupportedIcon = getFileIcon(fileName);
+            return (
+              <div className="flex flex-col items-center justify-center py-12 gap-4 text-muted-foreground">
+                <UnsupportedIcon className="h-12 w-12" />
+                <p className="text-sm">Preview is not available for this file type.</p>
+              </div>
+            );
+          })()}
       </div>
     </div>
   );

--- a/src/frontend/components/SharedDriveContentArea.tsx
+++ b/src/frontend/components/SharedDriveContentArea.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useSearchParams } from "react-router-dom";
 import { useDropzone } from "react-dropzone";
-import { Menu, Upload, Download, Trash2, Pencil, File, FolderOpen } from "lucide-react";
+import { Menu, Upload, Download, Trash2, Pencil, FolderOpen } from "lucide-react";
 import { Button } from "./ui/button";
 import { SharedDriveEditor } from "./editor";
 import CodeEditor from "./editor/CodeEditor";
@@ -16,7 +16,7 @@ import {
   useRenameSharedFile,
   useUploadSharedDriveFile,
 } from "../hooks";
-import { getPreviewType, formatSize, MAX_UPLOAD_SIZE } from "../lib/file-utils";
+import { getFileIcon, getPreviewType, formatSize, MAX_UPLOAD_SIZE } from "../lib/file-utils";
 import { useProjectLayout } from "../providers/ProjectLayoutProvider";
 
 export default function SharedDriveContentArea() {
@@ -280,12 +280,18 @@ export default function SharedDriveContentArea() {
           <iframe src={previewUrl} className="w-full h-full border-0" title={fileName} />
         )}
 
-        {!loading && !error && type === "unsupported" && (
-          <div className="flex flex-col items-center justify-center py-12 gap-4 text-muted-foreground">
-            <File className="h-12 w-12" />
-            <p className="text-sm">Preview is not available for this file type.</p>
-          </div>
-        )}
+        {!loading &&
+          !error &&
+          type === "unsupported" &&
+          (() => {
+            const UnsupportedIcon = getFileIcon(fileName);
+            return (
+              <div className="flex flex-col items-center justify-center py-12 gap-4 text-muted-foreground">
+                <UnsupportedIcon className="h-12 w-12" />
+                <p className="text-sm">Preview is not available for this file type.</p>
+              </div>
+            );
+          })()}
       </div>
 
       <RenameDialog

--- a/src/frontend/components/chat/AttachmentDisplay.tsx
+++ b/src/frontend/components/chat/AttachmentDisplay.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { FileIcon, Download } from "lucide-react";
+import { Download } from "lucide-react";
 import { type Attachment, formatFileSize } from "./types";
+import { getFileIcon } from "../../lib/file-utils";
 
 interface AttachmentDisplayProps {
   attachments: Attachment[];
@@ -20,6 +21,8 @@ export const AttachmentDisplay = React.memo(function AttachmentDisplay({
       {attachments.map((att) => {
         const url = `/api/projects/${projectName}/agents/${agentId}/attachments/${att.id}/${encodeURIComponent(att.filename)}`;
         const isImage = att.content_type.startsWith("image/");
+
+        const AttIcon = getFileIcon(att.filename);
 
         return isImage ? (
           <a
@@ -44,7 +47,7 @@ export const AttachmentDisplay = React.memo(function AttachmentDisplay({
             rel="noopener noreferrer"
             className="flex items-center gap-2 px-3 py-2 rounded-md border border-border hover:bg-muted/50 text-sm"
           >
-            <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <AttIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate max-w-40">{att.filename}</span>
             <span className="text-xs text-muted-foreground whitespace-nowrap">
               ({formatFileSize(att.size)})

--- a/src/frontend/components/chat/ChatInput.tsx
+++ b/src/frontend/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Paperclip, Square, X, FileIcon, Check, AlertCircle } from "lucide-react";
+import { Paperclip, Square, X, Check, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { type AgentOverview } from "@/components/types";
@@ -14,6 +14,7 @@ import {
 import { useFileMention } from "../../hooks/useFileMention";
 import type { SharedDriveFile } from "../../hooks/shared-drive";
 import { type PendingFile, MAX_FILE_SIZE, formatFileSize } from "./types";
+import { getFileIcon } from "../../lib/file-utils";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 
 interface ChatInputProps {
@@ -268,39 +269,42 @@ export function ChatInput({ agent, onMessageSent }: ChatInputProps) {
       )}
       {pendingFiles.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-2">
-          {pendingFiles.map((file, i) => (
-            <div
-              key={file.localId}
-              className="flex flex-col rounded-md border border-border bg-muted/50 text-xs overflow-hidden"
-            >
-              <div className="flex items-center gap-1.5 px-2 py-1">
-                {file.error ? (
-                  <AlertCircle className="h-3 w-3 text-destructive shrink-0" />
-                ) : file.progress === 100 ? (
-                  <Check className="h-3 w-3 text-green-500 shrink-0" />
-                ) : (
-                  <FileIcon className="h-3 w-3 text-muted-foreground shrink-0" />
-                )}
-                <span className="truncate max-w-32">{file.name}</span>
-                <span className="text-muted-foreground">({formatFileSize(file.size)})</span>
-                <button
-                  type="button"
-                  onClick={() => removePendingFile(i)}
-                  className="text-muted-foreground hover:text-foreground"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </div>
-              {file.progress > 0 && file.progress < 100 && (
-                <div className="h-0.5 bg-muted">
-                  <div
-                    className="h-full bg-primary transition-all duration-200"
-                    style={{ width: `${file.progress}%` }}
-                  />
+          {pendingFiles.map((file, i) => {
+            const PendingIcon = getFileIcon(file.name);
+            return (
+              <div
+                key={file.localId}
+                className="flex flex-col rounded-md border border-border bg-muted/50 text-xs overflow-hidden"
+              >
+                <div className="flex items-center gap-1.5 px-2 py-1">
+                  {file.error ? (
+                    <AlertCircle className="h-3 w-3 text-destructive shrink-0" />
+                  ) : file.progress === 100 ? (
+                    <Check className="h-3 w-3 text-green-500 shrink-0" />
+                  ) : (
+                    <PendingIcon className="h-3 w-3 text-muted-foreground shrink-0" />
+                  )}
+                  <span className="truncate max-w-32">{file.name}</span>
+                  <span className="text-muted-foreground">({formatFileSize(file.size)})</span>
+                  <button
+                    type="button"
+                    onClick={() => removePendingFile(i)}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
                 </div>
-              )}
-            </div>
-          ))}
+                {file.progress > 0 && file.progress < 100 && (
+                  <div className="h-0.5 bg-muted">
+                    <div
+                      className="h-full bg-primary transition-all duration-200"
+                      style={{ width: `${file.progress}%` }}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
       <div className="relative flex gap-2 items-end">

--- a/src/frontend/components/sidebar/SharedDrivePanel.tsx
+++ b/src/frontend/components/sidebar/SharedDrivePanel.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { Folder, File, Upload, FolderPlus, FileText, Trash2, Download, Pencil } from "lucide-react";
+import { Folder, Upload, FolderPlus, FileText, Trash2, Download, Pencil } from "lucide-react";
 import { Spinner } from "../ui/spinner";
 import {
   useProjectId,
@@ -30,7 +30,7 @@ import {
   useRenameSharedFile,
   useUploadSharedDriveFile,
 } from "../../hooks";
-import { formatSize, MAX_UPLOAD_SIZE } from "../../lib/file-utils";
+import { formatSize, getFileIcon, MAX_UPLOAD_SIZE } from "../../lib/file-utils";
 import type { SharedDriveFile } from "../../hooks/shared-drive";
 
 function Breadcrumbs({ path, onNavigate }: { path: string; onNavigate: (path: string) => void }) {
@@ -277,77 +277,76 @@ export default function SharedDrivePanel() {
             <p className="text-xs text-muted-foreground">Empty directory</p>
           </div>
         )}
-        {sortedFiles.map((file) => (
-          <div key={file.path} className="group flex items-center mx-1">
-            <button
-              type="button"
-              className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm flex-1 min-w-0 text-left ${
-                selectedFile === file.path
-                  ? "bg-accent text-accent-foreground"
-                  : "hover:bg-muted text-foreground"
-              }`}
-              onClick={() => {
-                if (file.type === "directory") {
-                  navigate(file.path);
-                } else {
-                  selectFile(file);
-                }
-              }}
-            >
-              {file.type === "directory" ? (
-                <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
-              ) : (
-                <File className="h-4 w-4 text-muted-foreground shrink-0" />
-              )}
-              <span className="truncate">{file.name}</span>
-            </button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-background text-muted-foreground"
-                  aria-label={`${file.name} actions`}
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                    aria-hidden="true"
+        {sortedFiles.map((file) => {
+          const FileTypeIcon = file.type === "directory" ? Folder : getFileIcon(file.name);
+          return (
+            <div key={file.path} className="group flex items-center mx-1">
+              <button
+                type="button"
+                className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm flex-1 min-w-0 text-left ${
+                  selectedFile === file.path
+                    ? "bg-accent text-accent-foreground"
+                    : "hover:bg-muted text-foreground"
+                }`}
+                onClick={() => {
+                  if (file.type === "directory") {
+                    navigate(file.path);
+                  } else {
+                    selectFile(file);
+                  }
+                }}
+              >
+                <FileTypeIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+                <span className="truncate">{file.name}</span>
+              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-background text-muted-foreground"
+                    aria-label={`${file.name} actions`}
                   >
-                    <circle cx="8" cy="3" r="1.5" />
-                    <circle cx="8" cy="8" r="1.5" />
-                    <circle cx="8" cy="13" r="1.5" />
-                  </svg>
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {file.type === "file" && (
-                  <DropdownMenuItem asChild>
-                    <a
-                      href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(file.path)}`}
-                      download
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="currentColor"
+                      aria-hidden="true"
                     >
-                      <Download className="h-4 w-4 mr-2" />
-                      Download
-                    </a>
+                      <circle cx="8" cy="3" r="1.5" />
+                      <circle cx="8" cy="8" r="1.5" />
+                      <circle cx="8" cy="13" r="1.5" />
+                    </svg>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {file.type === "file" && (
+                    <DropdownMenuItem asChild>
+                      <a
+                        href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(file.path)}`}
+                        download
+                      >
+                        <Download className="h-4 w-4 mr-2" />
+                        Download
+                      </a>
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem onClick={() => setRenameTarget(file)}>
+                    <Pencil className="h-4 w-4 mr-2" />
+                    Rename
                   </DropdownMenuItem>
-                )}
-                <DropdownMenuItem onClick={() => setRenameTarget(file)}>
-                  <Pencil className="h-4 w-4 mr-2" />
-                  Rename
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className="text-destructive focus:text-destructive"
-                  onClick={() => setDeleteTarget(file)}
-                >
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        ))}
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => setDeleteTarget(file)}
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          );
+        })}
       </div>
 
       {/* New Folder Dialog */}

--- a/src/frontend/lib/file-utils.test.ts
+++ b/src/frontend/lib/file-utils.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import { getFileIcon } from "./file-utils";
+import {
+  File,
+  FileCode,
+  FileJson,
+  FileSpreadsheet,
+  FileText,
+  Database,
+  Globe,
+  Image,
+  Settings,
+} from "lucide-react";
+
+describe("getFileIcon", () => {
+  it("returns FileCode for source code files", () => {
+    for (const ext of ["js", "ts", "jsx", "tsx", "py", "rb", "rs", "go", "java", "c", "cpp", "h"]) {
+      expect(getFileIcon(`file.${ext}`)).toBe(FileCode);
+    }
+  });
+
+  it("returns FileCode for shell scripts", () => {
+    for (const ext of ["sh", "bash", "zsh"]) {
+      expect(getFileIcon(`script.${ext}`)).toBe(FileCode);
+    }
+  });
+
+  it("returns FileCode for Elixir/Erlang files", () => {
+    for (const ext of ["ex", "exs", "erl"]) {
+      expect(getFileIcon(`module.${ext}`)).toBe(FileCode);
+    }
+  });
+
+  it("returns FileText for markdown files", () => {
+    expect(getFileIcon("README.md")).toBe(FileText);
+    expect(getFileIcon("notes.mdx")).toBe(FileText);
+  });
+
+  it("returns FileText for text and log files", () => {
+    expect(getFileIcon("readme.txt")).toBe(FileText);
+    expect(getFileIcon("server.log")).toBe(FileText);
+  });
+
+  it("returns FileJson for JSON/YAML/TOML files", () => {
+    for (const ext of ["json", "yaml", "yml", "toml"]) {
+      expect(getFileIcon(`config.${ext}`)).toBe(FileJson);
+    }
+  });
+
+  it("returns Image for image files", () => {
+    for (const ext of ["png", "jpg", "jpeg", "gif", "svg", "webp", "ico", "bmp"]) {
+      expect(getFileIcon(`photo.${ext}`)).toBe(Image);
+    }
+  });
+
+  it("returns FileSpreadsheet for CSV files", () => {
+    expect(getFileIcon("data.csv")).toBe(FileSpreadsheet);
+  });
+
+  it("returns Globe for web files", () => {
+    for (const ext of ["html", "css", "scss", "xml"]) {
+      expect(getFileIcon(`page.${ext}`)).toBe(Globe);
+    }
+  });
+
+  it("returns Database for SQL files", () => {
+    expect(getFileIcon("schema.sql")).toBe(Database);
+  });
+
+  it("returns FileText for PDF files", () => {
+    expect(getFileIcon("document.pdf")).toBe(FileText);
+  });
+
+  it("returns Settings for config/dotfiles", () => {
+    expect(getFileIcon(".env")).toBe(Settings);
+    expect(getFileIcon(".gitignore")).toBe(Settings);
+    expect(getFileIcon("Dockerfile")).toBe(Settings);
+    expect(getFileIcon("Makefile")).toBe(Settings);
+  });
+
+  it("returns generic File for unknown extensions", () => {
+    expect(getFileIcon("archive.zip")).toBe(File);
+    expect(getFileIcon("binary.bin")).toBe(File);
+  });
+
+  it("is case-insensitive", () => {
+    expect(getFileIcon("App.TSX")).toBe(FileCode);
+    expect(getFileIcon("DATA.CSV")).toBe(FileSpreadsheet);
+    expect(getFileIcon("IMAGE.PNG")).toBe(Image);
+  });
+});

--- a/src/frontend/lib/file-utils.ts
+++ b/src/frontend/lib/file-utils.ts
@@ -1,3 +1,16 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Database,
+  File,
+  FileCode,
+  FileJson,
+  FileSpreadsheet,
+  FileText,
+  Globe,
+  Image,
+  Settings,
+} from "lucide-react";
+
 export type PreviewType = "markdown" | "text" | "csv" | "image" | "pdf" | "unsupported";
 
 export const TEXT_EXTENSIONS = new Set([
@@ -64,3 +77,43 @@ export function formatSize(bytes: number): string {
 }
 
 export const MAX_UPLOAD_SIZE = 128 * 1024 * 1024; // 128 MB
+
+const CODE_EXTENSIONS = new Set([
+  "js",
+  "ts",
+  "jsx",
+  "tsx",
+  "py",
+  "rb",
+  "ex",
+  "exs",
+  "erl",
+  "rs",
+  "go",
+  "java",
+  "c",
+  "cpp",
+  "h",
+  "sh",
+  "bash",
+  "zsh",
+]);
+
+const CONFIG_DATA_EXTENSIONS = new Set(["json", "yaml", "yml", "toml"]);
+const WEB_EXTENSIONS = new Set(["html", "css", "scss", "xml"]);
+const DOTFILE_EXTENSIONS = new Set(["env", "gitignore", "dockerfile", "makefile"]);
+
+export function getFileIcon(name: string): LucideIcon {
+  const ext = getFileExtension(name);
+  if (CODE_EXTENSIONS.has(ext)) return FileCode;
+  if (ext === "md" || ext === "mdx") return FileText;
+  if (ext === "txt" || ext === "log") return FileText;
+  if (CONFIG_DATA_EXTENSIONS.has(ext)) return FileJson;
+  if (IMAGE_EXTENSIONS.has(ext)) return Image;
+  if (ext === "csv") return FileSpreadsheet;
+  if (WEB_EXTENSIONS.has(ext)) return Globe;
+  if (ext === "sql") return Database;
+  if (ext === "pdf") return FileText;
+  if (DOTFILE_EXTENSIONS.has(ext)) return Settings;
+  return File;
+}


### PR DESCRIPTION
## Summary
- Add `getFileIcon()` utility that maps file extensions to lucide-react icons (FileCode, FileJson, Image, FileSpreadsheet, Globe, Database, Settings, FileText, etc.)
- Replace generic `File` icon in shared drive panel, file preview panel, content area, chat attachments, and chat input pending files
- Add unit tests covering all icon categories, fallback behavior, and case-insensitivity

## Test plan
- [ ] Open shared drive — verify different file types show distinct icons (e.g., `.ts` shows code icon, `.json` shows config icon, `.png` shows image icon)
- [ ] Upload a file via chat input — verify pending file shows the correct icon
- [ ] Check chat attachment display for non-image files — verify correct icon
- [ ] Open an unsupported file type — verify the fallback icon renders
- [ ] Run `bun test` — all 1130 tests pass
- [ ] Run `bun run typecheck` — no errors
- [ ] Run `bun run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)