### PR TITLE
Replace logout button with user menu popover

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -652,6 +653,8 @@
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA=="],
 
     "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
+
+    "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
@@ -2278,6 +2281,8 @@
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/src/frontend/components/AgentSidebar.tsx
+++ b/src/frontend/components/AgentSidebar.tsx
@@ -9,6 +9,7 @@ import ProjectSwitcher from "./ProjectSwitcher";
 import AgentListPanel from "./sidebar/AgentListPanel";
 import SharedDrivePanel from "./sidebar/SharedDrivePanel";
 import { useProjects, useVersionCheck } from "../hooks";
+import UserMenu from "./UserMenu";
 
 function VersionFooter() {
   const { data } = useVersionCheck();
@@ -136,6 +137,7 @@ export default function AgentSidebar({ onNewAgent, onBrowseCatalog }: AgentSideb
           <Settings className="h-4 w-4" />
           Settings
         </Button>
+        <UserMenu variant="sidebar" />
       </div>
 
       <VersionFooter />

--- a/src/frontend/components/ProjectDashboard.tsx
+++ b/src/frontend/components/ProjectDashboard.tsx
@@ -28,35 +28,16 @@ import {
 } from "./ui/dropdown-menu";
 import AppLayout from "./AppLayout";
 import { useNavigate } from "react-router-dom";
-import { LogOut, MoreHorizontal } from "lucide-react";
+import { MoreHorizontal } from "lucide-react";
 import { PageLoader } from "./ui/spinner";
 import { ErrorState } from "./ui/error-state";
 import type { Project } from "./types";
 import { useProjects, useCreateProject, useDeleteProject } from "../hooks";
-import { useAppConfig, useLogout } from "../hooks/auth";
 import { useSubscription } from "../hooks/ws";
 import { useQueryClient } from "@tanstack/react-query";
+import UserMenu from "./UserMenu";
 
 const PROJECT_NAME_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
-
-function LogoutButton() {
-  const { data: config } = useAppConfig();
-  const logout = useLogout();
-  const navigate = useNavigate();
-
-  if (!config?.authEnabled) return null;
-
-  return (
-    <Button
-      variant="outline"
-      size="icon"
-      onClick={() => logout.mutate(undefined, { onSuccess: () => navigate("/login") })}
-      disabled={logout.isPending}
-    >
-      <LogOut className="h-4 w-4" />
-    </Button>
-  );
-}
 
 export default function ProjectDashboard() {
   const navigate = useNavigate();
@@ -114,7 +95,7 @@ export default function ProjectDashboard() {
           <h1 className="text-2xl font-bold">Projects</h1>
           <div className="flex items-center gap-2">
             <Button onClick={() => setCreateOpen(true)}>+ New Project</Button>
-            <LogoutButton />
+            <UserMenu />
           </div>
         </div>
 

--- a/src/frontend/components/UserMenu.test.tsx
+++ b/src/frontend/components/UserMenu.test.tsx
@@ -1,0 +1,105 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach } from "bun:test";
+import { http, HttpResponse } from "msw";
+import { SignJWT } from "jose";
+import { server } from "../test/msw-server";
+import { useAuthStore } from "../stores/auth";
+import UserMenu from "./UserMenu";
+import { renderWithProviders } from "../test/test-utils";
+
+const resetStore = () => useAuthStore.setState({ accessToken: null, refreshPromise: null });
+
+async function makeFakeJwt(sub = "admin"): Promise<string> {
+  const key = new TextEncoder().encode("test-secret");
+  return new SignJWT({ sub })
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime("15m")
+    .sign(key);
+}
+
+function enableAuth() {
+  server.use(http.get("*/api/config", () => HttpResponse.json({ authEnabled: true })));
+}
+
+describe("UserMenu", () => {
+  beforeEach(resetStore);
+
+  it("renders nothing when auth is disabled", async () => {
+    // Default MSW handler returns authEnabled: false
+    const { container } = renderWithProviders(<UserMenu />);
+    await waitFor(() => {
+      expect(container.innerHTML).not.toContain("User menu");
+    });
+  });
+
+  it("renders nothing when auth is enabled but no token", async () => {
+    enableAuth();
+    const { container } = renderWithProviders(<UserMenu />);
+    await waitFor(() => {
+      expect(container.innerHTML).not.toContain("User menu");
+    });
+  });
+
+  it("renders user icon button when auth is enabled and logged in", async () => {
+    enableAuth();
+    const token = await makeFakeJwt("testuser");
+    useAuthStore.setState({ accessToken: token });
+
+    renderWithProviders(<UserMenu />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "User menu" })).toBeInTheDocument();
+    });
+  });
+
+  it("shows username and logout in popover on click", async () => {
+    enableAuth();
+    const token = await makeFakeJwt("testuser");
+    useAuthStore.setState({ accessToken: token });
+
+    renderWithProviders(<UserMenu />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "User menu" })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "User menu" }));
+    expect(screen.getByText("testuser")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /log out/i })).toBeInTheDocument();
+  });
+
+  it("calls logout on clicking Log out", async () => {
+    enableAuth();
+    const token = await makeFakeJwt("testuser");
+    useAuthStore.setState({ accessToken: token });
+
+    let logoutCalled = false;
+    server.use(
+      http.post("*/api/auth/logout", () => {
+        logoutCalled = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    renderWithProviders(<UserMenu />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "User menu" })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "User menu" }));
+    await userEvent.click(screen.getByRole("button", { name: /log out/i }));
+
+    await waitFor(() => expect(logoutCalled).toBe(true));
+  });
+
+  it("shows username in trigger when sidebar variant", async () => {
+    enableAuth();
+    const token = await makeFakeJwt("sidebaruser");
+    useAuthStore.setState({ accessToken: token });
+
+    renderWithProviders(<UserMenu variant="sidebar" />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "User menu" })).toBeInTheDocument();
+    });
+    expect(screen.getByText("sidebaruser")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/UserMenu.test.tsx
+++ b/src/frontend/components/UserMenu.test.tsx
@@ -102,4 +102,19 @@ describe("UserMenu", () => {
     });
     expect(screen.getByText("sidebaruser")).toBeInTheDocument();
   });
