### PR TITLE
Fix remaining auth 401s in attachments, file preview, sidebar download

### DIFF
--- a/src/frontend/components/ChatPanel.test.tsx
+++ b/src/frontend/components/ChatPanel.test.tsx
@@ -517,7 +517,7 @@ describe("ChatPanel", () => {
     });
   });
 
-  it("renders file attachment as download link", async () => {
+  it("renders file attachment as download button", async () => {
     const msgWithAtt: Message = {
       id: 30,
       role: "agent",
@@ -532,11 +532,8 @@ describe("ChatPanel", () => {
     await waitFor(() => {
       expect(screen.getByText("report.pdf")).toBeInTheDocument();
     });
-    const link = screen.getByText("report.pdf").closest("a");
-    expect(link).toHaveAttribute(
-      "href",
-      "/api/projects/test-project/agents/a1/attachments/abc123/report.pdf",
-    );
+    const button = screen.getByText("report.pdf").closest("button");
+    expect(button).toBeInTheDocument();
   });
 
   it("renders image attachment as preview", async () => {
@@ -553,10 +550,7 @@ describe("ChatPanel", () => {
     renderChat(activeAgent);
     await waitFor(() => {
       const img = screen.getByAltText("screenshot.png");
-      expect(img).toHaveAttribute(
-        "src",
-        "/api/projects/test-project/agents/a1/attachments/img001/screenshot.png",
-      );
+      expect(img.getAttribute("src")).toMatch(/^blob:/);
     });
   });
 
@@ -579,10 +573,7 @@ describe("ChatPanel", () => {
     renderChat(activeAgent);
     await waitFor(() => {
       const img = screen.getByAltText("Screenshot 2026-04-10 at 10.30.00.png");
-      expect(img).toHaveAttribute(
-        "src",
-        "/api/projects/test-project/agents/a1/attachments/img002/Screenshot%202026-04-10%20at%2010.30.00.png",
-      );
+      expect(img.getAttribute("src")).toMatch(/^blob:/);
     });
   });
 

--- a/src/frontend/components/FilePreviewPanel.tsx
+++ b/src/frontend/components/FilePreviewPanel.tsx
@@ -7,6 +7,7 @@ import { SharedDriveEditor } from "./editor";
 import CodeEditor from "./editor/CodeEditor";
 import CsvEditor from "./editor/CsvEditor";
 import { useFileContent } from "../hooks/shared-drive";
+import { useAuthenticatedUrl } from "../hooks/use-authenticated-url";
 import { getFileIcon, getPreviewType } from "../lib/file-utils";
 import { useSubscription } from "../hooks/ws";
 import type { SharedDriveWsEvent } from "../lib/ws";
@@ -51,6 +52,10 @@ export default function FilePreviewPanel({
   const error = queryError ? queryError.message || "Failed to load file" : null;
 
   const downloadUrl = `/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(filePath)}`;
+  const previewUrl = `/api/projects/${projectName}/shared-drive/preview?path=${encodeURIComponent(filePath)}`;
+
+  const imageAuth = useAuthenticatedUrl(type === "image" ? downloadUrl : null);
+  const pdfAuth = useAuthenticatedUrl(type === "pdf" ? previewUrl : null);
 
   const handleDirtyChange = useCallback((dirty: boolean) => {
     hasUnsavedChanges.current = dirty;
@@ -163,21 +168,28 @@ export default function FilePreviewPanel({
 
         {!loading && !error && type === "image" && (
           <div className="flex items-center justify-center p-4">
-            <img
-              src={downloadUrl}
-              alt={fileName}
-              loading="lazy"
-              className="max-w-full max-h-[70vh] object-contain"
-            />
+            {imageAuth.isLoading && <Spinner size="sm" className="text-muted-foreground" />}
+            {imageAuth.blobUrl && (
+              <img
+                src={imageAuth.blobUrl}
+                alt={fileName}
+                className="max-w-full max-h-[70vh] object-contain"
+              />
+            )}
           </div>
         )}
 
         {!loading && !error && type === "pdf" && (
-          <iframe
-            src={`/api/projects/${projectName}/shared-drive/preview?path=${encodeURIComponent(filePath)}`}
-            className="w-full h-full border-0"
-            title={fileName}
-          />
+          <>
+            {pdfAuth.isLoading && (
+              <div className="flex items-center justify-center py-12">
+                <Spinner size="sm" className="text-muted-foreground" />
+              </div>
+            )}
+            {pdfAuth.blobUrl && (
+              <iframe src={pdfAuth.blobUrl} className="w-full h-full border-0" title={fileName} />
+            )}
+          </>
         )}
 
         {!loading &&

--- a/src/frontend/components/chat/AttachmentDisplay.tsx
+++ b/src/frontend/components/chat/AttachmentDisplay.tsx
@@ -2,11 +2,40 @@ import * as React from "react";
 import { Download } from "lucide-react";
 import { type Attachment, formatFileSize } from "./types";
 import { getFileIcon } from "../../lib/file-utils";
+import { useAuthenticatedUrl } from "../../hooks/use-authenticated-url";
+import { authenticatedDownload } from "../../lib/authenticated-download";
+import { Button } from "../ui/button";
+import { Spinner } from "../ui/spinner";
 
 interface AttachmentDisplayProps {
   attachments: Attachment[];
   projectName: string;
   agentId: string;
+}
+
+function ImageAttachment({ url, filename }: { url: string; filename: string }) {
+  const { blobUrl, isLoading } = useAuthenticatedUrl(url);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center max-w-48 max-h-32 rounded-md border border-border p-4">
+        <Spinner size="sm" className="text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!blobUrl) return null;
+
+  return (
+    <a
+      href={blobUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block rounded-md border border-border overflow-hidden hover:opacity-90 transition-opacity"
+    >
+      <img src={blobUrl} alt={filename} loading="lazy" className="max-w-48 max-h-32 object-cover" />
+    </a>
+  );
 }
 
 export const AttachmentDisplay = React.memo(function AttachmentDisplay({
@@ -25,27 +54,14 @@ export const AttachmentDisplay = React.memo(function AttachmentDisplay({
         const AttIcon = getFileIcon(att.filename);
 
         return isImage ? (
-          <a
-            key={att.id}
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block rounded-md border border-border overflow-hidden hover:opacity-90 transition-opacity"
-          >
-            <img
-              src={url}
-              alt={att.filename}
-              loading="lazy"
-              className="max-w-48 max-h-32 object-cover"
-            />
-          </a>
+          <ImageAttachment key={att.id} url={url} filename={att.filename} />
         ) : (
-          <a
+          <Button
             key={att.id}
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 px-3 py-2 rounded-md border border-border hover:bg-muted/50 text-sm"
+            variant="outline"
+            size="sm"
+            onClick={() => authenticatedDownload(url, att.filename)}
+            className="flex items-center gap-2"
           >
             <AttIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate max-w-40">{att.filename}</span>
@@ -53,7 +69,7 @@ export const AttachmentDisplay = React.memo(function AttachmentDisplay({
               ({formatFileSize(att.size)})
             </span>
             <Download className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          </a>
+          </Button>
         );
       })}
     </div>

--- a/src/frontend/components/sidebar/SharedDrivePanel.tsx
+++ b/src/frontend/components/sidebar/SharedDrivePanel.tsx
@@ -31,6 +31,7 @@ import {
   useSyncedParam,
 } from "../../hooks";
 import { formatSize, getFileIcon, MAX_UPLOAD_SIZE } from "../../lib/file-utils";
+import { authenticatedDownload } from "../../lib/authenticated-download";
 import type { SharedDriveFile } from "../../hooks/shared-drive";
 
 function Breadcrumbs({ path, onNavigate }: { path: string; onNavigate: (path: string) => void }) {
@@ -331,14 +332,16 @@ export default function SharedDrivePanel() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   {file.type === "file" && (
-                    <DropdownMenuItem asChild>
-                      <a
-                        href={`/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(file.path)}`}
-                        download
-                      >
-                        <Download className="h-4 w-4 mr-2" />
-                        Download
-                      </a>
+                    <DropdownMenuItem
+                      onClick={() =>
+                        authenticatedDownload(
+                          `/api/projects/${projectName}/shared-drive/download?path=${encodeURIComponent(file.path)}`,
+                          file.name,
+                        )
+                      }
+                    >
+                      <Download className="h-4 w-4 mr-2" />
+                      Download
                     </DropdownMenuItem>
                   )}
                   <DropdownMenuItem onClick={() => setRenameTarget(file)}>

--- a/src/frontend/test/msw-handlers.ts
+++ b/src/frontend/test/msw-handlers.ts
@@ -51,6 +51,16 @@ export const defaultHandlers = [
       { status: 201 },
     ),
   ),
+  http.get(
+    "*/api/projects/:id/agents/:aid/attachments/:attId/*",
+    () =>
+      new HttpResponse(new Uint8Array([137, 80, 78, 71]), {
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "Content-Disposition": 'inline; filename="file"',
+        },
+      }),
+  ),
 
   // --- Activity ---
   http.get("*/api/projects/:id/activity", () =>


### PR DESCRIPTION
## Summary
- Follow-up to #282 — fixes the same unauthenticated resource loading bug in three components that were missed:
  - **AttachmentDisplay**: chat attachment images now use blob URLs, file downloads use `authenticatedDownload` via shadcn `<Button>`
  - **FilePreviewPanel**: side panel image/PDF previews now use `useAuthenticatedUrl`
  - **SharedDrivePanel**: sidebar download dropdown now uses `authenticatedDownload` instead of plain `<a href>`
- Added MSW handler for attachment GET endpoint

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — all 1230 tests pass
- [ ] Manual: send a message with an image attachment, verify it renders
- [ ] Manual: click a file attachment in chat, verify it downloads
- [ ] Manual: open file preview side panel with an image, verify it loads
- [ ] Manual: use sidebar dropdown "Download" on a file, verify it downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)