### PR TITLE
Add date range and pagination to message search

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,7 +105,9 @@ Commands:
   stop               Stop a running daemon
   status             Check if the server is running
   search-messages    Search past conversation history (used by agents via Bash)
-                     shire search-messages --project-id <id> --agent-id <id> --query <text> [--limit <n>]
+                     shire search-messages --project-id <id> --agent-id <id> --query <text>
+                                           [--start-date <iso>] [--end-date <iso>]
+                                           [--limit <n>] [--offset <n>]
 
 Options:
   -p, --port     Port to listen on (default: 8080)
@@ -237,6 +239,9 @@ async function handleSearchMessages(cmdArgs: string[]): Promise<void> {
   let agentId = "";
   let query = "";
   let limit = 10;
+  let offset = 0;
+  let startDate: string | undefined;
+  let endDate: string | undefined;
 
   for (let i = 0; i < cmdArgs.length; i++) {
     const arg = cmdArgs[i];
@@ -253,12 +258,32 @@ async function handleSearchMessages(cmdArgs: string[]): Promise<void> {
         process.exit(1);
       }
       limit = parsed;
+    } else if (arg === "--offset") {
+      const parsed = parseInt(cmdArgs[++i] ?? "0", 10);
+      if (Number.isNaN(parsed) || parsed < 0) {
+        console.error("--offset must be a non-negative integer");
+        process.exit(1);
+      }
+      offset = parsed;
+    } else if (arg === "--start-date") {
+      startDate = cmdArgs[++i];
+      if (!startDate) {
+        console.error("--start-date requires a value");
+        process.exit(1);
+      }
+    } else if (arg === "--end-date") {
+      endDate = cmdArgs[++i];
+      if (!endDate) {
+        console.error("--end-date requires a value");
+        process.exit(1);
+      }
     }
   }
 
   if (!projectId || !agentId || !query) {
     console.error(
-      "Usage: shire search-messages --project-id <id> --agent-id <id> --query <text> [--limit <n>]",
+      "Usage: shire search-messages --project-id <id> --agent-id <id> --query <text> " +
+        "[--start-date <iso>] [--end-date <iso>] [--limit <n>] [--offset <n>]",
     );
     process.exit(1);
   }
@@ -267,7 +292,12 @@ async function handleSearchMessages(cmdArgs: string[]): Promise<void> {
   getDb();
   const { searchMessages } = await import("./db/fts");
   try {
-    const results = searchMessages(projectId, agentId, query, limit);
+    const results = searchMessages(projectId, agentId, query, {
+      limit,
+      offset,
+      startDate,
+      endDate,
+    });
     console.log(JSON.stringify(results, null, 2));
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));

--- a/src/db/fts.test.ts
+++ b/src/db/fts.test.ts
@@ -107,8 +107,110 @@ describe("FTS message search", () => {
       });
     }
 
-    const results = searchMessages("p1", "a1", "deployment", 2);
+    const results = searchMessages("p1", "a1", "deployment", { limit: 2 });
     expect(results.length).toBe(2);