+
+  it("hides username in popover for sidebar variant", async () => {
+    enableAuth();
+    const token = await makeFakeJwt("sidebaruser");
+    useAuthStore.setState({ accessToken: token });
+
+    renderWithProviders(<UserMenu variant="sidebar" />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "User menu" })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "User menu" }));
+    // Username appears only once (in the trigger), not duplicated in the popover
+    expect(screen.getAllByText("sidebaruser")).toHaveLength(1);
+  });
 });

--- a/src/frontend/components/UserMenu.tsx
+++ b/src/frontend/components/UserMenu.tsx
@@ -1,0 +1,57 @@
+import { CircleUser, LogOut } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "./ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { Separator } from "./ui/separator";
+import { useAppConfig, useLogout } from "../hooks/auth";
+import { useUsername } from "../stores/auth";
+
+interface UserMenuProps {
+  variant?: "icon" | "sidebar";
+}
+
+export default function UserMenu({ variant = "icon" }: UserMenuProps) {
+  const { data: config } = useAppConfig();
+  const username = useUsername();
+  const logout = useLogout();
+  const navigate = useNavigate();
+
+  if (!config?.authEnabled || !username) return null;
+
+  const trigger =
+    variant === "sidebar" ? (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full justify-start gap-2 text-muted-foreground"
+        aria-label="User menu"
+      >
+        <CircleUser className="h-4 w-4" />
+        {username}
+      </Button>
+    ) : (
+      <Button variant="ghost" size="icon" aria-label="User menu">
+        <CircleUser className="h-5 w-5" />
+      </Button>
+    );
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align="end" className="w-48 p-2">
+        <div className="px-2 py-1.5 text-sm font-medium truncate">{username}</div>
+        <Separator className="my-1" />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start gap-2"
+          onClick={() => logout.mutate(undefined, { onSuccess: () => navigate("/login") })}
+          disabled={logout.isPending}
+        >
+          <LogOut className="h-4 w-4" />
+          Log out
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/frontend/components/UserMenu.tsx
+++ b/src/frontend/components/UserMenu.tsx
@@ -39,8 +39,12 @@ export default function UserMenu({ variant = "icon" }: UserMenuProps) {
     <Popover>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent align="end" className="w-48 p-2">
-        <div className="px-2 py-1.5 text-sm font-medium truncate">{username}</div>
-        <Separator className="my-1" />
+        {variant === "icon" && (
+          <>
+            <div className="px-2 py-1.5 text-sm font-medium truncate">{username}</div>
+            <Separator className="my-1" />
+          </>
+        )}
         <Button
           variant="ghost"
           size="sm"

--- a/src/frontend/components/ui/separator.tsx
+++ b/src/frontend/components/ui/separator.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@/components/lib/utils";
+
+const Separator = React.forwardRef<
+  React.ComponentRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0 bg-border",
+      orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+      className,
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/src/frontend/stores/auth.test.ts
+++ b/src/frontend/stores/auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { SignJWT } from "jose";
-import { useAuthStore, getAccessToken, isTokenExpired } from "../stores/auth";
+import { useAuthStore, getAccessToken, isTokenExpired, useUsername } from "../stores/auth";
 import { api } from "../lib/api";
 import { http, HttpResponse } from "msw";
 import { waitFor, act } from "@testing-library/react";
@@ -215,6 +215,28 @@ describe("api client auth integration", () => {
     await api.config.$get();
     expect(refreshCalled).toBe(false);
     expect(getAccessToken()).toBe(validToken);
+  });
+});
+
+describe("useUsername", () => {
+  beforeEach(resetStore);
+
+  it("returns null when no token is set", () => {
+    const { result } = renderHookWithProviders(() => useUsername());
+    expect(result.current).toBeNull();
+  });
+
+  it("returns username from JWT sub claim", async () => {
+    const token = await makeFakeJwt();
+    setState({ accessToken: token });
+    const { result } = renderHookWithProviders(() => useUsername());
+    expect(result.current).toBe("admin");
+  });
+
+  it("returns null for malformed token", () => {
+    setState({ accessToken: "not-a-jwt" });
+    const { result } = renderHookWithProviders(() => useUsername());
+    expect(result.current).toBeNull();
   });
 });
 

