### PR TITLE
Fix shared drive 401 on image/PDF preview and downloads

### DIFF
--- a/src/frontend/components/SharedDrive.test.tsx
+++ b/src/frontend/components/SharedDrive.test.tsx
@@ -334,10 +334,7 @@ describe("SharedDriveContentArea", () => {
     await waitFor(() => {
       const img = screen.getByRole("img", { name: "photo.png" });
       expect(img).toBeInTheDocument();
-      expect(img).toHaveAttribute(
-        "src",
-        "/api/projects/test-project/shared-drive/download?path=photo.png",
-      );
+      expect(img.getAttribute("src")).toMatch(/^blob:/);
     });
   });
 
@@ -378,11 +375,11 @@ describe("SharedDriveContentArea", () => {
     });
   });
 
-  it("shows download link for selected file", async () => {
+  it("shows download button for selected file", async () => {
     renderContentArea("/projects/test-project/shared?file=photo.png");
     await waitFor(() => {
-      const link = screen.getByRole("link", { name: "Download" });
-      expect(link).toBeInTheDocument();
+      const button = screen.getByRole("button", { name: "Download" });
+      expect(button).toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/SharedDriveContentArea.tsx
+++ b/src/frontend/components/SharedDriveContentArea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useDropzone } from "react-dropzone";
-import { Menu, Upload, Download, Trash2, Pencil, FolderOpen } from "lucide-react";
+import { Menu, Upload, Download, Trash2, Pencil, FolderOpen, AlertCircle } from "lucide-react";
 import { Button } from "./ui/button";
 import { SharedDriveEditor } from "./editor";
 import CodeEditor from "./editor/CodeEditor";
@@ -18,6 +18,8 @@ import {
 } from "../hooks";
 import { getFileIcon, getPreviewType, formatSize, MAX_UPLOAD_SIZE } from "../lib/file-utils";
 import { useProjectLayout } from "../providers/ProjectLayoutProvider";
+import { useAuthenticatedUrl } from "../hooks/use-authenticated-url";
+import { authenticatedDownload } from "../lib/authenticated-download";
 
 export default function SharedDriveContentArea() {
   const { projectId, projectName } = useProjectId();
@@ -44,6 +46,16 @@ export default function SharedDriveContentArea() {
   const [uploadProgress, setUploadProgress] = React.useState<number | null>(null);
   const [uploadError, setUploadError] = React.useState<string | null>(null);
   const fileProgressRef = React.useRef<Map<string, number>>(new Map());
+
+  const downloadUrl = filePath
+    ? `/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(filePath)}`
+    : null;
+  const previewUrl = filePath
+    ? `/api/projects/${projectName}/shared-drive/preview?path=${encodeURIComponent(filePath)}`
+    : null;
+
+  const imageAuth = useAuthenticatedUrl(type === "image" ? downloadUrl : null);
+  const pdfAuth = useAuthenticatedUrl(type === "pdf" ? previewUrl : null);
 
   const handleDelete = () => {
     if (!filePath) return;
@@ -158,9 +170,6 @@ export default function SharedDriveContentArea() {
     );
   }
 
-  const previewUrl = `/api/projects/${projectName}/shared-drive/preview?path=${encodeURIComponent(filePath)}`;
-  const downloadUrl = `/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(filePath)}`;
-
   return (
     <div className="flex flex-col h-full relative" {...getRootProps()}>
       <input {...getInputProps()} />
@@ -195,14 +204,16 @@ export default function SharedDriveContentArea() {
           >
             <Pencil className="h-4 w-4" />
           </Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
-            <a
-              href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(filePath)}`}
-              download
-              aria-label="Download"
-            >
-              <Download className="h-4 w-4" />
-            </a>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label="Download"
+            onClick={() => {
+              if (downloadUrl) authenticatedDownload(downloadUrl, fileName);
+            }}
+          >
+            <Download className="h-4 w-4" />
           </Button>
           <Button
             variant="ghost"
@@ -265,17 +276,34 @@ export default function SharedDriveContentArea() {
 
         {!loading && !error && type === "image" && (
           <div className="flex items-center justify-center p-4">
-            <img
-              src={downloadUrl}
-              alt={fileName}
-              loading="lazy"
-              className="max-w-full max-h-[70vh] object-contain"
-            />
+            {imageAuth.isLoading && <Spinner size="sm" className="text-muted-foreground" />}
+            {imageAuth.error && (
+              <div className="flex flex-col items-center gap-2 text-muted-foreground">
+                <AlertCircle className="h-8 w-8" />
+                <p className="text-sm">{imageAuth.error}</p>
+              </div>
+            )}
+            {imageAuth.blobUrl && (
+              <img
+                src={imageAuth.blobUrl}
+                alt={fileName}
+                className="max-w-full max-h-[70vh] object-contain"
+              />
+            )}
           </div>
         )}
 
         {!loading && !error && type === "pdf" && (
-          <iframe src={previewUrl} className="w-full h-full border-0" title={fileName} />
+          <>
+            {pdfAuth.isLoading && (
+              <div className="flex items-center justify-center py-12">
+                <Spinner size="sm" className="text-muted-foreground" />
+              </div>
+            )}
+            {pdfAuth.blobUrl && (
+              <iframe src={pdfAuth.blobUrl} className="w-full h-full border-0" title={fileName} />
+            )}
+          </>
         )}
 
         {!loading &&

--- a/src/frontend/components/editor/nodes/ImageComponent.tsx
+++ b/src/frontend/components/editor/nodes/ImageComponent.tsx
@@ -1,7 +1,8 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $getNodeByKey } from "lexical";
 import { useState } from "react";
-import { ChevronDown, ImageOff, Trash, Type } from "lucide-react";
+import { ChevronDown, ImageOff, Loader2, Trash, Type } from "lucide-react";
+import { useAuthenticatedUrl } from "../../../hooks/use-authenticated-url";
 import { $isImageNode } from "./ImageNode";
 import { cn } from "../../../components/lib/utils";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../../../components/ui/dialog";
@@ -28,6 +29,10 @@ export const ImageComponent = ({ src, altText, width, height, nodeKey }: ImageCo
   const [isAltDialogOpen, setIsAltDialogOpen] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
+
+  const needsAuth = src.startsWith("/api/");
+  const authUrl = useAuthenticatedUrl(needsAuth ? src : null);
+  const effectiveSrc = needsAuth ? authUrl.blobUrl : src;
 
   const updateAltText = (nextAltText: string) => {
     editor.update(() => {
@@ -97,17 +102,27 @@ export const ImageComponent = ({ src, altText, width, height, nodeKey }: ImageCo
             Retry
           </Button>
         </div>
-      ) : (
+      ) : needsAuth && authUrl.isLoading ? (
+        <div
+          className="flex items-center justify-center"
+          style={{
+            height: height ? `${height}px` : "100px",
+            width: width ? `${width}px` : "100%",
+          }}
+        >
+          <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : effectiveSrc ? (
         <img
           key={retryKey}
-          src={src}
+          src={effectiveSrc}
           alt={altText || ""}
           width={width ?? undefined}
           height={height ?? undefined}
           className="max-w-full h-auto"
           onError={() => setHasError(true)}
         />
-      )}
+      ) : null}
       {altText && !hasError && <p className="text-sm text-muted-foreground italic">{altText}</p>}
       <Dialog open={isAltDialogOpen} onOpenChange={setIsAltDialogOpen}>
         <DialogContent>

--- a/src/frontend/hooks/index.ts
+++ b/src/frontend/hooks/index.ts
@@ -11,3 +11,4 @@ export * from "./alert-channels";
 export * from "./version";
 export * from "./use-is-desktop";
 export * from "./use-synced-param";
+export * from "./use-authenticated-url";

--- a/src/frontend/hooks/uploads.ts
+++ b/src/frontend/hooks/uploads.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getValidToken } from "../lib/api";
 
 export interface UploadResult {
   id: string;
@@ -7,14 +8,19 @@ export interface UploadResult {
   size: number;
 }
 
-function uploadWithProgress<T>(
+async function uploadWithProgress<T>(
   url: string,
   formData: FormData,
   onProgress?: (percent: number) => void,
 ): Promise<T> {
+  const token = await getValidToken();
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open("POST", url);
+
+    if (token) {
+      xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+    }
 
     if (onProgress) {
       xhr.upload.addEventListener("progress", (e) => {

--- a/src/frontend/hooks/use-authenticated-url.test.ts
+++ b/src/frontend/hooks/use-authenticated-url.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, mock, afterEach, type Mock } from "bun:test";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useAuthenticatedUrl } from "./use-authenticated-url";
+
+// Mock getValidToken
+const mockGetValidToken = mock(() => Promise.resolve("test-token" as string | null));
+mock.module("../lib/api", () => ({
+  getValidToken: mockGetValidToken,
+}));
+
+// Mock auth store
+mock.module("../stores/auth", () => ({
+  useAuthStore: {
+    getState: () => ({
+      refreshAccessToken: () => Promise.resolve("refreshed-token"),
+    }),
+  },
+}));
+
+let mockFetch: Mock<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>;
+let mockRevokeObjectURL: Mock<(url: string) => void>;
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+beforeEach(() => {
+  mockGetValidToken.mockImplementation(() => Promise.resolve("test-token" as string | null));
+
+  URL.createObjectURL = (_blob: Blob | MediaSource) => {
+    return `blob:http://localhost/${Math.random().toString(36).slice(2)}`;
+  };
+  mockRevokeObjectURL = mock((_url: string) => {});
+  URL.revokeObjectURL = mockRevokeObjectURL;
+
+  mockFetch = mock(async () => {
+    return new Response(new Blob(["fake-image-data"], { type: "image/png" }), { status: 200 });
+  });
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+describe("useAuthenticatedUrl", () => {
+  it("returns null blobUrl when url is null", () => {
+    const { result } = renderHook(() => useAuthenticatedUrl(null));
+    expect(result.current.blobUrl).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches with auth header and returns blob URL", async () => {
+    const { result } = renderHook(() => useAuthenticatedUrl("/api/test/download"));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.blobUrl).toMatch(/^blob:/);
+    expect(result.current.error).toBeNull();
+
+    const fetchCall = mockFetch.mock.calls[0];
+    expect(fetchCall[0]).toBe("/api/test/download");
+    expect((fetchCall[1]?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-token",
+    );
+  });
+
+  it("fetches without auth header when token is null", async () => {
+    mockGetValidToken.mockImplementation(() => Promise.resolve(null));
+
+    const { result } = renderHook(() => useAuthenticatedUrl("/api/test/download"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.blobUrl).toMatch(/^blob:/);
+    const fetchCall = mockFetch.mock.calls[0];
+    expect((fetchCall[1]?.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it("sets error on non-ok response", async () => {
+    mockFetch.mockImplementation(async () => {
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const { result } = renderHook(() => useAuthenticatedUrl("/api/test/download"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.blobUrl).toBeNull();
+    expect(result.current.error).toBe("Failed to load resource (404)");
+  });
+
+  it("retries on 401 with refreshed token", async () => {
+    let callCount = 0;
+    mockFetch.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      return new Response(new Blob(["data"]), { status: 200 });
+    });
+
+    const { result } = renderHook(() => useAuthenticatedUrl("/api/test/download"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.blobUrl).toMatch(/^blob:/);
+    expect(callCount).toBe(2);
+
+    const secondCall = mockFetch.mock.calls[1];
+    expect((secondCall[1]?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer refreshed-token",
+    );
+  });
+
+  it("revokes blob URL on unmount", async () => {
+    const { result, unmount } = renderHook(() => useAuthenticatedUrl("/api/test/download"));
+
+    await waitFor(() => {
+      expect(result.current.blobUrl).not.toBeNull();
+    });
+
+    const blobUrl = result.current.blobUrl;
+    unmount();
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith(blobUrl);
+  });
+
+  it("resets state when url changes to null", async () => {
+    const { result, rerender } = renderHook(
+      ({ url }: { url: string | null }) => useAuthenticatedUrl(url),
+      { initialProps: { url: "/api/test/download" as string | null } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.blobUrl).not.toBeNull();
+    });
+
+    rerender({ url: null });
+
+    expect(result.current.blobUrl).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/frontend/hooks/use-authenticated-url.ts
+++ b/src/frontend/hooks/use-authenticated-url.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect } from "react";
+import { getValidToken } from "../lib/api";
+import { useAuthStore } from "../stores/auth";
+
+interface AuthenticatedUrlResult {
+  blobUrl: string | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useAuthenticatedUrl(url: string | null): AuthenticatedUrlResult {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!url) {
+      setBlobUrl(null);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+
+    const fetchResource = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const token = await getValidToken();
+        const headers: Record<string, string> = {};
+        if (token) {
+          headers["Authorization"] = `Bearer ${token}`;
+        }
+
+        let res = await fetch(url, { headers, signal: controller.signal });
+
+        if (res.status === 401 && token) {
+          const newToken = await useAuthStore.getState().refreshAccessToken();
+          if (newToken) {
+            headers["Authorization"] = `Bearer ${newToken}`;
+            res = await fetch(url, { headers, signal: controller.signal });
+          }
+        }
+
+        if (!res.ok) {
+          throw new Error(`Failed to load resource (${res.status})`);
+        }
+
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        if (controller.signal.aborted) {
+          URL.revokeObjectURL(objectUrl);
+          return;
+        }
+        setBlobUrl(objectUrl);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "Failed to load resource");
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchResource();
+
+    return () => {
+      controller.abort();
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [url]);
+
+  return { blobUrl, isLoading, error };
+}

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -2,7 +2,7 @@ import { hc } from "hono/client";
 import type { AppType } from "../../server";
 import { useAuthStore, getAccessToken, isTokenExpired } from "../stores/auth";
 
-async function getValidToken(): Promise<string | null> {
+export async function getValidToken(): Promise<string | null> {
   const token = getAccessToken();
   if (!token) return null;
   if (!isTokenExpired(token)) return token;

--- a/src/frontend/lib/authenticated-download.test.ts
+++ b/src/frontend/lib/authenticated-download.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { authenticatedDownload } from "./authenticated-download";
+
+// Mock getValidToken
+const mockGetValidToken = mock(() => Promise.resolve("test-token" as string | null));
+mock.module("./api", () => ({
+  getValidToken: mockGetValidToken,
+}));
+
+// Mock auth store
+mock.module("../stores/auth", () => ({
+  useAuthStore: {
+    getState: () => ({
+      refreshAccessToken: () => Promise.resolve("refreshed-token"),
+    }),
+  },
+}));
+
+let mockFetch: Mock<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>;
+
+beforeEach(() => {
+  mockGetValidToken.mockImplementation(() => Promise.resolve("test-token" as string | null));
+
+  URL.createObjectURL = mock((_blob: Blob | MediaSource) => "blob:http://localhost/fake-blob");
+  URL.revokeObjectURL = mock((_url: string) => {});
+
+  mockFetch = mock(async () => {
+    return new Response(new Blob(["file-content"]), { status: 200 });
+  });
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+});
+
+describe("authenticatedDownload", () => {
+  it("fetches with auth header and triggers download", async () => {
+    const clickMock = mock(() => {});
+    const originalCreateElement = document.createElement.bind(document);
+    document.createElement = ((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === "a") {
+        el.click = clickMock;
+      }
+      return el;
+    }) as unknown as typeof document.createElement;
+    document.body.appendChild = ((_node: unknown) =>
+      _node) as unknown as typeof document.body.appendChild;
+    document.body.removeChild = ((_node: unknown) =>
+      _node) as unknown as typeof document.body.removeChild;
+
+    await authenticatedDownload("/api/test/download", "test-file.png");
+
+    // Verify fetch was called with auth
+    const fetchCall = mockFetch.mock.calls[0];
+    expect(fetchCall[0]).toBe("/api/test/download");
+    expect((fetchCall[1]?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-token",
+    );
+
+    // Verify download was triggered
+    expect(clickMock).toHaveBeenCalled();
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:http://localhost/fake-blob");
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetch.mockImplementation(async () => {
+      return new Response("Not Found", { status: 404 });
+    });
+
+    await expect(authenticatedDownload("/api/test/download", "file.png")).rejects.toThrow(
+      "Download failed (404)",
+    );
+  });
+
+  it("retries on 401 with refreshed token", async () => {
+    let callCount = 0;
+    mockFetch.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      return new Response(new Blob(["data"]), { status: 200 });
+    });
+
+    const clickMock = mock(() => {});
+    const originalCreateElement = document.createElement.bind(document);
+    document.createElement = ((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === "a") el.click = clickMock;
+      return el;
+    }) as unknown as typeof document.createElement;
+    document.body.appendChild = ((_node: unknown) =>
+      _node) as unknown as typeof document.body.appendChild;
+    document.body.removeChild = ((_node: unknown) =>
+      _node) as unknown as typeof document.body.removeChild;
+
+    await authenticatedDownload("/api/test/download", "file.png");
+
+    expect(callCount).toBe(2);
+    const secondCall = mockFetch.mock.calls[1];
+    expect((secondCall[1]?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer refreshed-token",
+    );
+    expect(clickMock).toHaveBeenCalled();
+  });
+
+  it("works without auth when token is null", async () => {
+    mockGetValidToken.mockImplementation(() => Promise.resolve(null));
+
+    const clickMock = mock(() => {});
+    const originalCreateElement = document.createElement.bind(document);
+    document.createElement = ((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === "a") el.click = clickMock;
+      return el;
+    }) as unknown as typeof document.createElement;
+    document.body.appendChild = ((_node: unknown) =>
+      _node) as unknown as typeof document.body.appendChild;
+    document.body.removeChild = ((_node: unknown) =>
+      _node) as unknown as typeof document.body.removeChild;
+
+    await authenticatedDownload("/api/test/download", "file.png");
+
+    const fetchCall = mockFetch.mock.calls[0];
+    expect((fetchCall[1]?.headers as Record<string, string>).Authorization).toBeUndefined();
+    expect(clickMock).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/lib/authenticated-download.ts
+++ b/src/frontend/lib/authenticated-download.ts
@@ -1,0 +1,37 @@
+import { getValidToken } from "./api";
+import { useAuthStore } from "../stores/auth";
+
+export async function authenticatedDownload(url: string, filename: string): Promise<void> {
+  const token = await getValidToken();
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  let res = await fetch(url, { headers });
+
+  if (res.status === 401 && token) {
+    const newToken = await useAuthStore.getState().refreshAccessToken();
+    if (newToken) {
+      headers["Authorization"] = `Bearer ${newToken}`;
+      res = await fetch(url, { headers });
+    }
+  }
+
+  if (!res.ok) {
+    throw new Error(`Download failed (${res.status})`);
+  }
+
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement("a");
+    a.href = objectUrl;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}

--- a/src/frontend/test/msw-handlers.ts
+++ b/src/frontend/test/msw-handlers.ts
@@ -91,6 +91,16 @@ export const defaultHandlers = [
     HttpResponse.json({ ok: true, newPath: "/renamed.md" }),
   ),
   http.delete("*/api/projects/:id/shared-drive", () => HttpResponse.json({ ok: true })),
+  http.get(
+    "*/api/projects/:id/shared-drive/download",
+    () =>
+      new HttpResponse(new Uint8Array([137, 80, 78, 71]), {
+        headers: {
+          "Content-Type": "image/png",
+          "Content-Disposition": 'inline; filename="file.png"',
+        },
+      }),
+  ),
   http.get("*/api/projects/:id/shared-drive/preview", () =>
     HttpResponse.json({ content: "", contentType: "text/plain" }),
   ),


### PR DESCRIPTION
## Summary
- Browser `<img>` and `<iframe>` tags don't send `Authorization` headers, causing 401 errors on authenticated shared drive endpoints even when logged in
- Added `useAuthenticatedUrl` hook that fetches resources with JWT auth headers and returns blob URLs for use in `<img src>` / `<iframe src>`
- Added `authenticatedDownload` utility for click-triggered file downloads with auth
- Fixed XHR uploads in `uploads.ts` to include auth headers
- Handles token refresh on 401, blob URL memory cleanup on unmount, and AbortController for rapid navigation

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (no new warnings)
- [x] `bun test` — all 1220 tests pass
- [ ] Manual: log in, navigate to shared drive, upload an image — verify preview renders
- [ ] Manual: test PDF preview
- [ ] Manual: test file download button
- [ ] Manual: test image embedded in markdown editor content
- [ ] Manual: test with auth disabled (`unset SHIRE_USERNAME`) — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)