### PR TITLE
Fix sidebar size not persisting when file panel is collapsed

### DIFF
--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -87,13 +87,11 @@ export default function ProjectLayout() {
   }, [isProjectIndex, agentList, agentStorageKey, projectName, navigate]);
 
   // Persist sidebar/panel sizes to localStorage (global, not per-project).
-  // Use two different panel sets: with and without the file preview panel.
-  const panelIds = effectivePanelFilePath
-    ? ["sidebar", "content", "file-panel"]
-    : ["sidebar", "content"];
+  // Always include all three panels so the sidebar size is saved under one
+  // consistent key regardless of whether the file panel is open or collapsed.
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "shire:layout",
-    panelIds,
+    panelIds: ["sidebar", "content", "file-panel"],
   });
 
   // Track last known panel size so onResize can distinguish "user collapsed"


### PR DESCRIPTION
## Summary

- `panelIds` was switching between `["sidebar", "content"]` and `["sidebar", "content", "file-panel"]` based on preview state
- This caused `useDefaultLayout` to save/restore under different localStorage keys
- The 2-panel key was often never written, so sidebar reset to default 20% on reload
- Fix: always use the fixed 3-panel array since all panels are always in the DOM

## Test plan

- [ ] Resize sidebar with no preview open → reload → sidebar size persists
- [ ] Resize sidebar with preview open → close preview → reload → sidebar size persists
- [ ] `bun test` passes
- [ ] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)