### PR TITLE
Enhance agent sidebar with emoji avatars, busy indicators, and merged menu

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.39.0",
+        "frimousse": "^0.3.0",
         "hono": "^4.7.0",
         "js-yaml": "^4.1.0",
         "lexical": "^0.42.0",
@@ -1357,6 +1358,8 @@
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "frimousse": ["frimousse@0.3.0", "", { "peerDependencies": { "react": "^18 || ^19", "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"] }, "sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 

--- a/drizzle/0005_handy_wild_child.sql
+++ b/drizzle/0005_handy_wild_child.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `agents` ADD `emoji` text;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,476 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2f61f404-ad7a-4224-b6b5-2c19190d6ed3",
+  "prevId": "179f4ec2-7243-44d1-ad25-c39e325ae06b",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "agents_project_name": {
+          "name": "agents_project_name",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agents_project_id_projects_id_fk": {
+          "name": "agents_project_id_projects_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_channels": {
+      "name": "alert_channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "alert_channels_project_id_unique": {
+          "name": "alert_channels_project_id_unique",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "alert_channels_project_id_projects_id_fk": {
+          "name": "alert_channels_project_id_projects_id_fk",
+          "tableFrom": "alert_channels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_messages_agent": {
+          "name": "idx_messages_agent",
+          "columns": [
+            "project_id",
+            "agent_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_project_id_projects_id_fk": {
+          "name": "messages_project_id_projects_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_agent_id_agents_id_fk": {
+          "name": "messages_agent_id_agents_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_tasks_project_id_projects_id_fk": {
+          "name": "scheduled_tasks_project_id_projects_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_tasks_agent_id_agents_id_fk": {
+          "name": "scheduled_tasks_agent_id_agents_id_fk",
+          "tableFrom": "scheduled_tasks",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775020737187,
       "tag": "0004_futuristic_shinobi_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1775989324106,
+      "tag": "0005_handy_wild_child",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.39.0",
+    "frimousse": "^0.3.0",
     "hono": "^4.7.0",
     "js-yaml": "^4.1.0",
     "lexical": "^0.42.0",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,6 +22,7 @@ export const agents = sqliteTable(
       .notNull()
       .references(() => projects.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
+    emoji: text("emoji"),
     sessionId: text("session_id"),
     description: text("description"),
     harness: text("harness"),

--- a/src/frontend/components/AgentForm.tsx
+++ b/src/frontend/components/AgentForm.tsx
@@ -12,11 +12,14 @@ import {
   DialogDescription,
 } from "./ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { Popover, PopoverTrigger, PopoverContent } from "./ui/popover";
+import { EmojiPicker } from "frimousse";
 import type { Agent, HarnessType, Skill, SkillReference } from "./types";
 
 export interface AgentFormPayload {
   id?: string;
   name: string;
+  emoji?: string;
   description?: string;
   harness: HarnessType;
   model?: string;
@@ -36,6 +39,8 @@ const SLUG_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 
 export default function AgentForm({ open, title, agent, onSave, onClose }: AgentFormProps) {
   const [name, setName] = React.useState(agent?.name || "");
+  const [emoji, setEmoji] = React.useState(agent?.emoji || "");
+  const [emojiPickerOpen, setEmojiPickerOpen] = React.useState(false);
   const [description, setDescription] = React.useState(agent?.description || "");
   const [model, setModel] = React.useState(agent?.model || "");
   const [systemPrompt, setSystemPrompt] = React.useState(agent?.systemPrompt || "");
@@ -52,6 +57,7 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
     const event = isUpdate ? "update-agent" : "create-agent";
     const payload: AgentFormPayload = {
       name,
+      emoji: emoji || undefined,
       description: description || undefined,
       harness,
       model: model || undefined,
@@ -145,6 +151,80 @@ export default function AgentForm({ open, title, agent, onSave, onClose }: Agent
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What does this agent do?"
             />
+          </div>
+          <div className="space-y-2">
+            <Label>Avatar</Label>
+            <div className="flex items-center gap-2">
+              <Popover open={emojiPickerOpen} onOpenChange={setEmojiPickerOpen}>
+                <PopoverTrigger asChild>
+                  <Button type="button" variant="outline" className="h-10 w-10 text-lg p-0">
+                    {emoji || "🤖"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-fit p-0" align="start">
+                  <EmojiPicker.Root
+                    onEmojiSelect={({ emoji: e }) => {
+                      setEmoji(e);
+                      setEmojiPickerOpen(false);
+                    }}
+                    className="flex flex-col"
+                  >
+                    <EmojiPicker.Search
+                      className="mx-2 mt-2 h-9 rounded-md border border-input bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring"
+                      placeholder="Search emoji..."
+                      autoFocus
+                    />
+                    <EmojiPicker.Viewport className="h-[280px] overflow-y-auto overflow-x-hidden p-1">
+                      <EmojiPicker.Loading>
+                        <span className="flex items-center justify-center h-[280px] text-sm text-muted-foreground">
+                          Loading…
+                        </span>
+                      </EmojiPicker.Loading>
+                      <EmojiPicker.Empty>
+                        <span className="flex items-center justify-center h-[280px] text-sm text-muted-foreground">
+                          No emoji found.
+                        </span>
+                      </EmojiPicker.Empty>
+                      <EmojiPicker.List
+                        className="select-none"
+                        components={{
+                          CategoryHeader: ({ category, ...props }) => (
+                            <div
+                              className="px-2 py-1.5 text-xs font-medium text-muted-foreground bg-popover sticky top-0"
+                              {...props}
+                            >
+                              {category.label}
+                            </div>
+                          ),
+                          Emoji: ({ emoji: e, ...props }) => (
+                            <button
+                              className="flex items-center justify-center h-8 w-8 rounded text-lg hover:bg-accent cursor-pointer"
+                              {...props}
+                            >
+                              {e.emoji}
+                            </button>
+                          ),
+                        }}
+                      />
+                    </EmojiPicker.Viewport>
+                  </EmojiPicker.Root>
+                </PopoverContent>
+              </Popover>
+              <span className="text-sm text-muted-foreground">
+                {emoji ? "Click to change" : "Pick an emoji"}
+              </span>
+              {emoji && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setEmoji("")}
+                  className="text-muted-foreground"
+                >
+                  Reset
+                </Button>
+              )}
+            </div>
           </div>
           <div className="space-y-2">
             <Label htmlFor="harness">Harness</Label>

--- a/src/frontend/components/ChatHeader.tsx
+++ b/src/frontend/components/ChatHeader.tsx
@@ -1,13 +1,26 @@
-import { Menu, EllipsisVertical, Eraser } from "lucide-react";
-import { Button } from "./ui/button";
+import * as React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Menu, EllipsisVertical, Eraser, Settings, Trash2 } from "lucide-react";
+import { Button, buttonVariants } from "./ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
 import { type AgentOverview } from "./types";
-import { useProjectId, useClearSession } from "../hooks";
+import { useProjectId, useClearSession, useDeleteAgent } from "../hooks";
 
 interface ChatHeaderProps {
   agent: AgentOverview;
@@ -15,38 +28,90 @@ interface ChatHeaderProps {
 }
 
 export default function ChatHeader({ agent, onMenuToggle }: ChatHeaderProps) {
+  const navigate = useNavigate();
+  const { projectName } = useParams<{ projectName: string }>();
   const { projectId } = useProjectId();
   const clearSession = useClearSession(projectId ?? "");
+  const deleteAgentMut = useDeleteAgent(projectId ?? "");
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
+
+  const handleDelete = () => {
+    deleteAgentMut.mutate(agent.id, {
+      onSuccess: () => {
+        setDeleteOpen(false);
+        navigate(`/projects/${projectName}`);
+      },
+    });
+  };
 
   return (
-    <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
-      {onMenuToggle && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="md:hidden"
-          aria-label="Open menu"
-          onClick={onMenuToggle}
-        >
-          <Menu className="h-5 w-5" />
-        </Button>
-      )}
-      <h2 className="text-lg font-semibold">{agent.name}</h2>
-      <div className="ml-auto">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" aria-label="Agent options">
-              <EllipsisVertical className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => clearSession.mutate(agent.id)}>
-              <Eraser className="h-4 w-4 mr-2" />
-              Clear Session
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+    <>
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
+        {onMenuToggle && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            aria-label="Open menu"
+            onClick={onMenuToggle}
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+        )}
+        <span className="text-lg">{agent.emoji || "\u{1F916}"}</span>
+        <h2 className="text-lg font-semibold">{agent.name}</h2>
+        <div className="ml-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="Agent options">
+                <EllipsisVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => navigate(`/projects/${projectName}/agents/${agent.name}/settings`)}
+              >
+                <Settings className="h-4 w-4 mr-2" />
+                Settings
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => clearSession.mutate(agent.id)}>
+                <Eraser className="h-4 w-4 mr-2" />
+                Clear Session
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => setDeleteOpen(true)}
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
-    </div>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Agent</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete &ldquo;{agent.name}&rdquo;? This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={handleDelete}
+              disabled={deleteAgentMut.isPending}
+            >
+              {deleteAgentMut.isPending ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -93,6 +93,7 @@ export default function ProjectLayout() {
       setCurrentAgent({
         id: "",
         name: agent.name,
+        emoji: agent.emoji,
         description: agent.description,
         harness: agent.harness,
         model: agent.model,

--- a/src/frontend/components/sidebar/AgentListPanel.tsx
+++ b/src/frontend/components/sidebar/AgentListPanel.tsx
@@ -1,26 +1,7 @@
-import * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "../ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "../ui/alert-dialog";
-import { buttonVariants } from "../ui/button";
 import { Spinner } from "../ui/spinner";
-import { type AgentOverview } from "../types";
-import { useProjectId, useAgents, useDeleteAgent } from "../../hooks";
+import { useProjectId, useAgents } from "../../hooks";
 
 interface AgentListPanelProps {
   onNewAgent: () => void;
@@ -32,17 +13,8 @@ export default function AgentListPanel({ onNewAgent, onBrowseCatalog }: AgentLis
   const { agentName } = useParams<{ agentName: string }>();
   const { projectId, projectName } = useProjectId();
   const { data: agents = [], isLoading: agentsLoading } = useAgents(projectId);
-  const deleteAgentMut = useDeleteAgent(projectId ?? "");
 
   const selectedAgentId = agentName ? (agents.find((a) => a.name === agentName)?.id ?? null) : null;
-  const [deleteAgent, setDeleteAgent] = React.useState<AgentOverview | null>(null);
-
-  const handleDeleteConfirm = () => {
-    if (deleteAgent) {
-      deleteAgentMut.mutate(deleteAgent.id);
-      setDeleteAgent(null);
-    }
-  };
 
   const handleSelectAgent = (id: string) => {
     const agent = agents.find((a) => a.id === id);
@@ -60,58 +32,37 @@ export default function AgentListPanel({ onNewAgent, onBrowseCatalog }: AgentLis
           </div>
         )}
         {agents.map((agent) => (
-          <div key={agent.id} className="group flex items-center mx-1">
-            <button
-              type="button"
-              className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm flex-1 min-w-0 text-left ${
-                selectedAgentId === agent.id
-                  ? "bg-accent text-accent-foreground"
-                  : "hover:bg-muted text-foreground"
-              }`}
-              onClick={() => handleSelectAgent(agent.id)}
-            >
-              <span className="truncate">{agent.name}</span>
-              {agent.unreadCount ? (
-                <span className="ml-auto shrink-0 min-w-5 h-5 rounded-full bg-primary text-primary-foreground text-xs font-medium flex items-center justify-center px-1">
+          <button
+            key={agent.id}
+            type="button"
+            className={`flex items-center gap-2 px-3 py-2 mx-1 rounded-md text-sm w-[calc(100%-0.5rem)] min-w-0 text-left ${
+              selectedAgentId === agent.id
+                ? "bg-accent text-accent-foreground"
+                : "hover:bg-muted text-foreground"
+            }`}
+            onClick={() => handleSelectAgent(agent.id)}
+          >
+            <span className="shrink-0">{agent.emoji || "\u{1F916}"}</span>
+            <span className="truncate flex-1">{agent.name}</span>
+            <div className="ml-auto flex items-center gap-1.5 shrink-0">
+              {agent.busy && (
+                <span
+                  className="relative flex h-2 w-2"
+                  role="status"
+                  aria-label="Processing"
+                  title="Processing"
+                >
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-500" />
+                </span>
+              )}
+              {agent.unreadCount > 0 && (
+                <span className="min-w-5 h-5 rounded-full bg-primary text-primary-foreground text-xs font-medium flex items-center justify-center px-1">
                   {agent.unreadCount > 99 ? "99+" : agent.unreadCount}
                 </span>
-              ) : null}
-            </button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-background text-muted-foreground"
-                  aria-label={`${agent.name} actions`}
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <circle cx="8" cy="3" r="1.5" />
-                    <circle cx="8" cy="8" r="1.5" />
-                    <circle cx="8" cy="13" r="1.5" />
-                  </svg>
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onClick={() => navigate(`/projects/${projectName}/agents/${agent.name}/settings`)}
-                >
-                  Settings
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className="text-destructive focus:text-destructive"
-                  onClick={() => setDeleteAgent(agent)}
-                >
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+              )}
+            </div>
+          </button>
         ))}
         {!agentsLoading && agents.length === 0 && (
           <div className="px-3 py-6 text-center">
@@ -131,33 +82,6 @@ export default function AgentListPanel({ onNewAgent, onBrowseCatalog }: AgentLis
           Browse Catalog
         </Button>
       </div>
-
-      <AlertDialog
-        open={!!deleteAgent}
-        onOpenChange={(open) => {
-          if (!open) setDeleteAgent(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Agent</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete &ldquo;{deleteAgent?.name}&rdquo;? This action cannot
-              be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className={buttonVariants({ variant: "destructive" })}
-              onClick={handleDeleteConfirm}
-              disabled={deleteAgentMut.isPending}
-            >
-              {deleteAgentMut.isPending ? "Deleting..." : "Delete"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 }

--- a/src/frontend/components/types.ts
+++ b/src/frontend/components/types.ts
@@ -20,6 +20,7 @@ export interface Skill {
 export interface AgentOverview {
   id: string;
   name: string;
+  emoji?: string | null;
   busy: boolean;
   unreadCount: number;
   lastUserMessageAt?: string | null;

--- a/src/frontend/hooks/agents.ts
+++ b/src/frontend/hooks/agents.ts
@@ -55,6 +55,7 @@ export function useAgentDetail(projectId: string | undefined, agentId: string | 
 
 interface AgentMutationData {
   name: string;
+  emoji?: string;
   description?: string;
   harness?: "claude_code" | "pi" | "opencode" | "codex";
   model?: string;

--- a/src/frontend/test/AgentForm.test.tsx
+++ b/src/frontend/test/AgentForm.test.tsx
@@ -175,6 +175,53 @@ describe("AgentForm", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders emoji picker button with default robot emoji", () => {
+    renderForm();
+    expect(screen.getByText("\u{1F916}")).toBeInTheDocument();
+    expect(screen.getByText("Pick an emoji")).toBeInTheDocument();
+  });
+
+  it("renders emoji from agent prop in picker button", () => {
+    const agent: Agent = {
+      id: "a1",
+      name: "emoji-agent",
+      emoji: "\u{1F680}",
+      busy: false,
+      unreadCount: 0,
+      harness: "claude_code",
+    };
+    renderForm(agent);
+    expect(screen.getByText("\u{1F680}")).toBeInTheDocument();
+    expect(screen.getByText("Click to change")).toBeInTheDocument();
+  });
+
+  it("includes emoji in payload when agent has emoji from catalog", async () => {
+    const localOnSave = mock(() => {});
+    const catalogAgent: Agent = {
+      id: "",
+      name: "rocket-agent",
+      emoji: "\u{1F680}",
+      busy: false,
+      unreadCount: 0,
+      harness: "claude_code",
+    };
+
+    render(
+      <AgentForm
+        open={true}
+        title="New Agent from Catalog"
+        agent={catalogAgent}
+        onSave={localOnSave}
+        onClose={mock(() => {})}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Save Agent"));
+
+    const payload = (localOnSave.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
+    expect(payload.emoji).toBe("\u{1F680}");
+  });
+
   it("submits create-agent with structured fields when agent has empty id (catalog prefill)", async () => {
     const localOnSave = mock(() => {});
     const catalogAgent: Agent = {

--- a/src/frontend/test/AgentSidebar.test.tsx
+++ b/src/frontend/test/AgentSidebar.test.tsx
@@ -171,37 +171,31 @@ describe("AgentSidebar", () => {
     // Navigation should have been triggered (no error thrown)
   });
 
-  it("shows delete confirmation dialog and executes delete", async () => {
-    let deletedId: string | undefined;
-    server.use(
-      http.delete("*/api/projects/:id/agents/:aid", ({ params }) => {
-        deletedId = params.aid as string;
-        return HttpResponse.json({ ok: true });
-      }),
-    );
+  it("renders emoji avatar for agents", async () => {
     setProjects();
-    setAgents(defaultAgents);
+    setAgents([{ ...defaultAgents[0], emoji: "\u{1F680}" }, { ...defaultAgents[1] }]);
     renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
 
     await waitFor(() => {
       expect(screen.getByText("Active Agent")).toBeInTheDocument();
     });
 
-    // Open the actions dropdown for the first agent
-    const actionButtons = screen.getAllByRole("button", { name: /actions/ });
-    await userEvent.click(actionButtons[0]);
+    // Custom emoji for first agent
+    expect(screen.getByText("\u{1F680}")).toBeInTheDocument();
+    // Default robot emoji for second agent (no emoji set)
+    expect(screen.getByText("\u{1F916}")).toBeInTheDocument();
+  });
 
-    // Click "Delete" in the dropdown
-    await userEvent.click(screen.getByText("Delete"));
+  it("renders busy indicator when agent is busy", async () => {
+    setProjects();
+    setAgents([{ ...defaultAgents[0], busy: true }]);
+    renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
 
-    // Confirm deletion in the alert dialog
-    expect(screen.getByText("Delete Agent")).toBeInTheDocument();
-    const alertDialog = screen.getByRole("alertdialog");
-    const confirmButton = alertDialog.querySelector("button:last-of-type");
-    expect(confirmButton).toBeTruthy();
-    await userEvent.click(confirmButton!);
+    await waitFor(() => {
+      expect(screen.getByText("Active Agent")).toBeInTheDocument();
+    });
 
-    await waitFor(() => expect(deletedId).toBe("a1"));
+    expect(screen.getByRole("status", { name: "Processing" })).toBeInTheDocument();
   });
 
   it("renders Schedules link", async () => {
@@ -220,53 +214,6 @@ describe("AgentSidebar", () => {
     await waitFor(() => {
       expect(screen.getByText("Files")).toBeInTheDocument();
     });
-  });
-
-  it("navigates to settings on dropdown Settings click", async () => {
-    setProjects();
-    setAgents(defaultAgents);
-    renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
-
-    await waitFor(() => {
-      expect(screen.getByText("Active Agent")).toBeInTheDocument();
-    });
-
-    // Open the actions dropdown for the first agent
-    const actionButtons = screen.getAllByRole("button", { name: /actions/ });
-    await userEvent.click(actionButtons[0]);
-
-    // Click "Settings" in the dropdown - use getAllByText since "Settings" appears
-    // both in the dropdown and in the sidebar nav
-    const settingsOptions = screen.getAllByText("Settings");
-    // The dropdown option is the one inside DropdownMenuContent
-    const dropdownSettings = settingsOptions.find((el) => el.closest("[role='menuitem']") !== null);
-    if (dropdownSettings) {
-      await userEvent.click(dropdownSettings);
-    }
-  });
-
-  it("dismisses delete dialog when onOpenChange fires false", async () => {
-    setProjects();
-    setAgents(defaultAgents);
-    renderWithProviders(<AgentSidebar {...defaultProps} />, routeOpts);
-
-    await waitFor(() => {
-      expect(screen.getByText("Active Agent")).toBeInTheDocument();
-    });
-
-    // Open the actions dropdown and click Delete
-    const actionButtons = screen.getAllByRole("button", { name: /actions/ });
-    await userEvent.click(actionButtons[0]);
-    await userEvent.click(screen.getByText("Delete"));
-
-    // Dialog should be open
-    expect(screen.getByText("Delete Agent")).toBeInTheDocument();
-
-    // Press Cancel to dismiss
-    await userEvent.click(screen.getByText("Cancel"));
-
-    // Dialog should be closed
-    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 
   it("handles case when agent not found in handleSelectAgent", async () => {

--- a/src/frontend/test/ChatHeader.test.tsx
+++ b/src/frontend/test/ChatHeader.test.tsx
@@ -14,23 +14,41 @@ const agent: AgentOverview = {
   unreadCount: 0,
 };
 
+const agentWithEmoji: AgentOverview = {
+  ...agent,
+  emoji: "\u{1F680}",
+};
+
 /**
  * ChatHeader calls useProjectId() which reads projectName from useParams()
  * and resolves the project id from GET /api/projects.
  * We render at route "/projects/test-project" and let the default MSW handler
  * return [{ id: "p1", name: "test-project" }].
  */
-function renderChatHeader(props?: { onMenuToggle?: () => void }) {
-  return renderWithProviders(<ChatHeader agent={agent} {...props} />, {
-    route: "/projects/test-project",
-    routePath: "/projects/:projectName",
-  });
+function renderChatHeader(props?: { onMenuToggle?: () => void; agentOverride?: AgentOverview }) {
+  return renderWithProviders(
+    <ChatHeader agent={props?.agentOverride ?? agent} onMenuToggle={props?.onMenuToggle} />,
+    {
+      route: "/projects/test-project/agents/test-agent",
+      routePath: "/projects/:projectName/agents/:agentName",
+    },
+  );
 }
 
 describe("ChatHeader", () => {
   it("renders agent name", () => {
     renderChatHeader();
     expect(screen.getByText("test-agent")).toBeInTheDocument();
+  });
+
+  it("renders default robot emoji when no emoji set", () => {
+    renderChatHeader();
+    expect(screen.getByText("\u{1F916}")).toBeInTheDocument();
+  });
+
+  it("renders custom emoji when set", () => {
+    renderChatHeader({ agentOverride: agentWithEmoji });
+    expect(screen.getByText("\u{1F680}")).toBeInTheDocument();
   });
 
   it("sends clear session request when Clear Session is clicked", async () => {
@@ -54,6 +72,60 @@ describe("ChatHeader", () => {
     await user.click(screen.getByText("Clear Session"));
 
     await waitFor(() => expect(clearCalled).toBe(true));
+  });
+
+  it("renders Settings option in dropdown", async () => {
+    const user = userEvent.setup();
+    renderChatHeader();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Agent options" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Agent options" }));
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("renders Delete option in dropdown and shows confirmation dialog", async () => {
+    const user = userEvent.setup();
+    renderChatHeader();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Agent options" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Agent options" }));
+    await user.click(screen.getByText("Delete"));
+
+    expect(screen.getByText("Delete Agent")).toBeInTheDocument();
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+
+  it("executes delete when confirmed", async () => {
+    let deletedId: string | undefined;
+    server.use(
+      http.delete("*/api/projects/:id/agents/:aid", ({ params }) => {
+        deletedId = params.aid as string;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderChatHeader();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Agent options" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Agent options" }));
+    await user.click(screen.getByText("Delete"));
+
+    const alertDialog = screen.getByRole("alertdialog");
+    const confirmButton = alertDialog.querySelector("button:last-of-type");
+    expect(confirmButton).toBeTruthy();
+    await user.click(confirmButton!);
+
+    await waitFor(() => expect(deletedId).toBe("a1"));
   });
 
   it("renders mobile menu toggle when onMenuToggle is provided", () => {

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -33,6 +33,7 @@ export const agentRoutes = new Hono<AppEnv>()
       "json",
       z.object({
         name: z.string(),
+        emoji: z.string().max(10).optional(),
         description: z.string().optional(),
         harness: z.enum(["claude_code", "pi", "opencode", "codex"]).optional(),
         model: z.string().optional(),
@@ -66,6 +67,7 @@ export const agentRoutes = new Hono<AppEnv>()
       "json",
       z.object({
         name: z.string().optional(),
+        emoji: z.string().max(10).optional(),
         description: z.string().optional(),
         harness: z.enum(["claude_code", "pi", "opencode", "codex"]).optional(),
         model: z.string().optional(),

--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -18,6 +18,7 @@ interface AgentManagerOpts {
   projectId: string;
   agentId: string;
   agentName: string;
+  emoji?: string | null;
 }
 
 interface MessageEnvelope {
@@ -75,6 +76,7 @@ export class AgentManager {
   readonly projectId: string;
   readonly agentId: string;
   agentName: string;
+  emoji: string | null;
   running = false;
 
   private harness: Harness | null = null;
@@ -98,6 +100,7 @@ export class AgentManager {
     this.projectId = opts.projectId;
     this.agentId = opts.agentId;
     this.agentName = opts.agentName;
+    this.emoji = opts.emoji ?? null;
     this.initLastRead();
     this.initLastUserMessage();
   }

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -16,6 +16,7 @@ import { valid as isValidSlug } from "../services/slug";
 
 export interface AgentFields {
   name?: string;
+  emoji?: string;
   description?: string;
   harness?: string;
   model?: string;
@@ -74,7 +75,7 @@ export class Coordinator {
 
     const dbAgents = agentsService.listAgents(this.projectId);
     const results = await Promise.allSettled(
-      dbAgents.map((agent) => this.startAgentManager(agent.id, agent.name)),
+      dbAgents.map((agent) => this.startAgentManager(agent.id, agent.name, agent.emoji)),
     );
     const ok = results.filter((r) => r.status === "fulfilled").length;
     const failed = results.filter((r) => r.status === "rejected");
@@ -112,6 +113,7 @@ export class Coordinator {
         this.projectId,
         {
           name: params.name,
+          emoji: params.emoji,
           description: params.description,
           harness: params.harness,
           model: params.model,
@@ -129,7 +131,7 @@ export class Coordinator {
     }
 
     // Start process
-    await this.startAgentManager(agent.id, agent.name);
+    await this.startAgentManager(agent.id, agent.name, agent.emoji);
     await this.writePeersYaml();
 
     bus.emit(`project:${this.projectId}:agents`, {
@@ -176,9 +178,12 @@ export class Coordinator {
       await skillsService.writeSkills(this.projectId, agentId, params.skills, harness);
     }
 
-    // Restart the agent to pick up changes
+    // Update cached fields and restart the agent to pick up changes
     const proc = this.agents.get(agentId);
-    if (proc) await proc.restart();
+    if (proc) {
+      if (params.emoji !== undefined) proc.emoji = params.emoji ?? null;
+      await proc.restart();
+    }
 
     await this.writePeersYaml();
 
@@ -230,6 +235,7 @@ export class Coordinator {
   listAgentStatuses(): Array<{
     id: string;
     name: string;
+    emoji: string | null;
     busy: boolean;
     unreadCount: number;
     lastReadMessageId: number | null;
@@ -245,6 +251,7 @@ export class Coordinator {
     const result: Array<{
       id: string;
       name: string;
+      emoji: string | null;
       busy: boolean;
       unreadCount: number;
       lastReadMessageId: number | null;
@@ -254,6 +261,7 @@ export class Coordinator {
       result.push({
         id,
         name: proc.agentName,
+        emoji: proc.emoji,
         busy: proc.busy,
         unreadCount: unreads.get(id) ?? 0,
         lastReadMessageId: proc.getLastReadMessageId(),
@@ -292,6 +300,7 @@ export class Coordinator {
     return {
       id: agentId,
       name: proc.agentName,
+      emoji: agent?.emoji ?? null,
       description: agent?.description ?? "",
       harness: agent?.harness ?? "claude_code",
       model: agent?.model ?? null,
@@ -310,11 +319,16 @@ export class Coordinator {
 
   // --- Private ---
 
-  private async startAgentManager(agentId: string, agentName: string): Promise<void> {
+  private async startAgentManager(
+    agentId: string,
+    agentName: string,
+    emoji?: string | null,
+  ): Promise<void> {
     const proc = new AgentManager({
       projectId: this.projectId,
       agentId,
       agentName,
+      emoji,
     });
 
     this.agents.set(agentId, proc);

--- a/src/services/agents.test.ts
+++ b/src/services/agents.test.ts
@@ -328,6 +328,27 @@ describe("agents service", () => {
     });
   });
 
+  describe("emoji support", () => {
+    it("stores emoji on creation", () => {
+      const agent = agents.createAgent(projectId, {
+        name: "emoji-agent",
+        emoji: "\u{1F680}",
+      });
+      expect(agent.emoji).toBe("\u{1F680}");
+    });
+
+    it("defaults emoji to null when not provided", () => {
+      const agent = agents.createAgent(projectId, { name: "no-emoji-agent" });
+      expect(agent.emoji).toBeNull();
+    });
+
+    it("updates emoji via updateAgent", () => {
+      const agent = agents.createAgent(projectId, { name: "update-emoji-agent" });
+      const updated = agents.updateAgent(agent.id, { emoji: "\u{1F916}" });
+      expect(updated!.emoji).toBe("\u{1F916}");
+    });
+  });
+
   describe("transaction support", () => {
     it("createMessage rolls back when transaction fails", () => {
       const initialMessages = agents.listMessages(projectId, agentId).messages.length;

--- a/src/services/agents.ts
+++ b/src/services/agents.ts
@@ -29,6 +29,7 @@ export function createAgent(
   projectId: string,
   data: {
     name: string;
+    emoji?: string;
     description?: string;
     harness?: string;
     model?: string;
@@ -41,6 +42,7 @@ export function createAgent(
     .values({
       projectId,
       name: data.name,
+      emoji: data.emoji,
       description: data.description,
       harness: data.harness,
       model: data.model,
@@ -54,6 +56,7 @@ export function updateAgent(
   id: string,
   fields: {
     name?: string;
+    emoji?: string;
     description?: string;
     harness?: string;
     model?: string;


### PR DESCRIPTION
## Summary

- **Emoji avatars**: Agents can now have emoji avatars. Added `emoji` column to DB, emoji picker (frimousse, headless 470-byte lib) in the agent form, and display in sidebar + chat header. Catalog agents get their emoji pre-filled. Default: 🤖
- **Busy indicator**: Pulsing amber dot appears next to agent name when processing, with accessible `role="status"` and `aria-label`
- **Merged 3-dot menu**: Removed per-agent dropdown from sidebar. Settings, Clear Session, and Delete (with confirmation dialog) now live in the chat header dropdown

## Test plan
- [x] 1115 tests pass (3 new: emoji in AgentForm, emoji in sidebar, busy indicator)
- [x] TypeScript typecheck clean
- [x] ESLint clean (only pre-existing CsvEditor warning)
- [x] Prettier formatting verified
- [ ] Manual: create agent from catalog → emoji shows in sidebar and chat header
- [ ] Manual: create custom agent → default 🤖 shows, pick emoji via form
- [ ] Manual: send message → busy indicator pulses while processing
- [ ] Manual: chat header 3-dot → Settings, Clear Session, Delete all work
- [ ] Manual: delete from chat header redirects to project page

🤖 Generated with [Claude Code](https://claude.com/claude-code)