### PR TITLE
Fix file preview links not working on mobile

### DIFF
--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -17,6 +17,7 @@ import {
   useUpdateAgentCache,
   fetchCatalogAgent,
   findDefaultAgent,
+  useIsDesktop,
 } from "../hooks";
 import { useSubscription, type AgentListWsEvent, type SharedDriveWsEvent } from "../lib/ws";
 import {
@@ -26,20 +27,6 @@ import {
 } from "../providers/ProjectLayoutProvider";
 
 const ProjectLayoutContextProvider = ProjectLayoutContext.Provider;
-
-const DESKTOP_MQ = "(min-width: 768px)";
-
-function useIsDesktop() {
-  return React.useSyncExternalStore(
-    (cb) => {
-      const mq = window.matchMedia(DESKTOP_MQ);
-      mq.addEventListener("change", cb);
-      return () => mq.removeEventListener("change", cb);
-    },
-    () => window.matchMedia(DESKTOP_MQ).matches,
-    () => true,
-  );
-}
 
 export default function ProjectLayout() {
   const { projectName, agentName } = useParams();

--- a/src/frontend/components/chat/SharedDriveLink.tsx
+++ b/src/frontend/components/chat/SharedDriveLink.tsx
@@ -1,7 +1,8 @@
 import type { AnchorHTMLAttributes, MouseEvent } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import type { Element } from "hast";
 import { useProjectLayout } from "../../providers/ProjectLayoutProvider";
+import { useIsDesktop } from "../../hooks/use-is-desktop";
 
 interface SharedDriveLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   projectName: string;
@@ -16,6 +17,8 @@ export function SharedDriveLink({
   ...rest
 }: SharedDriveLinkProps) {
   const { setPanelFilePath } = useProjectLayout();
+  const navigate = useNavigate();
+  const isDesktop = useIsDesktop();
 
   if (href?.startsWith("/shared/")) {
     const filePath = href.slice("/shared".length);
@@ -26,7 +29,12 @@ export function SharedDriveLink({
       if (e.metaKey || e.ctrlKey || e.button === 1) return;
 
       e.preventDefault();
-      setPanelFilePath(filePath);
+
+      if (isDesktop) {
+        setPanelFilePath(filePath);
+      } else {
+        navigate(to);
+      }
     };
 
     return (

--- a/src/frontend/hooks/index.ts
+++ b/src/frontend/hooks/index.ts
@@ -9,3 +9,4 @@ export * from "./uploads";
 export * from "./schedules";
 export * from "./alert-channels";
 export * from "./version";
+export * from "./use-is-desktop";

--- a/src/frontend/hooks/use-is-desktop.ts
+++ b/src/frontend/hooks/use-is-desktop.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from "react";
+
+const DESKTOP_MQ = "(min-width: 768px)";
+
+export function useIsDesktop() {
+  return useSyncExternalStore(
+    (cb) => {
+      const mq = window.matchMedia(DESKTOP_MQ);
+      mq.addEventListener("change", cb);
+      return () => mq.removeEventListener("change", cb);
+    },
+    () => window.matchMedia(DESKTOP_MQ).matches,
+    () => true,
+  );
+}

--- a/src/frontend/test/SharedDriveLink.test.tsx
+++ b/src/frontend/test/SharedDriveLink.test.tsx
@@ -1,9 +1,15 @@
-import { describe, it, expect, mock } from "bun:test";
+import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { SharedDriveLink } from "../components/chat/SharedDriveLink";
 import { ProjectLayoutProvider } from "../providers/ProjectLayoutProvider";
+
+/** Renders the current router location so tests can assert navigation. */
+function LocationDisplay() {
+  const location = useLocation();
+  return <span data-testid="location">{location.pathname + location.search}</span>;
+}
 
 const layoutValue = {
   projectId: "p1",
@@ -16,10 +22,21 @@ const layoutValue = {
   setPanelFilePath: mock(() => {}),
 };
 
-function renderLink(href: string, text: string, projectName = "my-project") {
+function renderLink(
+  href: string,
+  text: string,
+  projectName = "my-project",
+  opts?: { setPanelFilePath?: ReturnType<typeof mock> },
+) {
   return render(
     <MemoryRouter>
-      <ProjectLayoutProvider value={{ ...layoutValue, projectName }}>
+      <ProjectLayoutProvider
+        value={{
+          ...layoutValue,
+          projectName,
+          ...(opts?.setPanelFilePath && { setPanelFilePath: opts.setPanelFilePath }),
+        }}
+      >
         <SharedDriveLink href={href} projectName={projectName}>
           {text}
         </SharedDriveLink>
@@ -27,6 +44,20 @@ function renderLink(href: string, text: string, projectName = "my-project") {
     </MemoryRouter>,
   );
 }
+
+function setDesktop(isDesktop: boolean) {
+  window.matchMedia = mock((query: string) => ({
+    matches: isDesktop && query === "(min-width: 768px)",
+    media: query,
+    addEventListener: mock(() => {}),
+    removeEventListener: mock(() => {}),
+  })) as unknown as typeof window.matchMedia;
+}
+
+afterEach(() => {
+  // Reset to default (mobile) after each test
+  setDesktop(false);
+});
 
 describe("SharedDriveLink", () => {
   it("renders shared drive paths as internal links", () => {
@@ -54,7 +85,16 @@ describe("SharedDriveLink", () => {
     );
   });
 
-  it("calls setPanelFilePath on click instead of navigating", async () => {
+  it("opens side panel on click on desktop", async () => {
+    setDesktop(true);
+    const setPanelFilePath = mock(() => {});
+    renderLink("/shared/hello.md", "/shared/hello.md", "my-project", { setPanelFilePath });
+    await userEvent.click(screen.getByText("/shared/hello.md"));
+    expect(setPanelFilePath).toHaveBeenCalledWith("/hello.md");
+  });
+
+  it("navigates to shared drive route on click on mobile", async () => {
+    setDesktop(false);
     const setPanelFilePath = mock(() => {});
     render(
       <MemoryRouter>
@@ -62,10 +102,14 @@ describe("SharedDriveLink", () => {
           <SharedDriveLink href="/shared/hello.md" projectName="my-project">
             /shared/hello.md
           </SharedDriveLink>
+          <LocationDisplay />
         </ProjectLayoutProvider>
       </MemoryRouter>,
     );
     await userEvent.click(screen.getByText("/shared/hello.md"));
-    expect(setPanelFilePath).toHaveBeenCalledWith("/hello.md");
+    expect(setPanelFilePath).not.toHaveBeenCalled();
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/projects/my-project/shared?file=%2Fhello.md",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Shared drive links in chat called `setPanelFilePath` on click, but the `FilePreviewPanel` side panel only renders in the desktop layout — on mobile, clicking did nothing
- On mobile, clicking a shared drive link now navigates to `/projects/{name}/shared?file=...` instead
- Extracted `useIsDesktop` hook to `src/frontend/hooks/use-is-desktop.ts` for reuse across components

## Test plan
- [x] Desktop: clicking shared drive link in chat opens side panel (unchanged)
- [x] Mobile: clicking shared drive link in chat navigates to shared drive route
- [x] Cmd/Ctrl+click still opens in new tab on both
- [x] All 1117 tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)