### PR TITLE
Support backtick-wrapped /shared/ paths as clickable links

### DIFF
--- a/src/frontend/lib/remark-shared-links.ts
+++ b/src/frontend/lib/remark-shared-links.ts
@@ -1,9 +1,12 @@
 import { findAndReplace } from "mdast-util-find-and-replace";
-import type { Root, PhrasingContent } from "mdast";
+import { visit, CONTINUE } from "unist-util-visit";
+import type { Root, PhrasingContent, Parent } from "mdast";
 
 function stripTrailingPunctuation(path: string): string {
   return path.replace(/[.,;:]+$/, "");
 }
+
+const sharedPathOnly = /^\/shared\/\S+$/;
 
 export default function remarkSharedLinks() {
   return (tree: Root) => {
@@ -20,5 +23,19 @@ export default function remarkSharedLinks() {
         },
       ],
     ]);
+
+    // Also handle backtick-wrapped paths like `/shared/file.txt`
+    visit(tree, "inlineCode", (node, index, parent) => {
+      if (index === undefined || !parent) return;
+      const value = node.value.trim();
+      if (!sharedPathOnly.test(value)) return;
+      const cleanPath = stripTrailingPunctuation(value);
+      (parent as Parent).children.splice(index, 1, {
+        type: "link",
+        url: cleanPath,
+        children: [{ type: "text", value: cleanPath }],
+      });
+      return [CONTINUE, index + 1] as const;
+    });
   };
 }

--- a/src/frontend/test/remark-shared-links.test.ts
+++ b/src/frontend/test/remark-shared-links.test.ts
@@ -49,4 +49,21 @@ describe("remarkSharedLinks", () => {
     const result = process("```\n/shared/file.txt\n```");
     expect(result).not.toContain("[/shared/file.txt]");
   });
+
+  it("converts backtick-wrapped /shared/ path to a link", () => {
+    const result = process("Check `/shared/file.txt` for details.");
+    expect(result).toContain("[/shared/file.txt](/shared/file.txt)");
+    expect(result).not.toContain("`/shared/file.txt`");
+  });
+
+  it("converts backtick-wrapped nested /shared/ path to a link", () => {
+    const result = process("See `/shared/a/b/c.md` here.");
+    expect(result).toContain("[/shared/a/b/c.md](/shared/a/b/c.md)");
+  });
+
+  it("does not convert backtick code containing more than just a path", () => {
+    const result = process("Run `cat /shared/file.txt` to see it.");
+    expect(result).toContain("`cat /shared/file.txt`");
+    expect(result).not.toContain("[/shared/file.txt]");
+  });
 });


### PR DESCRIPTION
## Summary

- Agents sometimes wrap `/shared/` paths in backticks despite system prompt instructions not to. The `remark-shared-links` plugin now also converts `inlineCode` nodes whose entire value is a `/shared/` path into clickable links.
- Only standalone paths are converted — inline code with other text (e.g. `` `cat /shared/file.txt` ``) remains as code.

## Test plan

- [x] New test: backtick-wrapped `/shared/file.txt` becomes a link
- [x] New test: backtick-wrapped nested path becomes a link
- [x] New test: inline code with more than just a path stays as code
- [x] All existing tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)