+  });
+
+  it("filters results by date range", () => {
+    seedProject(db);
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Early deployment notes" },
+      createdAt: "2026-03-01T00:00:00.000Z",
+    });
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Mid deployment notes" },
+      createdAt: "2026-04-05T00:00:00.000Z",
+    });
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Late deployment notes" },
+      createdAt: "2026-05-10T00:00:00.000Z",
+    });
+
+    const inRange = searchMessages("p1", "a1", "deployment", {
+      startDate: "2026-04-01",
+      endDate: "2026-04-30",
+    });
+    expect(inRange.length).toBe(1);
+    expect(JSON.parse(inRange[0].content).text).toBe("Mid deployment notes");
+
+    const fromApril = searchMessages("p1", "a1", "deployment", { startDate: "2026-04-01" });
+    expect(fromApril.length).toBe(2);
+
+    const untilApril = searchMessages("p1", "a1", "deployment", { endDate: "2026-04-30" });
+    expect(untilApril.length).toBe(2);
+  });
+
+  it("extends date-only endDate to end-of-day", () => {
+    seedProject(db);
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Midday deployment notes" },
+      createdAt: "2026-04-30T12:00:00.000Z",
+    });
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Next-day deployment notes" },
+      createdAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    // Date-only endDate should include messages later the same day.
+    const results = searchMessages("p1", "a1", "deployment", { endDate: "2026-04-30" });
+    expect(results.length).toBe(1);
+    expect(JSON.parse(results[0].content).text).toBe("Midday deployment notes");
+  });
+
+  it("paginates via limit + offset", () => {
+    seedProject(db);
+    for (let i = 0; i < 5; i++) {
+      agentsService.createMessage({
+        projectId: "p1",
+        agentId: "a1",
+        role: "user",
+        content: { text: `Message about deployment number ${i}` },
+      });
+    }
+
+    const page1 = searchMessages("p1", "a1", "deployment", { limit: 2, offset: 0 });
+    const page2 = searchMessages("p1", "a1", "deployment", { limit: 2, offset: 2 });
+    const page3 = searchMessages("p1", "a1", "deployment", { limit: 2, offset: 4 });
+    const beyond = searchMessages("p1", "a1", "deployment", { limit: 2, offset: 10 });
+
+    expect(page1.length).toBe(2);
+    expect(page2.length).toBe(2);
+    expect(page3.length).toBe(1);
+    expect(beyond.length).toBe(0);
+
+    const ids = new Set([...page1, ...page2, ...page3].map((r) => r.id));
+    expect(ids.size).toBe(5);
+  });
+
+  it("throws on invalid date inputs", () => {
+    seedProject(db);
+    expect(() => searchMessages("p1", "a1", "deploy", { startDate: "not-a-date" })).toThrow(
+      "Invalid startDate",
+    );
+    expect(() => searchMessages("p1", "a1", "deploy", { endDate: "also-bad" })).toThrow(
+      "Invalid endDate",
+    );
+  });
+
+  it("throws on invalid limit or offset", () => {
+    seedProject(db);
+    expect(() => searchMessages("p1", "a1", "deploy", { limit: 0 })).toThrow("limit");
+    expect(() => searchMessages("p1", "a1", "deploy", { offset: -1 })).toThrow("offset");
   });
 
   it("removes FTS entries when messages are deleted", () => {

--- a/src/db/fts.ts
+++ b/src/db/fts.ts
@@ -9,29 +9,73 @@ export interface FtsResult {
   relevance: number;
 }
 
+export interface SearchMessagesOptions {
+  limit?: number;
+  offset?: number;
+  startDate?: string;
+  endDate?: string;
+}
+
 /**
  * Search messages using FTS5 with BM25 ranking.
- * Returns messages matching the query, filtered by project and agent, ordered by relevance.
+ * Returns messages matching the query, filtered by project/agent and optional
+ * date range, ordered by relevance. Supports pagination via `limit` + `offset`.
  */
 export function searchMessages(
   projectId: string,
   agentId: string,
   query: string,
-  limit = 10,
+  options: SearchMessagesOptions = {},
 ): FtsResult[] {
-  const sqlite = getSqlite();
-  const stmt = sqlite.query<FtsResult, [string, string, string, number]>(`
+  const { limit = 10, offset = 0, startDate } = options;
+  let { endDate } = options;
+
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("limit must be a positive integer");
+  }
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error("offset must be a non-negative integer");
+  }
+  if (startDate !== undefined && Number.isNaN(Date.parse(startDate))) {
+    throw new Error(`Invalid startDate: ${startDate}`);
+  }
+  if (endDate !== undefined && Number.isNaN(Date.parse(endDate))) {
+    throw new Error(`Invalid endDate: ${endDate}`);
+  }
+
+  // Timestamps are stored as full ISO-8601 (e.g. "2026-04-30T12:34:56.789Z") and
+  // compared lexicographically. A date-only endDate like "2026-04-30" would wrongly
+  // exclude every message later that same day, so extend it to end-of-day.
+  if (endDate !== undefined && !endDate.includes("T")) {
+    endDate = `${endDate}T23:59:59.999Z`;
+  }
+
+  const conditions: string[] = ["messages_fts MATCH ?", "m.project_id = ?", "m.agent_id = ?"];
+  const params: (string | number)[] = [query, projectId, agentId];
+
+  if (startDate !== undefined) {
+    conditions.push("m.created_at >= ?");
+    params.push(startDate);
+  }
+  if (endDate !== undefined) {
+    conditions.push("m.created_at <= ?");
+    params.push(endDate);
+  }
+
+  params.push(limit, offset);
+
+  const sql = `
     SELECT m.id, m.role, m.content, m.created_at, f.rank AS relevance
     FROM messages_fts f
     JOIN messages m ON m.id = f.rowid
-    WHERE messages_fts MATCH ?
-      AND m.project_id = ?
-      AND m.agent_id = ?
+    WHERE ${conditions.join(" AND ")}
     ORDER BY f.rank
-    LIMIT ?
-  `);
+    LIMIT ? OFFSET ?
+  `;
+
+  const sqlite = getSqlite();
   try {
-    return stmt.all(query, projectId, agentId, limit);
+    return sqlite.query<FtsResult, (string | number)[]>(sql).all(...params);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Invalid search query: ${message}`);

--- a/src/runtime/system-prompt.ts
+++ b/src/runtime/system-prompt.ts
@@ -101,8 +101,12 @@ Violations include:
 ## Message History Search
 Search your past conversation history using:
 \`\`\`
-${shireCommand} search-messages --project-id ${projectId} --agent-id ${agentId} --query "your search terms"
+${shireCommand} search-messages --project-id ${projectId} --agent-id ${agentId} --query "your search terms" [--start-date <iso>] [--end-date <iso>] [--limit <n>] [--offset <n>]
 \`\`\`
+- \`--query\` uses SQLite FTS5 syntax and results are BM25-ranked by relevance.
+- \`--start-date\` / \`--end-date\` are ISO-8601 (e.g. \`2026-04-01\` or \`2026-04-01T00:00:00Z\`), both inclusive — use them to narrow to a specific time window.
+- Paginate deeper into results with \`--limit\` (default 10) + \`--offset\` (default 0). For example, \`--limit 10 --offset 10\` returns the second page.
+
 Use this when you need to recall what was discussed in previous sessions — past decisions, instructions, or context no longer in your current conversation.
 `;
 


### PR DESCRIPTION
## Summary
- `searchMessages` now accepts an options object with `startDate`, `endDate`, `limit`, and `offset`. Date-only `endDate` is extended to end-of-day so inclusive ranges behave as expected against the stored full-ISO timestamps.
- `shire search-messages` CLI gains `--start-date`, `--end-date`, and `--offset` flags (with validation); help text updated.
- Agent system prompt now documents the full flag set — query syntax, ISO-8601 date range, and `--limit` / `--offset` pagination — so agents know they can scope recall to a time window and page past the top BM25 hits.

## Test plan
- [x] `bun test src/db/fts.test.ts` — 14 passing (5 new: date range, end-of-day extension, pagination, invalid date, invalid limit/offset)
- [x] `bun test` — 1131 passing
- [x] `bun run typecheck`
- [x] `bun run lint` (only pre-existing unrelated CsvEditor warning remains)
- [ ] Manual smoke: `shire search-messages --query deploy --start-date 2026-04-01 --end-date 2026-04-10 --limit 5 --offset 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)