### PR TITLE
Fix catalog form showing stale agent values on re-selection

### DIFF
--- a/src/frontend/components/ProjectLayout.test.tsx
+++ b/src/frontend/components/ProjectLayout.test.tsx
@@ -1,14 +1,80 @@
 // Primary test coverage is in src/frontend/test/ProjectDashboard.test.tsx
 // This file verifies the key-prop fix for AgentForm remounting.
 
-import { describe, it, expect } from "bun:test";
-import * as fs from "fs";
-import * as path from "path";
+import { describe, it, expect, mock } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import AgentForm from "./AgentForm";
+import type { Agent } from "./types";
 
 describe("ProjectLayout: AgentForm key prop", () => {
-  it("passes key={currentAgent?.id} to AgentForm to reset state on agent change", () => {
-    const source = fs.readFileSync(path.join(import.meta.dir, "ProjectLayout.tsx"), "utf-8");
-    // Verify the key prop is set on AgentForm
-    expect(source).toContain('key={currentAgent?.id ?? "new"}');
+  it("remounts AgentForm with fresh values when key changes (simulates catalog re-selection)", () => {
+    const noop = mock(() => {});
+
+    const agentA: Agent = {
+      id: "",
+      name: "agent-alpha",
+      description: "Alpha agent",
+      emoji: "\u{1F680}",
+      busy: false,
+      unreadCount: 0,
+      harness: "claude_code",
+      model: "claude-sonnet-4-6",
+      systemPrompt: "You are Alpha.",
+    };
+
+    const agentB: Agent = {
+      id: "",
+      name: "agent-beta",
+      description: "Beta agent",
+      emoji: "\u{1F525}",
+      busy: false,
+      unreadCount: 0,
+      harness: "pi",
+      model: "gpt-4o",
+      systemPrompt: "You are Beta.",
+    };
+
+    // Render with agent A (key=0)
+    const { rerender } = render(
+      <AgentForm
+        key={0}
+        open={true}
+        title="New Agent"
+        agent={agentA}
+        onSave={noop}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByLabelText("Name")).toHaveValue("agent-alpha");
+    expect(screen.getByLabelText("Description")).toHaveValue("Alpha agent");
+
+    // Re-render with agent B but SAME key — simulates the old bug
+    rerender(
+      <AgentForm
+        key={0}
+        open={true}
+        title="New Agent"
+        agent={agentB}
+        onSave={noop}
+        onClose={noop}
+      />,
+    );
+    // With the same key, React reuses the component instance and useState keeps old values
+    expect(screen.getByLabelText("Name")).toHaveValue("agent-alpha"); // BUG: still shows A
+
+    // Re-render with agent B and DIFFERENT key — simulates the fix
+    rerender(
+      <AgentForm
+        key={1}
+        open={true}
+        title="New Agent"
+        agent={agentB}
+        onSave={noop}
+        onClose={noop}
+      />,
+    );
+    // New key forces remount, useState initializes with fresh values from agent B
+    expect(screen.getByLabelText("Name")).toHaveValue("agent-beta");
+    expect(screen.getByLabelText("Description")).toHaveValue("Beta agent");
   });
 });

--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -126,6 +126,7 @@ export default function ProjectLayout() {
   const [editingAgent, setEditingAgent] = React.useState<Agent | null>(null);
   const [currentAgent, setCurrentAgent] = React.useState<Agent | null>(null);
   const [catalogOpen, setCatalogOpen] = React.useState(false);
+  const [formKey, setFormKey] = React.useState(0);
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
 
   // Close mobile sidebar when agent changes
@@ -154,6 +155,7 @@ export default function ProjectLayout() {
       });
       setEditingAgent(null);
       setFormTitle("New Agent from Catalog");
+      setFormKey((k) => k + 1);
       setFormOpen(true);
     } catch {
       setCatalogOpen(true);
@@ -205,6 +207,7 @@ export default function ProjectLayout() {
     setCurrentAgent(null);
     setEditingAgent(null);
     setFormTitle("New Agent");
+    setFormKey((k) => k + 1);
     setFormOpen(true);
   };
 
@@ -324,7 +327,7 @@ export default function ProjectLayout() {
         )}
 
         <AgentForm
-          key={currentAgent?.id ?? "new"}
+          key={currentAgent?.id || formKey}
           open={formOpen}
           title={formTitle}
           agent={currentAgent}


### PR DESCRIPTION
## Summary
- When selecting agent A from catalog, canceling, then selecting agent B, the form still showed agent A's values
- Root cause: `AgentForm` key was always `"new"` for catalog agents (since `currentAgent.id` is always `""`), so React reused the component instance and `useState` hooks retained stale values
- Fix: added a `formKey` counter that increments on each form open (catalog add and new agent), ensuring React remounts the form with fresh state

## Test plan
- [x] Added behavioral test proving same-key reuses stale state, different-key remounts correctly
- [x] All 1231 tests pass
- [x] Typecheck, lint pass
- [ ] Manual: select catalog agent A → cancel → select agent B → verify form shows B's values

🤖 Generated with [Claude Code](https://claude.com/claude-code)