### PR TITLE
Use dev-compatible command for search-messages

### DIFF
--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -11,6 +11,7 @@ import * as skillsService from "../services/skills";
 import { createHarness, type Harness, type HarnessType } from "./harness";
 import type { AgentEvent } from "./harness/types";
 import { buildInternalPrompt } from "./system-prompt";
+import { getPackageRoot } from "../utils/package-root";
 
 const MAX_AUTO_RESTARTS = 3;
 
@@ -299,10 +300,15 @@ export class AgentManager {
     const model = agent.model ?? "claude-sonnet-4-6";
     const systemPrompt = agent.systemPrompt ?? "";
     const agentDir = workspace.agentDir(this.projectId, this.agentId);
+    const isCompiled = process.argv[1]?.startsWith("/$bunfs/");
+    const shireCommand = isCompiled
+      ? "shire"
+      : `bun run ${join(getPackageRoot(__dirname, 2), "src", "cli.ts")}`;
     const internalSystemPrompt = buildInternalPrompt({
       agentName: this.agentName,
       projectId: this.projectId,
       agentId: this.agentId,
+      shireCommand,
     });
 
     this.harness = createHarness(harnessType);

--- a/src/runtime/system-prompt.ts
+++ b/src/runtime/system-prompt.ts
@@ -6,12 +6,14 @@ interface BuildInternalPromptOpts {
   agentName: string;
   projectId: string;
   agentId: string;
+  shireCommand?: string;
 }
 
 export function buildInternalPrompt({
   agentName,
   projectId,
   agentId,
+  shireCommand = "shire",
 }: BuildInternalPromptOpts): string {
   const peersPath = workspace.peersPath(projectId);
   const agentDir = workspace.agentDir(projectId, agentId);
@@ -99,7 +101,7 @@ Violations include:
 ## Message History Search
 Search your past conversation history using:
 \`\`\`
-shire search-messages --project-id ${projectId} --agent-id ${agentId} --query "your search terms"
+${shireCommand} search-messages --project-id ${projectId} --agent-id ${agentId} --query "your search terms"
 \`\`\`
 Use this when you need to recall what was discussed in previous sessions — past decisions, instructions, or context no longer in your current conversation.
 `;


### PR DESCRIPTION
## Summary
- In dev mode, system prompt tells agents to use `bun run <root>/src/cli.ts search-messages` instead of `shire search-messages`
- Detects compiled binary via `process.argv[1]?.startsWith("/$bunfs/")` (same pattern used in `cli.ts`)
- Ensures agents can use message search during development without needing the installed binary

## Test plan
- [x] Typecheck, lint, and all 1127 tests pass
- [ ] Manual: `bun run dev`, send agent a search query, verify it uses `bun run .../src/cli.ts` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)