### PR TITLE
Make --query optional in shire search-messages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,9 +105,11 @@ Commands:
   stop               Stop a running daemon
   status             Check if the server is running
   search-messages    Search past conversation history (used by agents via Bash)
-                     shire search-messages --project-id <id> --agent-id <id> --query <text>
+                     shire search-messages --project-id <id> --agent-id <id>
+                                           [--query <text>]
                                            [--start-date <iso>] [--end-date <iso>]
                                            [--limit <n>] [--offset <n>]
+                     At least one of --query or --start-date/--end-date is required.
 
 Options:
   -p, --port     Port to listen on (default: 8080)
@@ -280,11 +282,16 @@ async function handleSearchMessages(cmdArgs: string[]): Promise<void> {
     }
   }
 
-  if (!projectId || !agentId || !query) {
+  if (!projectId || !agentId) {
     console.error(
-      "Usage: shire search-messages --project-id <id> --agent-id <id> --query <text> " +
-        "[--start-date <iso>] [--end-date <iso>] [--limit <n>] [--offset <n>]",
+      "Usage: shire search-messages --project-id <id> --agent-id <id> " +
+        "[--query <text>] [--start-date <iso>] [--end-date <iso>] [--limit <n>] [--offset <n>]",
     );
+    process.exit(1);
+  }
+
+  if (!query && startDate === undefined && endDate === undefined) {
+    console.error("Provide at least one of --query, --start-date, or --end-date");
     process.exit(1);
   }
 

--- a/src/db/fts.test.ts
+++ b/src/db/fts.test.ts
@@ -197,6 +197,83 @@ describe("FTS message search", () => {
     expect(ids.size).toBe(5);
   });
 
+  it("supports date-only search with empty query", () => {
+    seedProject(db);
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Unrelated morning chat" },
+      createdAt: "2026-04-08T09:00:00.000Z",
+    });
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "agent",
+      content: { text: "Different topic entirely" },
+      createdAt: "2026-04-08T15:00:00.000Z",
+    });
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "Message on another day" },
+      createdAt: "2026-04-09T09:00:00.000Z",
+    });
+
+    const results = searchMessages("p1", "a1", "", {
+      startDate: "2026-04-08",
+      endDate: "2026-04-08",
+    });
+    expect(results.length).toBe(2);
+    // Ordered by created_at DESC when no text filter is given.
+    expect(JSON.parse(results[0].content).text).toBe("Different topic entirely");
+    expect(JSON.parse(results[1].content).text).toBe("Unrelated morning chat");
+  });
+
+  it("date-only search excludes non-indexed roles", () => {
+    seedProject(db);
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "user",
+      content: { text: "User message" },
+      createdAt: "2026-04-08T09:00:00.000Z",
+    });
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "tool_use",
+      content: {
+        tool: "Bash",
+        tool_use_id: "t1",
+        input: {},
+        output: "something",
+        is_error: false,
+      },
+      createdAt: "2026-04-08T10:00:00.000Z",
+    });
+    agentsService.createMessage({
+      projectId: "p1",
+      agentId: "a1",
+      role: "system",
+      content: { text: "System notice" },
+      createdAt: "2026-04-08T11:00:00.000Z",
+    });
+
+    const results = searchMessages("p1", "a1", "", {
+      startDate: "2026-04-08",
+      endDate: "2026-04-08",
+    });
+    expect(results.length).toBe(1);
+    expect(results[0].role).toBe("user");
+  });
+
+  it("throws when neither query nor date range is given", () => {
+    seedProject(db);
+    expect(() => searchMessages("p1", "a1", "")).toThrow("query or a date range");
+  });
+
   it("throws on invalid date inputs", () => {
     seedProject(db);
     expect(() => searchMessages("p1", "a1", "deploy", { startDate: "not-a-date" })).toThrow(

--- a/src/db/fts.ts
+++ b/src/db/fts.ts
@@ -24,7 +24,7 @@ export interface SearchMessagesOptions {
 export function searchMessages(
   projectId: string,
   agentId: string,
-  query: string,
+  query = "",
   options: SearchMessagesOptions = {},
 ): FtsResult[] {
   const { limit = 10, offset = 0, startDate } = options;
@@ -50,8 +50,23 @@ export function searchMessages(
     endDate = `${endDate}T23:59:59.999Z`;
   }
 
-  const conditions: string[] = ["messages_fts MATCH ?", "m.project_id = ?", "m.agent_id = ?"];
-  const params: (string | number)[] = [query, projectId, agentId];
+  const hasTextFilter = query.length > 0;
+
+  if (!hasTextFilter && startDate === undefined && endDate === undefined) {
+    throw new Error("searchMessages requires a query or a date range");
+  }
+
+  const conditions: string[] = ["m.project_id = ?", "m.agent_id = ?"];
+  const params: (string | number)[] = [projectId, agentId];
+
+  if (hasTextFilter) {
+    conditions.unshift("messages_fts MATCH ?");
+    params.unshift(query);
+  } else {
+    // Without an FTS MATCH we lose BM25 ranking, so scope to the same roles the
+    // FTS index covers for consistent results and order by recency.
+    conditions.push("m.role IN ('user', 'agent', 'inter_agent')");
+  }
 
   if (startDate !== undefined) {
     conditions.push("m.created_at >= ?");
@@ -64,12 +79,20 @@ export function searchMessages(
 
   params.push(limit, offset);
 
-  const sql = `
+  const sql = hasTextFilter
+    ? `
     SELECT m.id, m.role, m.content, m.created_at, f.rank AS relevance
     FROM messages_fts f
     JOIN messages m ON m.id = f.rowid
     WHERE ${conditions.join(" AND ")}
     ORDER BY f.rank
+    LIMIT ? OFFSET ?
+  `
+    : `
+    SELECT m.id, m.role, m.content, m.created_at, 0 AS relevance
+    FROM messages m
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY m.created_at DESC
     LIMIT ? OFFSET ?
   `;
 

--- a/src/runtime/system-prompt.ts
+++ b/src/runtime/system-prompt.ts
@@ -101,9 +101,10 @@ Violations include:
 ## Message History Search
 Search your past conversation history using:
 \`\`\`
-${shireCommand} search-messages --project-id ${projectId} --agent-id ${agentId} --query "your search terms" [--start-date <iso>] [--end-date <iso>] [--limit <n>] [--offset <n>]
+${shireCommand} search-messages --project-id ${projectId} --agent-id ${agentId} [--query "terms"] [--start-date <iso>] [--end-date <iso>] [--limit <n>] [--offset <n>]
 \`\`\`
-- \`--query\` uses SQLite FTS5 syntax and results are BM25-ranked by relevance.
+- \`--query\` uses SQLite FTS5 syntax; results are BM25-ranked by relevance. Omit \`--query\` entirely if you only want to browse by date range — results are then ordered newest-first.
+- You must provide at least one of \`--query\`, \`--start-date\`, or \`--end-date\`.
 - \`--start-date\` / \`--end-date\` are ISO-8601 (e.g. \`2026-04-01\` or \`2026-04-01T00:00:00Z\`), both inclusive — use them to narrow to a specific time window.
 - Paginate deeper into results with \`--limit\` (default 10) + \`--offset\` (default 0). For example, \`--limit 10 --offset 10\` returns the second page.
 


### PR DESCRIPTION
## Summary
- FTS5 rejects a bare \`*\` as a standalone query, so agents calling \`shire search-messages --query "*" --start-date ... --end-date ...\` hit "Invalid search query" and couldn't browse by date range alone.
- Make \`--query\` optional. When omitted, \`searchMessages\` skips the FTS MATCH join and selects directly from \`messages\` filtered to the same indexed roles (\`user\`, \`agent\`, \`inter_agent\`), ordered by \`created_at DESC\`.
- At least one of \`--query\`, \`--start-date\`, or \`--end-date\` is still required — both the CLI and the service enforce this.
- System prompt updated to tell agents to omit \`--query\` entirely when they only want date-range filtering.

## Test plan
- [x] \`bun test src/db/fts.test.ts\` — 17 passing (3 new: date-only search, role filtering on date-only path, error when nothing given)
- [x] \`bun test\` — 1151 passing
- [x] \`bun run typecheck\`, \`bun run lint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)