### PR TITLE
Persist navigation state via URL params + localStorage

### DIFF
--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -18,6 +18,7 @@ import {
   fetchCatalogAgent,
   findDefaultAgent,
   useIsDesktop,
+  useSyncedParam,
 } from "../hooks";
 import { useSubscription, type AgentListWsEvent, type SharedDriveWsEvent } from "../lib/ws";
 import {
@@ -48,19 +49,42 @@ export default function ProjectLayout() {
   const location = useLocation();
   const isSharedDriveRoute = location.pathname === `/projects/${projectName}/shared`;
 
-  // --- File preview panel state ---
-  const [panelFilePath, setPanelFilePath] = React.useState<string | null>(null);
+  // --- File preview panel state (synced to URL ?preview= and localStorage) ---
+  const [panelFilePath, setPanelFilePath] = useSyncedParam(
+    "preview",
+    `shire:preview:${projectName}`,
+    { disabled: isSharedDriveRoute },
+  );
   const filePanelRef = React.useRef<PanelImperativeHandle>(null);
 
   // Only show the panel on agent chat routes, not on the shared drive view
   const effectivePanelFilePath = isSharedDriveRoute ? null : panelFilePath;
 
-  // Reset panel when project changes
-  const [prevProjectName, setPrevProjectName] = React.useState(projectName);
-  if (projectName !== prevProjectName) {
-    setPrevProjectName(projectName);
-    setPanelFilePath(null);
-  }
+  // --- Remember last-viewed agent per project ---
+  const agentStorageKey = `shire:agent:${projectName}`;
+  React.useEffect(() => {
+    if (agentName) {
+      try {
+        localStorage.setItem(agentStorageKey, agentName);
+      } catch {
+        // ignore
+      }
+    }
+  }, [agentName, agentStorageKey]);
+
+  // Redirect project index to last-viewed agent (only on the exact index route)
+  const isProjectIndex = location.pathname === `/projects/${projectName}`;
+  React.useEffect(() => {
+    if (!isProjectIndex || agentList.length === 0) return;
+    try {
+      const saved = localStorage.getItem(agentStorageKey);
+      if (saved && agentList.some((a) => a.name === saved)) {
+        navigate(`/projects/${projectName}/agents/${saved}`, { replace: true });
+      }
+    } catch {
+      // ignore
+    }
+  }, [isProjectIndex, agentList, agentStorageKey, projectName, navigate]);
 
   // Expand/collapse the file panel imperatively
   React.useEffect(() => {

--- a/src/frontend/components/SharedDriveContentArea.tsx
+++ b/src/frontend/components/SharedDriveContentArea.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useSearchParams } from "react-router-dom";
 import { useDropzone } from "react-dropzone";
 import { Menu, Upload, Download, Trash2, Pencil, FolderOpen } from "lucide-react";
 import { Button } from "./ui/button";
@@ -15,6 +14,7 @@ import {
   useDeleteSharedFile,
   useRenameSharedFile,
   useUploadSharedDriveFile,
+  useSyncedParam,
 } from "../hooks";
 import { getFileIcon, getPreviewType, formatSize, MAX_UPLOAD_SIZE } from "../lib/file-utils";
 import { useProjectLayout } from "../providers/ProjectLayoutProvider";
@@ -22,9 +22,7 @@ import { useProjectLayout } from "../providers/ProjectLayoutProvider";
 export default function SharedDriveContentArea() {
   const { projectId, projectName } = useProjectId();
   const { sidebarOpen, setSidebarOpen } = useProjectLayout();
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  const filePath = searchParams.get("file");
+  const [filePath, setFilePath] = useSyncedParam("file", `shire:file:${projectName}`);
   const fileName = filePath ? (filePath.split("/").pop() ?? "") : "";
   const type = filePath ? getPreviewType(fileName) : null;
   const needsContent = type === "markdown" || type === "text" || type === "csv";
@@ -51,7 +49,7 @@ export default function SharedDriveContentArea() {
     if (!filePath) return;
     deleteSharedFile.mutate(filePath);
     setDeleteOpen(false);
-    setSearchParams({});
+    setFilePath(null);
   };
 
   const handleRename = (newName: string) => {
@@ -60,7 +58,7 @@ export default function SharedDriveContentArea() {
       { path: filePath, newName },
       {
         onSuccess: (data: { ok: boolean; newPath: string }) => {
-          setSearchParams({ file: data.newPath });
+          setFilePath(data.newPath);
         },
       },
     );

--- a/src/frontend/components/sidebar/SharedDrivePanel.tsx
+++ b/src/frontend/components/sidebar/SharedDrivePanel.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useSearchParams } from "react-router-dom";
 import { useDropzone } from "react-dropzone";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -29,6 +28,7 @@ import {
   useDeleteSharedFile,
   useRenameSharedFile,
   useUploadSharedDriveFile,
+  useSyncedParam,
 } from "../../hooks";
 import { formatSize, getFileIcon, MAX_UPLOAD_SIZE } from "../../lib/file-utils";
 import type { SharedDriveFile } from "../../hooks/shared-drive";
@@ -66,8 +66,7 @@ function Breadcrumbs({ path, onNavigate }: { path: string; onNavigate: (path: st
 
 export default function SharedDrivePanel() {
   const { projectId, projectName } = useProjectId();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const selectedFile = searchParams.get("file");
+  const [selectedFile, setSelectedFile] = useSyncedParam("file", `shire:file:${projectName}`);
   const parentDir = selectedFile
     ? selectedFile.substring(0, selectedFile.lastIndexOf("/")) || "/"
     : null;
@@ -112,7 +111,7 @@ export default function SharedDrivePanel() {
   };
 
   const selectFile = (file: SharedDriveFile) => {
-    setSearchParams({ file: file.path });
+    setSelectedFile(file.path);
   };
 
   const handleRename = (newName: string) => {
@@ -122,7 +121,7 @@ export default function SharedDrivePanel() {
       {
         onSuccess: (data: { ok: boolean; newPath: string }) => {
           if (selectedFile === renameTarget.path) {
-            setSearchParams({ file: data.newPath });
+            setSelectedFile(data.newPath);
           }
         },
       },
@@ -146,7 +145,7 @@ export default function SharedDrivePanel() {
       { name: trimmedName, path: currentPath },
       {
         onSuccess: (data) => {
-          setSearchParams({ file: data.path });
+          setSelectedFile(data.path);
         },
       },
     );
@@ -156,7 +155,7 @@ export default function SharedDrivePanel() {
     deleteSharedFile.mutate(file.path);
     setDeleteTarget(null);
     if (selectedFile === file.path) {
-      setSearchParams({});
+      setSelectedFile(null);
     }
   };
 

--- a/src/frontend/hooks/index.ts
+++ b/src/frontend/hooks/index.ts
@@ -10,3 +10,4 @@ export * from "./schedules";
 export * from "./alert-channels";
 export * from "./version";
 export * from "./use-is-desktop";
+export * from "./use-synced-param";

--- a/src/frontend/hooks/use-synced-param.ts
+++ b/src/frontend/hooks/use-synced-param.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect } from "react";
+import { useSearchParams, useLocation } from "react-router-dom";
+
+function getStored(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Two-way sync between a URL search param and localStorage.
+ *
+ * - Reads from the URL param first, falls back to localStorage.
+ * - Writes update both the URL param and localStorage.
+ * - On route changes, restores the param from localStorage when it's
+ *   missing from the URL (unless `disabled` is true).
+ */
+export function useSyncedParam(
+  paramName: string,
+  storageKey: string,
+  options?: { disabled?: boolean },
+): [string | null, (value: string | null) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const disabled = options?.disabled ?? false;
+
+  const fromUrl = searchParams.get(paramName);
+  const value = fromUrl ?? (disabled ? null : getStored(storageKey));
+
+  // Keep localStorage in sync when the URL param is present
+  useEffect(() => {
+    if (fromUrl) {
+      try {
+        localStorage.setItem(storageKey, fromUrl);
+      } catch {
+        // ignore
+      }
+    }
+  }, [fromUrl, storageKey]);
+
+  // Restore param from localStorage on route change when URL doesn't have it
+  useEffect(() => {
+    if (disabled) return;
+    const stored = getStored(storageKey);
+    const params = new URLSearchParams(location.search);
+    if (!params.has(paramName) && stored) {
+      setSearchParams(
+        (prev) => {
+          prev.set(paramName, stored);
+          return prev;
+        },
+        { replace: true },
+      );
+    }
+  }, [location.pathname, location.search, disabled, paramName, setSearchParams, storageKey]);
+
+  const setValue = useCallback(
+    (newValue: string | null) => {
+      try {
+        if (newValue) {
+          localStorage.setItem(storageKey, newValue);
+        } else {
+          localStorage.removeItem(storageKey);
+        }
+      } catch {
+        // ignore
+      }
+      setSearchParams(
+        (prev) => {
+          if (newValue) {
+            prev.set(paramName, newValue);
+          } else {
+            prev.delete(paramName);
+          }
+          return prev;
+        },
+        { replace: true },
+      );
+    },
+    [paramName, storageKey, setSearchParams],
+  );
+
+  return [value, setValue];
+}

--- a/src/frontend/test/AgentDashboard.test.tsx
+++ b/src/frontend/test/AgentDashboard.test.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, mock } from "bun:test";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
 import { server } from "./msw-server";
 import ProjectLayout from "../components/ProjectLayout";
 import AgentChatView from "../components/AgentChatView";
+import SharedDriveContentArea from "../components/SharedDriveContentArea";
 import { type AgentOverview } from "../components/types";
 
 mock.module("../lib/ws", () => ({
@@ -33,6 +34,12 @@ function setAgents(agentList: AgentOverview[]) {
   server.use(http.get("*/api/projects/:id/agents", () => HttpResponse.json(agentList)));
 }
 
+/** Renders the current router location so tests can assert navigation. */
+function LocationDisplay() {
+  const location = useLocation();
+  return <span data-testid="location">{location.pathname}</span>;
+}
+
 function renderWithLayout(route = "/projects/test-project") {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
@@ -45,8 +52,10 @@ function renderWithLayout(route = "/projects/test-project") {
           <Route path="/projects/:projectName" element={<ProjectLayout />}>
             <Route index element={<AgentChatView />} />
             <Route path="agents/:agentName" element={<AgentChatView />} />
+            <Route path="shared" element={<SharedDriveContentArea />} />
           </Route>
         </Routes>
+        <LocationDisplay />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -170,6 +179,50 @@ describe("ProjectLayout + AgentChatView", () => {
     renderWithLayout("/projects/test-project/agents/Agent Two");
     await waitFor(() => {
       expect(screen.getAllByText("Agent Two").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("agent localStorage redirect", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("saves current agent to localStorage", async () => {
+      setAgents(agents);
+      renderWithLayout("/projects/test-project/agents/Agent Two");
+      await waitFor(() => {
+        expect(localStorage.getItem("shire:agent:test-project")).toBe("Agent Two");
+      });
+    });
+
+    it("redirects project index to last-viewed agent", async () => {
+      setAgents(agents);
+      localStorage.setItem("shire:agent:test-project", "Agent Two");
+      renderWithLayout("/projects/test-project");
+      await waitFor(() => {
+        expect(screen.getByTestId("location").textContent).toBe(
+          "/projects/test-project/agents/Agent Two",
+        );
+      });
+    });
+
+    it("does not redirect when saved agent no longer exists", async () => {
+      setAgents(agents);
+      localStorage.setItem("shire:agent:test-project", "Deleted Agent");
+      renderWithLayout("/projects/test-project");
+      await waitFor(() => {
+        expect(screen.getAllByText("Agent One").length).toBeGreaterThanOrEqual(1);
+      });
+      expect(screen.getByTestId("location").textContent).toBe("/projects/test-project");
+    });
+
+    it("does not redirect on the shared drive route", async () => {
+      setAgents(agents);
+      localStorage.setItem("shire:agent:test-project", "Agent Two");
+      renderWithLayout("/projects/test-project/shared");
+      await waitFor(() => {
+        expect(screen.getByTestId("location").textContent).toBe("/projects/test-project/shared");
+      });
     });
   });
 });

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -472,4 +472,39 @@ describe("SharedDriveContentArea", () => {
       expect(screen.getByText(/too large/)).toBeInTheDocument();
     });
   });
+
+  it("saves selected file to localStorage", async () => {
+    renderContentArea("/projects/test-project/shared?file=readme.md");
+    await waitFor(() => {
+      expect(localStorage.getItem("shire:file:test-project")).toBe("readme.md");
+    });
+  });
+
+  it("restores file from localStorage when no URL param", async () => {
+    localStorage.setItem("shire:file:test-project", "photo.png");
+    renderContentArea("/projects/test-project/shared");
+    await waitFor(() => {
+      const img = screen.getByRole("img", { name: "photo.png" });
+      expect(img).toBeInTheDocument();
+    });
+  });
+
+  it("clears localStorage on file delete", async () => {
+    server.use(
+      http.delete("*/api/projects/:id/shared-drive", () => HttpResponse.json({ ok: true })),
+    );
+    renderContentArea("/projects/test-project/shared?file=readme.md");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = screen.getByRole("alertdialog");
+    const confirmBtn = Array.from(dialog.querySelectorAll("button")).find(
+      (b) => b.textContent === "Delete",
+    );
+    await userEvent.click(confirmBtn!);
+    await waitFor(() => {
+      expect(localStorage.getItem("shire:file:test-project")).toBeNull();
+    });
+  });
 });

--- a/src/frontend/test/SharedDrive.test.tsx
+++ b/src/frontend/test/SharedDrive.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach } from "bun:test";
 import { http, HttpResponse } from "msw";
 import { server } from "./msw-server";
 import SharedDrivePanel from "../components/sidebar/SharedDrivePanel";
@@ -299,6 +299,10 @@ describe("SharedDrivePanel", () => {
 });
 
 describe("SharedDriveContentArea", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("shows empty state when no file selected", async () => {
     renderContentArea();
     await waitFor(() => {

--- a/src/frontend/test/use-synced-param.test.tsx
+++ b/src/frontend/test/use-synced-param.test.tsx
@@ -1,0 +1,98 @@
+import { act } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "bun:test";
+import { useSyncedParam } from "../hooks/use-synced-param";
+import { renderHookWithProviders } from "./test-utils";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useSyncedParam", () => {
+  it("reads value from URL search param", () => {
+    const { result } = renderHookWithProviders(() => useSyncedParam("file", "shire:file:test"), {
+      route: "/test?file=%2Fdocs%2Freadme.md",
+      routePath: "/test",
+    });
+    expect(result.current[0]).toBe("/docs/readme.md");
+  });
+
+  it("falls back to localStorage when URL param is absent", () => {
+    localStorage.setItem("shire:file:test", "/docs/readme.md");
+    const { result } = renderHookWithProviders(() => useSyncedParam("file", "shire:file:test"), {
+      route: "/test",
+      routePath: "/test",
+    });
+    expect(result.current[0]).toBe("/docs/readme.md");
+  });
+
+  it("returns null when neither URL nor localStorage has a value", () => {
+    const { result } = renderHookWithProviders(() => useSyncedParam("file", "shire:file:test"), {
+      route: "/test",
+      routePath: "/test",
+    });
+    expect(result.current[0]).toBeNull();
+  });
+
+  it("URL param takes precedence over localStorage", () => {
+    localStorage.setItem("shire:file:test", "/old-file.md");
+    const { result } = renderHookWithProviders(() => useSyncedParam("file", "shire:file:test"), {
+      route: "/test?file=%2Fnew-file.md",
+      routePath: "/test",
+    });
+    expect(result.current[0]).toBe("/new-file.md");
+  });
+
+  it("syncs URL param to localStorage", () => {
+    renderHookWithProviders(() => useSyncedParam("file", "shire:file:test"), {
+      route: "/test?file=%2Fdocs%2Freadme.md",
+      routePath: "/test",
+    });
+    expect(localStorage.getItem("shire:file:test")).toBe("/docs/readme.md");
+  });
+
+  it("setValue updates both URL and localStorage", () => {
+    const { result } = renderHookWithProviders(() => useSyncedParam("file", "shire:file:test"), {
+      route: "/test",
+      routePath: "/test",
+    });
+
+    act(() => {
+      result.current[1]("/new-path.md");
+    });
+
+    expect(result.current[0]).toBe("/new-path.md");
+    expect(localStorage.getItem("shire:file:test")).toBe("/new-path.md");
+  });
+
+  it("setValue(null) clears both URL and localStorage", () => {
+    localStorage.setItem("shire:file:test", "/old.md");
+    const { result } = renderHookWithProviders(() => useSyncedParam("file", "shire:file:test"), {
+      route: "/test?file=%2Fold.md",
+      routePath: "/test",
+    });
+
+    act(() => {
+      result.current[1](null);
+    });
+
+    expect(result.current[0]).toBeNull();
+    expect(localStorage.getItem("shire:file:test")).toBeNull();
+  });
+
+  it("returns null from localStorage when disabled", () => {
+    localStorage.setItem("shire:file:test", "/saved.md");
+    const { result } = renderHookWithProviders(
+      () => useSyncedParam("file", "shire:file:test", { disabled: true }),
+      { route: "/test", routePath: "/test" },
+    );
+    expect(result.current[0]).toBeNull();
+  });
+
+  it("still reads URL param when disabled", () => {
+    const { result } = renderHookWithProviders(
+      () => useSyncedParam("file", "shire:file:test", { disabled: true }),
+      { route: "/test?file=%2Fdocs%2Freadme.md", routePath: "/test" },
+    );
+    expect(result.current[0]).toBe("/docs/readme.md");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `useSyncedParam` hook: two-way sync between URL search params and localStorage
- **Preview panel**: `?preview={path}` persists across agent-to-agent navigation
- **Shared drive file**: `?file={path}` on `/shared` route persists when navigating away and back
- **Last-viewed agent**: project index auto-redirects to last-viewed agent via localStorage

## Test plan

- [ ] Open agent chat, click a shared file link — URL shows `?preview=/path`
- [ ] Navigate to another agent — preview panel stays open
- [ ] Close panel — `?preview` removed from URL and localStorage
- [ ] On `/shared`, select a file, navigate away, come back — file restored
- [ ] Visit project index after viewing an agent — redirects to last agent
- [ ] Visit `/shared` with a saved agent — no unwanted redirect
- [ ] `bun test` passes (1136 tests, 0 failures)
- [ ] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)