### PR TITLE
Add Open button to @-mention popover to preview files directly

### DIFF
--- a/src/frontend/components/chat/ChatInput.tsx
+++ b/src/frontend/components/chat/ChatInput.tsx
@@ -10,8 +10,11 @@ import {
   useUploadAttachment,
   useUpdateAgentCache,
 } from "../../hooks";
+import { useNavigate } from "react-router-dom";
 import { useFileMention } from "../../hooks/useFileMention";
 import type { SharedDriveFile } from "../../hooks/shared-drive";
+import { useIsDesktop } from "../../hooks/use-is-desktop";
+import { useProjectLayout } from "../../providers/ProjectLayoutProvider";
 import { type PendingFile, MAX_FILE_SIZE, formatFileSize } from "./types";
 import { getFileIcon } from "../../lib/file-utils";
 import { FileMentionDropdown } from "./FileMentionDropdown";
@@ -38,7 +41,23 @@ export function ChatInput({ agent, onMessageSent }: ChatInputProps) {
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const mention = useFileMention(input, cursorPos, projectId);
-  const { selectItem, triggerIndex } = mention;
+  const { selectItem, triggerIndex, dismiss } = mention;
+  const { projectName, setPanelFilePath } = useProjectLayout();
+  const isDesktop = useIsDesktop();
+  const navigate = useNavigate();
+
+  const handleMentionPreview = React.useCallback(
+    (item: SharedDriveFile) => {
+      if (item.type !== "file") return;
+      if (isDesktop) {
+        setPanelFilePath(item.path);
+      } else {
+        navigate(`/projects/${projectName}/shared?file=${encodeURIComponent(item.path)}`);
+      }
+      dismiss();
+    },
+    [isDesktop, setPanelFilePath, navigate, projectName, dismiss],
+  );
 
   const insertMention = React.useCallback(
     (mentionText: string) => {
@@ -302,6 +321,7 @@ export function ChatInput({ agent, onMessageSent }: ChatInputProps) {
               isLoading={mention.isLoading}
               onSelect={handleMentionSelect}
               onNavigateBack={handleNavigateBack}
+              onPreview={handleMentionPreview}
             />
           )}
           <Textarea

--- a/src/frontend/components/chat/FileMentionDropdown.tsx
+++ b/src/frontend/components/chat/FileMentionDropdown.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
-import { FolderIcon, ChevronLeft, Loader2, ExternalLink } from "lucide-react";
+import { FolderIcon, ChevronLeft, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import type { SharedDriveFile } from "../../hooks/shared-drive";
 import { getFileIcon } from "../../lib/file-utils";
 
@@ -38,22 +40,24 @@ export function FileMentionDropdown({
   return (
     <div className="absolute bottom-full left-0 right-0 z-50 mb-1 rounded-md border border-border bg-popover shadow-md">
       {showBackButton && (
-        <button
+        <Button
           type="button"
-          className="flex w-full items-center gap-2 border-b border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent"
+          variant="ghost"
+          size="xs"
+          className="w-full justify-start rounded-none border-b border-border px-3 py-1.5 text-muted-foreground"
           onMouseDown={(e) => {
             e.preventDefault();
             onNavigateBack();
           }}
         >
-          <ChevronLeft className="h-3 w-3" />
+          <ChevronLeft />
           <span className="truncate">{currentPath}</span>
-        </button>
+        </Button>
       )}
       <div ref={listRef} className="max-h-48 overflow-y-auto py-1">
         {isLoading && (
           <div className="flex items-center justify-center py-4">
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            <Spinner size="sm" className="text-muted-foreground" />
           </div>
         )}
         {!isLoading && items.length === 0 && (
@@ -62,45 +66,46 @@ export function FileMentionDropdown({
         {!isLoading &&
           items.map((item, index) => {
             const ItemIcon = item.type === "directory" ? FolderIcon : getFileIcon(item.name);
+            const isSelected = index === selectedIndex;
             const isFile = item.type === "file";
             return (
-              <div
-                key={item.path}
-                className="flex items-center hover:bg-accent data-[selected=true]:bg-accent"
-                data-selected={index === selectedIndex}
-              >
-                <button
+              <div key={item.path} className="flex items-center">
+                <Button
                   type="button"
-                  data-selected={index === selectedIndex}
-                  className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-sm"
+                  variant="ghost"
+                  size="sm"
+                  data-selected={isSelected}
+                  className="min-w-0 flex-1 justify-start rounded-none px-3 py-1.5 text-sm data-[selected=true]:bg-accent"
                   onMouseDown={(e) => {
                     e.preventDefault();
                     onSelect(item);
                   }}
                 >
-                  <ItemIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <ItemIcon className="text-muted-foreground" />
                   <span className="truncate">{item.name}</span>
                   {currentPath === "/" && item.path !== "/" + item.name && (
-                    <span className="truncate text-xs text-muted-foreground">
+                    <span className="truncate text-xs font-normal text-muted-foreground">
                       {item.path.slice(0, item.path.lastIndexOf("/"))}
                     </span>
                   )}
-                </button>
+                </Button>
                 {isFile && onPreview && (
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="xs"
                     aria-label="Open file"
                     title="Open file"
-                    className="mr-2 flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-background hover:text-foreground"
+                    className="mr-2 text-muted-foreground"
                     onMouseDown={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
                       onPreview(item);
                     }}
                   >
-                    <ExternalLink className="h-3 w-3" />
+                    <ExternalLink />
                     <span>Open</span>
-                  </button>
+                  </Button>
                 )}
               </div>
             );

--- a/src/frontend/components/chat/FileMentionDropdown.tsx
+++ b/src/frontend/components/chat/FileMentionDropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { FolderIcon, ChevronLeft, Loader2 } from "lucide-react";
+import { FolderIcon, ChevronLeft, Loader2, ExternalLink } from "lucide-react";
 import type { SharedDriveFile } from "../../hooks/shared-drive";
 import { getFileIcon } from "../../lib/file-utils";
 
@@ -10,6 +10,7 @@ interface FileMentionDropdownProps {
   isLoading: boolean;
   onSelect: (item: SharedDriveFile) => void;
   onNavigateBack: () => void;
+  onPreview?: (item: SharedDriveFile) => void;
 }
 
 export function FileMentionDropdown({
@@ -19,6 +20,7 @@ export function FileMentionDropdown({
   isLoading,
   onSelect,
   onNavigateBack,
+  onPreview,
 }: FileMentionDropdownProps) {
   const listRef = React.useRef<HTMLDivElement>(null);
 
@@ -60,25 +62,47 @@ export function FileMentionDropdown({
         {!isLoading &&
           items.map((item, index) => {
             const ItemIcon = item.type === "directory" ? FolderIcon : getFileIcon(item.name);
+            const isFile = item.type === "file";
             return (
-              <button
+              <div
                 key={item.path}
-                type="button"
+                className="flex items-center hover:bg-accent data-[selected=true]:bg-accent"
                 data-selected={index === selectedIndex}
-                className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent data-[selected=true]:bg-accent"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  onSelect(item);
-                }}
               >
-                <ItemIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <span className="truncate">{item.name}</span>
-                {currentPath === "/" && item.path !== "/" + item.name && (
-                  <span className="truncate text-xs text-muted-foreground">
-                    {item.path.slice(0, item.path.lastIndexOf("/"))}
-                  </span>
+                <button
+                  type="button"
+                  data-selected={index === selectedIndex}
+                  className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-sm"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onSelect(item);
+                  }}
+                >
+                  <ItemIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{item.name}</span>
+                  {currentPath === "/" && item.path !== "/" + item.name && (
+                    <span className="truncate text-xs text-muted-foreground">
+                      {item.path.slice(0, item.path.lastIndexOf("/"))}
+                    </span>
+                  )}
+                </button>
+                {isFile && onPreview && (
+                  <button
+                    type="button"
+                    aria-label="Open file"
+                    title="Open file"
+                    className="mr-2 flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-background hover:text-foreground"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onPreview(item);
+                    }}
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    <span>Open</span>
+                  </button>
                 )}
-              </button>
+              </div>
             );
           })}
       </div>

--- a/src/frontend/components/editor/CsvEditor.tsx
+++ b/src/frontend/components/editor/CsvEditor.tsx
@@ -176,6 +176,9 @@ export default function CsvEditor({ initialContent, projectId, filePath }: CsvEd
     });
   }, [filteredRowsWithIndices, sortConfig]);
 
+  // React Compiler skips memoizing this component because useVirtualizer returns
+  // non-memoizable functions. Tracked upstream:
+  // https://github.com/TanStack/virtual/issues/1119
   const virtualizer = useVirtualizer({
     count: sortedRows.length,
     getScrollElement: () => scrollRef.current,

--- a/src/frontend/test/ChatInputMention.test.tsx
+++ b/src/frontend/test/ChatInputMention.test.tsx
@@ -1,12 +1,27 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, mock } from "bun:test";
 import { http, HttpResponse } from "msw";
 import { server } from "./msw-server";
 import { ChatInput } from "../components/chat/ChatInput";
 import type { AgentOverview } from "../components/types";
 import type { SharedDriveFile } from "../hooks/shared-drive";
+import {
+  ProjectLayoutContext,
+  type ProjectLayoutContextValue,
+} from "../providers/ProjectLayoutProvider";
 import { renderWithProviders, waitForText } from "./test-utils";
+
+const layoutContextValue: ProjectLayoutContextValue = {
+  projectId: "p1",
+  projectName: "test-project",
+  sidebarOpen: false,
+  setSidebarOpen: () => {},
+  onNewAgent: () => {},
+  onBrowseCatalog: () => {},
+  panelFilePath: null,
+  setPanelFilePath: () => {},
+};
 
 const activeAgent: AgentOverview = {
   id: "a1",
@@ -43,7 +58,12 @@ function setFiles(files: SharedDriveFile[]) {
 }
 
 function renderChatInput() {
-  return renderWithProviders(<ChatInput agent={activeAgent} />, routeOpts);
+  return renderWithProviders(
+    <ProjectLayoutContext.Provider value={layoutContextValue}>
+      <ChatInput agent={activeAgent} />
+    </ProjectLayoutContext.Provider>,
+    routeOpts,
+  );
 }
 
 describe("ChatInput file mention", () => {
@@ -124,6 +144,56 @@ describe("ChatInput file mention", () => {
     await userEvent.type(textarea, "@zzzzz");
 
     await waitForText("No files found");
+  });
+
+  it("opens a file in the preview panel when the Open button is clicked (desktop)", async () => {
+    // Force desktop mode: useIsDesktop() reads window.matchMedia("(min-width: 768px)").matches.
+    // Return a STABLE stub object — useSyncExternalStore calls matchMedia multiple times
+    // (subscribe + snapshot) and expects a consistent reference for change notifications.
+    const originalMatchMedia = window.matchMedia;
+    const desktopMq: MediaQueryList = {
+      matches: true,
+      media: "(min-width: 768px)",
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList;
+    window.matchMedia = (() => desktopMq) as unknown as typeof window.matchMedia;
+
+    try {
+      setFiles(sampleFiles);
+      const setPanelFilePath = mock((_path: string | null) => {});
+      const value: ProjectLayoutContextValue = { ...layoutContextValue, setPanelFilePath };
+      renderWithProviders(
+        <ProjectLayoutContext.Provider value={value}>
+          <ChatInput agent={activeAgent} />
+        </ProjectLayoutContext.Provider>,
+        routeOpts,
+      );
+
+      const textarea = screen.getByPlaceholderText(/Type a message/) as HTMLTextAreaElement;
+      await userEvent.type(textarea, "@rea");
+
+      await waitForText("readme.md");
+
+      const openButton = screen.getByRole("button", { name: /open file/i });
+      openButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+      await waitFor(() => {
+        expect(setPanelFilePath).toHaveBeenCalledWith("/readme.md");
+      });
+      // Textarea value unchanged — no mention was inserted
+      expect(textarea.value).toBe("@rea");
+      // Dropdown closes
+      await waitFor(() => {
+        expect(screen.queryByText("readme.md")).toBeNull();
+      });
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   it("navigates keyboard down and up through items", async () => {

--- a/src/frontend/test/FileMentionDropdown.test.tsx
+++ b/src/frontend/test/FileMentionDropdown.test.tsx
@@ -78,6 +78,26 @@ describe("FileMentionDropdown", () => {
     expect(onNavigateBack).toHaveBeenCalled();
   });
 
+  it("renders an Open button for file rows but not directory rows", () => {
+    renderDropdown({ onPreview: mock(() => {}) });
+    const openButtons = screen.getAllByRole("button", { name: /open file/i });
+    // Two files in sampleFiles, directory excluded
+    expect(openButtons).toHaveLength(2);
+  });
+
+  it("calls onPreview with the file when the Open button is clicked, and does not call onSelect", () => {
+    const onSelect = mock(() => {});
+    const onPreview = mock(() => {});
+    renderDropdown({ onSelect, onPreview });
+
+    const openButtons = screen.getAllByRole("button", { name: /open file/i });
+    openButtons[0].dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+    expect(onPreview).toHaveBeenCalledTimes(1);
+    expect(onPreview).toHaveBeenCalledWith(sampleFiles[1]); // readme.md (first file in items)
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
   it("renders different icons for different file types", () => {
     const files: SharedDriveFile[] = [
       { name: "script.ts", path: "/script.ts", type: "file", size: 100 },


### PR DESCRIPTION
## Summary
- Adds an **Open** button on each file row in the `@`-mention file search popover in ChatInput.
- Desktop: opens the file in the side preview panel via `setPanelFilePath` from `ProjectLayoutContext` (same mechanism as file links in messages).
- Mobile: navigates to the full-page shared drive view at `/projects/:name/shared?file=...`, mirroring `SharedDriveLink.tsx`.
- Directory rows do not get an Open button.
- Clicking Open closes the popover and does **not** insert a mention or modify the textarea.

## Test plan
- [x] `bun test` — 1154/1154 passing
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (pre-existing CsvEditor warning only)
- [ ] `bun run dev`: type `@` in chat composer, confirm Open button appears on file rows, click it — preview panel opens with that file, textarea unchanged, dropdown closes
- [ ] Resize below desktop breakpoint: clicking Open navigates to `/projects/:name/shared?file=...` instead
- [ ] Directory rows still navigate into the directory on body click; no Open button rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)