--- a/src/frontend/stores/auth.ts
+++ b/src/frontend/stores/auth.ts
@@ -48,6 +48,17 @@ export function getAccessToken(): string | null {
   return useAuthStore.getState().accessToken;
 }
 
+export function useUsername(): string | null {
+  const token = useAuthStore((s) => s.accessToken);
+  if (!token) return null;
+  try {
+    const { sub } = decodeJwt(token);
+    return (sub as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function isTokenExpired(token: string): boolean {
   try {
     const { exp } = decodeJwt(token);


### PR DESCRIPTION
## Summary
- Replace the bare logout icon button with a user icon (`CircleUser`) that opens a popover showing the username and a "Log out" button
- Add `UserMenu` component to both the **projects page** header and the **agent sidebar** footer
- Only visible when auth is enabled and user is logged in
- Add `useUsername()` hook that derives username from the JWT `sub` claim
- Add shadcn `Separator` component (`@radix-ui/react-separator`)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (no errors)
- [x] `bun test` — all 1218 tests pass
- [x] New tests: `UserMenu.test.tsx` (6 tests) and `useUsername` hook tests (3 tests)
- [ ] Manual: verify user icon appears on projects page when logged in
- [ ] Manual: verify user icon appears in agent sidebar when logged in
- [ ] Manual: verify popover shows username and logout button
- [ ] Manual: verify logout redirects to /login
- [ ] Manual: verify menu is hidden when auth is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)