### PR TITLE
Fix WebSocket broadcast gaps for cross-tab sync

### DIFF
--- a/src/runtime/agent-manager.ts
+++ b/src/runtime/agent-manager.ts
@@ -217,6 +217,7 @@ export class AgentManager {
         content: savedAttachments.length > 0 ? { text, attachments: savedAttachments } : { text },
       });
       this.lastUserMessageAt = msg.createdAt;
+      this.broadcastNewMessage(msg);
     }
 
     // Send directly to harness (no inbox file needed for direct messages)
@@ -258,6 +259,14 @@ export class AgentManager {
     if (this.busy) {
       await this.harness.interrupt();
       this.busy = false;
+      this.broadcastAgent({
+        type: "agent_busy",
+        payload: { agentId: this.agentId, active: false },
+      });
+      this.broadcastAgents({
+        type: "agent_busy",
+        payload: { agentId: this.agentId, active: false },
+      });
     }
     await this.harness.clearSession();
     agentsService.setSessionId(this.agentId, null);
@@ -283,6 +292,14 @@ export class AgentManager {
       if (this.busy) {
         await this.harness.interrupt();
         this.busy = false;
+        this.broadcastAgent({
+          type: "agent_busy",
+          payload: { agentId: this.agentId, active: false },
+        });
+        this.broadcastAgents({
+          type: "agent_busy",
+          payload: { agentId: this.agentId, active: false },
+        });
       }
       await this.harness.clearSession();
       agentsService.setSessionId(this.agentId, null);


### PR DESCRIPTION
## Summary
- Broadcast `agent_busy: false` after interrupt in `clearSession`/`clearHistory` so all tabs update the busy indicator
- Broadcast user messages via `new_message_notification` so other tabs see the user's message without waiting for the agent response

## Test plan
- [x] All 1236 tests pass, typecheck clean, lint clean
- [ ] Playwright: open two tabs on same agent, send message in tab 1, verify tab 2 shows it
- [ ] Playwright: trigger clear session while busy, verify busy indicator clears in other tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)