### PR TITLE
Match editor code blocks to chat message style

### DIFF
--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -124,12 +124,6 @@
   --terminal-fg: oklch(0.9 0 0);
 }
 
-/* Editor: code block color variables */
-:root {
-  --code-background: rgb(40, 44, 52);
-  --code-foreground: rgb(171, 178, 191);
-}
-
 /* Editor: contenteditable styles */
 div[contenteditable] {
   caret-color: var(--primary);
@@ -265,27 +259,37 @@ th:focus-within .shire-table-cell-action-button {
 .shire-content-root > code {
   margin: 1rem 0;
   font-size: 0.875rem;
-  background-color: var(--code-background);
-  color: var(--code-foreground);
   display: block;
   border-radius: 0.375rem;
   padding: 1rem;
-  caret-color: white;
+  border: 1px solid var(--border);
+  background-color: var(--background);
+  color: var(--foreground);
+  caret-color: currentColor;
+  overflow-x: auto;
 }
 
-.shire-content-root > code::selection {
-  background-color: rgb(255 255 255 / 0.2);
-}
+/* Light mode syntax colors (github-light) */
+.shire-attr { color: #032f62; }
+.shire-property { color: #005cc5; }
+.shire-selector { color: #22863a; }
+.shire-function { color: #6f42c1; }
+.shire-comment { color: #6a737d; }
+.shire-variable { color: #e36209; }
+.shire-operator { color: #d73a49; }
+.shire-punctuation { color: #24292e; }
+.shire-keyword { color: #d73a49; }
 
-.shire-attr { color: rgb(152, 195, 121); }
-.shire-property { color: rgb(209, 154, 102); }
-.shire-selector { color: rgb(224, 108, 117); }
-.shire-function { color: rgb(97, 175, 239); }
-.shire-comment { color: rgb(92, 99, 112); }
-.shire-variable { color: rgb(198, 120, 221); }
-.shire-operator { color: rgb(97, 175, 239); }
-.shire-punctuation { color: rgb(171, 178, 191); }
-.shire-keyword { color: rgb(198, 120, 221); }
+/* Dark mode syntax colors (github-dark) */
+.dark .shire-attr { color: #9ecbff; }
+.dark .shire-property { color: #79b8ff; }
+.dark .shire-selector { color: #85e89d; }
+.dark .shire-function { color: #b392f0; }
+.dark .shire-comment { color: #8b949e; }
+.dark .shire-variable { color: #ffab70; }
+.dark .shire-operator { color: #f97583; }
+.dark .shire-punctuation { color: #e1e4e8; }
+.dark .shire-keyword { color: #f97583; }
 
 /* Override Tailwind prose pre backgrounds for light/dark mode */
 .prose pre {


### PR DESCRIPTION
## Summary
- Replace hardcoded One Dark colors with theme-aware CSS variables (`--background`, `--foreground`, `--border`) for the markdown editor code block container
- Update syntax highlighting colors from One Dark to GitHub light/dark theme variants, matching Shiki's output in chat messages
- Fix `overflow: hidden` → `overflow-x: auto` so long lines scroll instead of being clipped

## Test plan
- [ ] Open a shared drive markdown file containing code blocks
- [ ] Compare visually with chat message code blocks — container and syntax colors should match
- [ ] Toggle light/dark mode and verify both look correct
- [ ] Verify code blocks remain editable with visible caret
- [ ] Test long lines scroll horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)