### PR TITLE
Fix ENOSPC inotify exhaustion in shared-drive watcher

### DIFF
--- a/src/frontend/components/FilePreviewPanel.tsx
+++ b/src/frontend/components/FilePreviewPanel.tsx
@@ -72,25 +72,20 @@ export default function FilePreviewPanel({
 
   // Subscribe to file changes — debounce to wait for streaming edits to settle
   useSubscription<SharedDriveWsEvent>(
-    `project:${projectId}:shared-drive`,
-    useCallback(
-      (event) => {
-        if (event.type === "file_changed" && event.payload.path === filePath) {
-          if (hasUnsavedChanges.current) {
-            setExternalChangeDetected(true);
-            return;
-          }
-          // Debounce: reset timer on each event, refresh only after writes settle
-          if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
-          refreshTimerRef.current = setTimeout(() => {
-            refreshTimerRef.current = null;
-            setRefreshVersion((v) => v + 1);
-            toast("File updated", { duration: 2000 });
-          }, 500);
-        }
-      },
-      [filePath],
-    ),
+    projectId && filePath ? `shared-drive:${projectId}:${filePath}` : null,
+    useCallback((event) => {
+      if (event.type !== "file_changed") return;
+      if (hasUnsavedChanges.current) {
+        setExternalChangeDetected(true);
+        return;
+      }
+      if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = setTimeout(() => {
+        refreshTimerRef.current = null;
+        setRefreshVersion((v) => v + 1);
+        toast("File updated", { duration: 2000 });
+      }, 500);
+    }, []),
   );
 
   return (

--- a/src/frontend/components/ProjectLayout.tsx
+++ b/src/frontend/components/ProjectLayout.tsx
@@ -21,7 +21,7 @@ import {
   useSyncedParam,
 } from "../hooks";
 import { useSubscription } from "../hooks/ws";
-import type { AgentListWsEvent, SharedDriveWsEvent } from "../lib/ws";
+import type { AgentListWsEvent } from "../lib/ws";
 import {
   ProjectLayoutContext,
   ProjectLayoutProvider,
@@ -184,20 +184,6 @@ export default function ProjectLayout() {
         break;
     }
   });
-
-  // Subscribe to shared drive file changes to keep caches fresh
-  useSubscription<SharedDriveWsEvent>(
-    projectId ? `project:${projectId}:shared-drive` : null,
-    React.useCallback(
-      (event) => {
-        if (event.type === "file_changed") {
-          queryClient.invalidateQueries({ queryKey: ["shared-drive", projectId] });
-          queryClient.invalidateQueries({ queryKey: ["file-content", projectId] });
-        }
-      },
-      [queryClient, projectId],
-    ),
-  );
 
   const handleBrowseCatalog = () => {
     setCatalogOpen(true);

--- a/src/frontend/components/sidebar/SharedDrivePanel.tsx
+++ b/src/frontend/components/sidebar/SharedDrivePanel.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
 import { useDropzone } from "react-dropzone";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSubscription } from "../../hooks/ws";
+import type { SharedDriveWsEvent } from "../../lib/ws";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import {
@@ -88,6 +91,19 @@ export default function SharedDrivePanel() {
     isError: filesError,
   } = useSharedDrive(projectId, currentPath);
   const files = data?.files ?? [];
+
+  const queryClient = useQueryClient();
+  useSubscription<SharedDriveWsEvent>(
+    projectId ? `shared-drive:${projectId}:${currentPath}` : null,
+    React.useCallback(
+      (event) => {
+        if (event.type === "file_changed") {
+          queryClient.invalidateQueries({ queryKey: ["shared-drive", projectId, currentPath] });
+        }
+      },
+      [queryClient, projectId, currentPath],
+    ),
+  );
 
   const createDirectory = useCreateDirectory(projectId ?? "");
   const createFile = useCreateFile(projectId ?? "");

--- a/src/routes/shared-drive.test.ts
+++ b/src/routes/shared-drive.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
-import { safePath } from "./shared-drive";
+import { safePath } from "../services/shared-drive-paths";
 import { createTestDb } from "../test/setup";
 import { createApp } from "../server";
 import { ProjectManager } from "../runtime/project-manager";

--- a/src/routes/shared-drive.ts
+++ b/src/routes/shared-drive.ts
@@ -2,9 +2,10 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { readdir, stat, readFile, mkdir, unlink, rm, writeFile, access, rename } from "fs/promises";
-import { join, resolve, basename, dirname } from "path";
+import { join, basename, dirname } from "path";
 import * as workspace from "../services/workspace";
 import * as projectsService from "../services/projects";
+import { safePath } from "../services/shared-drive-paths";
 import type { AppEnv } from "../types";
 import { mimeFromPath } from "../utils/mime";
 
@@ -13,15 +14,6 @@ function resolveProjectId(nameOrId: string): string | null {
   if (byId) return byId.id;
   const byName = projectsService.getProjectByName(nameOrId);
   return byName?.id ?? null;
-}
-
-export function safePath(sharedRoot: string, userPath: string): string | null {
-  // Normalize: treat "/" or empty as the shared root itself
-  const normalized = userPath === "/" || userPath === "" ? "." : userPath.replace(/^\/+/, "");
-  const resolved = resolve(sharedRoot, normalized);
-  // Guard against prefix collisions (e.g. /shared vs /shared-evil)
-  if (resolved !== sharedRoot && !resolved.startsWith(sharedRoot + "/")) return null;
-  return resolved;
 }
 
 const pathQuery = z.object({ path: z.string().optional() });

--- a/src/runtime/coordinator.ts
+++ b/src/runtime/coordinator.ts
@@ -10,7 +10,6 @@ import * as projectsService from "../services/projects";
 import * as workspace from "../services/workspace";
 import * as skillsService from "../services/skills";
 import { dispatchAlert } from "../services/alert-dispatcher";
-import { startSharedDriveWatcher, stopSharedDriveWatcher } from "../services/shared-drive-watcher";
 import type { Skill } from "../services/skills";
 import { valid as isValidSlug } from "../services/slug";
 
@@ -71,7 +70,6 @@ export class Coordinator {
     if (this.deployed) return;
 
     await workspace.ensureProjectDirs(this.projectId);
-    startSharedDriveWatcher(this.projectId);
 
     const dbAgents = agentsService.listAgents(this.projectId);
     const results = await Promise.allSettled(
@@ -310,7 +308,6 @@ export class Coordinator {
   }
 
   async stopAll(): Promise<void> {
-    stopSharedDriveWatcher(this.projectId);
     await Promise.all([...this.agents.values()].map((proc) => proc.stop()));
     this.agents.clear();
     for (const unsub of this.unsubscribes) unsub();

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { writeFile, mkdir, rm } from "fs/promises";
+import { join } from "path";
+import { handleWsMessage, handleWsClose } from "./server";
+import * as workspace from "./services/workspace";
+
+const DEBOUNCE_BUFFER_MS = 600;
+
+interface FakeWs {
+  send(data: string): void;
+  events: Array<{ topic: string; type: string; payload: { path: string } }>;
+}
+
+function makeWs(): FakeWs {
+  const events: FakeWs["events"] = [];
+  return {
+    events,
+    send(data: string) {
+      const parsed = JSON.parse(data) as {
+        topic: string;
+        type: string;
+        payload: { path: string };
+      };
+      events.push(parsed);
+    },
+  };
+}
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("handleWsMessage / handleWsClose — shared-drive integration", () => {
+  it("activates the watcher on subscribe and forwards file_changed to the ws", async () => {
+    const id = `ws-test-${Date.now()}-1`;
+    const sharedDir = workspace.sharedDir(id);
+    await mkdir(sharedDir, { recursive: true });
+    cleanups.push(() => rm(workspace.root(id), { recursive: true, force: true }));
+
+    const filePath = join(sharedDir, "note.md");
+    await writeFile(filePath, "v1", "utf-8");
+
+    const ws = makeWs();
+    const topic = `shared-drive:${id}:/note.md`;
+    handleWsMessage(ws, JSON.stringify({ type: "subscribe", topic }));
+    cleanups.push(() => handleWsClose(ws));
+    await wait(100);
+
+    await writeFile(filePath, "v2", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
+
+    const fileEvents = ws.events.filter((e) => e.type === "file_changed");
+    expect(fileEvents.length).toBeGreaterThanOrEqual(1);
+    expect(fileEvents[0].topic).toBe(topic);
+    expect(fileEvents[0].payload.path).toBe("/note.md");
+  });
+
+  it("releases the watcher on unsubscribe so further changes do not emit", async () => {
+    const id = `ws-test-${Date.now()}-2`;
+    const sharedDir = workspace.sharedDir(id);
+    await mkdir(sharedDir, { recursive: true });
+    cleanups.push(() => rm(workspace.root(id), { recursive: true, force: true }));
+
+    const filePath = join(sharedDir, "note.md");
+    await writeFile(filePath, "v1", "utf-8");
+
+    const ws = makeWs();
+    const topic = `shared-drive:${id}:/note.md`;
+    handleWsMessage(ws, JSON.stringify({ type: "subscribe", topic }));
+    await wait(100);
+
+    handleWsMessage(ws, JSON.stringify({ type: "unsubscribe", topic }));
+
+    await writeFile(filePath, "v2", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
+
+    expect(ws.events.filter((e) => e.type === "file_changed").length).toBe(0);
+  });
+
+  it("releases the watcher on ws close", async () => {
+    const id = `ws-test-${Date.now()}-3`;
+    const sharedDir = workspace.sharedDir(id);
+    await mkdir(sharedDir, { recursive: true });
+    cleanups.push(() => rm(workspace.root(id), { recursive: true, force: true }));
+
+    const filePath = join(sharedDir, "note.md");
+    await writeFile(filePath, "v1", "utf-8");
+
+    const ws = makeWs();
+    const topic = `shared-drive:${id}:/note.md`;
+    handleWsMessage(ws, JSON.stringify({ type: "subscribe", topic }));
+    await wait(100);
+
+    handleWsClose(ws);
+
+    await writeFile(filePath, "v2", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
+
+    expect(ws.events.filter((e) => e.type === "file_changed").length).toBe(0);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,9 @@ import { versionRoutes } from "./routes/version";
 import { authRoutes } from "./routes/auth";
 import { authMiddleware } from "./middleware/auth";
 import { isAuthEnabled } from "./lib/auth-config";
+import { acquireSharedDriveWatch, releaseSharedDriveWatch } from "./services/shared-drive-watcher";
+
+const SHARED_DRIVE_TOPIC_PREFIX = "shared-drive:";
 
 export interface AppContext {
   projectManager: ProjectManager;
@@ -97,13 +100,19 @@ export function handleWsMessage(ws: WsLike, data: string): void {
   switch (cmd.type) {
     case "subscribe": {
       if (!cmd.topic || subs.has(cmd.topic)) return;
-      const unsub = bus.on(cmd.topic, (event: BusEvent) => {
+      const busUnsub = bus.on(cmd.topic, (event: BusEvent) => {
         try {
           ws.send(JSON.stringify({ topic: cmd.topic, ...event }));
         } catch {
           // ws closed
         }
       });
+      const isSharedDrive = cmd.topic.startsWith(SHARED_DRIVE_TOPIC_PREFIX);
+      if (isSharedDrive) acquireSharedDriveWatch(cmd.topic);
+      const unsub = (): void => {
+        busUnsub();
+        if (isSharedDrive) releaseSharedDriveWatch(cmd.topic);
+      };
       subs.set(cmd.topic, unsub);
       break;
     }

--- a/src/services/shared-drive-paths.ts
+++ b/src/services/shared-drive-paths.ts
@@ -1,0 +1,14 @@
+import { resolve } from "path";
+
+/**
+ * Resolves a user-supplied path inside a project's shared root, rejecting any
+ * path that would escape the root (via traversal, absolute paths, or prefix
+ * collisions like `/shared` vs `/shared-evil`). Returns the absolute resolved
+ * path on success, or `null` if the path escapes the root.
+ */
+export function safePath(sharedRoot: string, userPath: string): string | null {
+  const normalized = userPath === "/" || userPath === "" ? "." : userPath.replace(/^\/+/, "");
+  const resolved = resolve(sharedRoot, normalized);
+  if (resolved !== sharedRoot && !resolved.startsWith(sharedRoot + "/")) return null;
+  return resolved;
+}

--- a/src/services/shared-drive-watcher.test.ts
+++ b/src/services/shared-drive-watcher.test.ts
@@ -2,112 +2,189 @@ import { describe, it, expect, afterEach } from "bun:test";
 import { writeFile, mkdir, rm } from "fs/promises";
 import { join } from "path";
 import { bus, type SharedDriveBusEvent } from "../events";
-import { startSharedDriveWatcher, stopSharedDriveWatcher } from "./shared-drive-watcher";
+import { acquireSharedDriveWatch, releaseSharedDriveWatch } from "./shared-drive-watcher";
 import * as workspace from "./workspace";
 
-const TEST_PROJECT_ID = "watcher-test-project";
+const DEBOUNCE_BUFFER_MS = 600; // 300ms debounce + slack
 
-async function ensureSharedDir(): Promise<string> {
-  const dir = workspace.sharedDir(TEST_PROJECT_ID);
-  await mkdir(dir, { recursive: true });
-  return dir;
+let projectCounter = 0;
+function nextProject(): { id: string; sharedDir: string } {
+  projectCounter += 1;
+  const id = `watcher-test-${Date.now()}-${projectCounter}`;
+  return { id, sharedDir: workspace.sharedDir(id) };
 }
 
+const cleanups: Array<() => Promise<void> | void> = [];
+
 afterEach(async () => {
-  stopSharedDriveWatcher(TEST_PROJECT_ID);
-  const dir = workspace.sharedDir(TEST_PROJECT_ID);
-  await rm(dir, { recursive: true, force: true });
+  for (const c of cleanups.splice(0)) await c();
 });
 
+function trackProject(id: string): void {
+  cleanups.push(async () => {
+    await rm(workspace.root(id), { recursive: true, force: true }).catch(() => {});
+  });
+}
+
+function collect(topic: string): {
+  events: SharedDriveBusEvent[];
+  unsub: () => void;
+} {
+  const events: SharedDriveBusEvent[] = [];
+  const unsub = bus.on<SharedDriveBusEvent>(topic, (event) => {
+    events.push(event);
+  });
+  return { events, unsub };
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
 describe("shared-drive-watcher", () => {
-  it("emits file_changed event when a file is written", async () => {
-    const sharedDir = await ensureSharedDir();
-    startSharedDriveWatcher(TEST_PROJECT_ID);
+  it("emits file_changed when an acquired file is modified", async () => {
+    const { id, sharedDir } = nextProject();
+    trackProject(id);
+    await mkdir(sharedDir, { recursive: true });
+    const filePath = join(sharedDir, "note.md");
+    await writeFile(filePath, "hello", "utf-8");
 
-    // Give the watcher time to initialize
-    await new Promise((r) => setTimeout(r, 200));
+    const topic = `shared-drive:${id}:/note.md`;
+    acquireSharedDriveWatch(topic);
+    cleanups.push(() => releaseSharedDriveWatch(topic));
+    await wait(100);
 
-    const events: SharedDriveBusEvent[] = [];
-    const unsub = bus.on<SharedDriveBusEvent>(
-      `project:${TEST_PROJECT_ID}:shared-drive`,
-      (event) => {
-        events.push(event);
-      },
-    );
+    const { events, unsub } = collect(topic);
+    cleanups.push(unsub);
 
-    // Write a file
-    await writeFile(join(sharedDir, "test.md"), "hello world", "utf-8");
+    await writeFile(filePath, "world", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
 
-    // Wait for debounce + some buffer
-    await new Promise((r) => setTimeout(r, 600));
-
-    unsub();
-
-    expect(events.length).toBeGreaterThanOrEqual(1);
-    const fileChangedEvents = events.filter((e) => e.type === "file_changed");
-    expect(fileChangedEvents.length).toBeGreaterThanOrEqual(1);
-    expect(fileChangedEvents[0].payload.path).toBe("/test.md");
+    const fileChanged = events.filter((e) => e.type === "file_changed");
+    expect(fileChanged.length).toBeGreaterThanOrEqual(1);
+    expect(fileChanged[0].payload.path).toBe("/note.md");
   });
 
-  it("emits event for files in subdirectories", async () => {
-    const sharedDir = await ensureSharedDir();
+  it("emits file_changed when a child of an acquired directory changes", async () => {
+    const { id, sharedDir } = nextProject();
+    trackProject(id);
     const subDir = join(sharedDir, "docs");
     await mkdir(subDir, { recursive: true });
 
-    startSharedDriveWatcher(TEST_PROJECT_ID);
-    await new Promise((r) => setTimeout(r, 200));
+    const topic = `shared-drive:${id}:/docs`;
+    acquireSharedDriveWatch(topic);
+    cleanups.push(() => releaseSharedDriveWatch(topic));
+    await wait(100);
 
-    const events: SharedDriveBusEvent[] = [];
-    const unsub = bus.on<SharedDriveBusEvent>(
-      `project:${TEST_PROJECT_ID}:shared-drive`,
-      (event) => {
-        events.push(event);
-      },
-    );
+    const { events, unsub } = collect(topic);
+    cleanups.push(unsub);
 
-    await writeFile(join(subDir, "nested.txt"), "nested content", "utf-8");
-    await new Promise((r) => setTimeout(r, 600));
+    await writeFile(join(subDir, "inside.txt"), "nested", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
 
-    unsub();
-
-    const fileChangedEvents = events.filter((e) => e.type === "file_changed");
-    expect(fileChangedEvents.length).toBeGreaterThanOrEqual(1);
-    expect(fileChangedEvents.some((e) => e.payload.path === "/docs/nested.txt")).toBe(true);
+    const fileChanged = events.filter((e) => e.type === "file_changed");
+    expect(fileChanged.length).toBeGreaterThanOrEqual(1);
+    expect(fileChanged.some((e) => e.payload.path === "/docs/inside.txt")).toBe(true);
   });
 
-  it("stopSharedDriveWatcher stops emitting events", async () => {
-    const sharedDir = await ensureSharedDir();
-    startSharedDriveWatcher(TEST_PROJECT_ID);
-    await new Promise((r) => setTimeout(r, 200));
+  it("acquires a missing path without throwing and supports release", async () => {
+    const { id, sharedDir } = nextProject();
+    trackProject(id);
+    await mkdir(sharedDir, { recursive: true });
 
-    stopSharedDriveWatcher(TEST_PROJECT_ID);
-
-    const events: SharedDriveBusEvent[] = [];
-    const unsub = bus.on<SharedDriveBusEvent>(
-      `project:${TEST_PROJECT_ID}:shared-drive`,
-      (event) => {
-        events.push(event);
-      },
-    );
-
-    await writeFile(join(sharedDir, "after-stop.md"), "ignored", "utf-8");
-    await new Promise((r) => setTimeout(r, 600));
-
-    unsub();
-
-    expect(events.length).toBe(0);
+    const topic = `shared-drive:${id}:/missing.md`;
+    expect(() => acquireSharedDriveWatch(topic)).not.toThrow();
+    await wait(50);
+    expect(() => releaseSharedDriveWatch(topic)).not.toThrow();
   });
 
-  it("does not crash when starting watcher for same project twice", async () => {
-    await ensureSharedDir();
-    startSharedDriveWatcher(TEST_PROJECT_ID);
-    await new Promise((r) => setTimeout(r, 200));
+  it("rejects path traversal and emits no events", async () => {
+    const { id, sharedDir } = nextProject();
+    trackProject(id);
+    await mkdir(sharedDir, { recursive: true });
 
-    // Second call should be a no-op
-    startSharedDriveWatcher(TEST_PROJECT_ID);
-    await new Promise((r) => setTimeout(r, 200));
+    const topic = `shared-drive:${id}:/../escape.md`;
+    acquireSharedDriveWatch(topic);
+    cleanups.push(() => releaseSharedDriveWatch(topic));
+    await wait(100);
 
-    // Should still be functional — just verify no exception was thrown
-    stopSharedDriveWatcher(TEST_PROJECT_ID);
+    const { events, unsub } = collect(topic);
+    cleanups.push(unsub);
+
+    // Modify a file inside shared (would fire if we accidentally watched root).
+    await writeFile(join(sharedDir, "decoy.md"), "x", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
+
+    expect(events.filter((e) => e.type === "file_changed").length).toBe(0);
+  });
+
+  it("refcounts: shared watcher persists until last release", async () => {
+    const { id, sharedDir } = nextProject();
+    trackProject(id);
+    await mkdir(sharedDir, { recursive: true });
+    const filePath = join(sharedDir, "shared.md");
+    await writeFile(filePath, "a", "utf-8");
+
+    const topic = `shared-drive:${id}:/shared.md`;
+    acquireSharedDriveWatch(topic);
+    acquireSharedDriveWatch(topic);
+    await wait(100);
+
+    // First release should leave the underlying watcher active.
+    releaseSharedDriveWatch(topic);
+
+    const { events, unsub } = collect(topic);
+    cleanups.push(unsub);
+
+    await writeFile(filePath, "b", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
+    expect(events.filter((e) => e.type === "file_changed").length).toBeGreaterThanOrEqual(1);
+
+    // Final release should close the watcher; subsequent changes must not emit.
+    releaseSharedDriveWatch(topic);
+
+    const beforeCount = events.filter((e) => e.type === "file_changed").length;
+    await writeFile(filePath, "c", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
+    const afterCount = events.filter((e) => e.type === "file_changed").length;
+    expect(afterCount).toBe(beforeCount);
+  });
+
+  it("releaseSharedDriveWatch on an unknown topic is a no-op", () => {
+    expect(() => releaseSharedDriveWatch("shared-drive:nope:/never")).not.toThrow();
+  });
+
+  it("scopes events to the acquired topic only", async () => {
+    const { id, sharedDir } = nextProject();
+    trackProject(id);
+    await mkdir(sharedDir, { recursive: true });
+    const a = join(sharedDir, "a.md");
+    const b = join(sharedDir, "b.md");
+    await writeFile(a, "a", "utf-8");
+    await writeFile(b, "b", "utf-8");
+
+    const topicA = `shared-drive:${id}:/a.md`;
+    const topicB = `shared-drive:${id}:/b.md`;
+    acquireSharedDriveWatch(topicA);
+    acquireSharedDriveWatch(topicB);
+    cleanups.push(() => releaseSharedDriveWatch(topicA));
+    cleanups.push(() => releaseSharedDriveWatch(topicB));
+    await wait(100);
+
+    const a1 = collect(topicA);
+    const b1 = collect(topicB);
+    cleanups.push(a1.unsub, b1.unsub);
+
+    await writeFile(a, "a-modified", "utf-8");
+    await wait(DEBOUNCE_BUFFER_MS);
+
+    expect(a1.events.filter((e) => e.type === "file_changed").length).toBeGreaterThanOrEqual(1);
+    expect(b1.events.filter((e) => e.type === "file_changed").length).toBe(0);
+  });
+
+  it("ignores malformed topics", () => {
+    expect(() => acquireSharedDriveWatch("not-a-shared-drive-topic")).not.toThrow();
+    expect(() => acquireSharedDriveWatch("shared-drive:")).not.toThrow();
+    expect(() => releaseSharedDriveWatch("not-a-shared-drive-topic")).not.toThrow();
   });
 });

--- a/src/services/shared-drive-watcher.ts
+++ b/src/services/shared-drive-watcher.ts
@@ -1,76 +1,140 @@
-import { watch, type FSWatcher } from "fs";
-import { mkdir } from "fs/promises";
-import { relative } from "path";
+import { watch, statSync, type FSWatcher } from "fs";
 import { bus, type SharedDriveBusEvent } from "../events";
+import { safePath } from "./shared-drive-paths";
 import * as workspace from "./workspace";
 
-const watchers = new Map<string, FSWatcher>();
-
-/** Tracks projects where stop was called while mkdir was still in-flight. */
-const stoppedProjects = new Set<string>();
-
-/** Debounce timers keyed by `${projectId}:${relativePath}`. */
-const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
+const TOPIC_PREFIX = "shared-drive:";
 const DEBOUNCE_MS = 300;
 
-export function startSharedDriveWatcher(projectId: string): void {
-  if (watchers.has(projectId)) return;
-  stoppedProjects.delete(projectId);
-
-  const sharedRoot = workspace.sharedDir(projectId);
-
-  // Ensure the directory exists before watching
-  mkdir(sharedRoot, { recursive: true })
-    .then(() => {
-      // Guard against stop being called before mkdir resolves
-      if (watchers.has(projectId) || stoppedProjects.has(projectId)) {
-        stoppedProjects.delete(projectId);
-        return;
-      }
-
-      const watcher = watch(sharedRoot, { recursive: true }, (_event, filename) => {
-        if (!filename) return;
-
-        // Normalize to forward-slash relative path with leading /
-        const rel = "/" + relative(sharedRoot, `${sharedRoot}/${filename}`).replace(/\\/g, "/");
-        const key = `${projectId}:${rel}`;
-
-        const existing = debounceTimers.get(key);
-        if (existing) clearTimeout(existing);
-
-        debounceTimers.set(
-          key,
-          setTimeout(() => {
-            debounceTimers.delete(key);
-            bus.emit<SharedDriveBusEvent>(`project:${projectId}:shared-drive`, {
-              type: "file_changed",
-              payload: { path: rel },
-            });
-          }, DEBOUNCE_MS),
-        );
-      });
-
-      watchers.set(projectId, watcher);
-    })
-    .catch((err) => {
-      console.error(`Failed to start shared drive watcher for project ${projectId}:`, err);
-    });
+interface Entry {
+  watcher: FSWatcher | null;
+  refCount: number;
+  debounceTimer: ReturnType<typeof setTimeout> | null;
+  pendingPath: string | null;
 }
 
-export function stopSharedDriveWatcher(projectId: string): void {
-  stoppedProjects.add(projectId);
-  const watcher = watchers.get(projectId);
-  if (watcher) {
-    watcher.close();
-    watchers.delete(projectId);
+const entries = new Map<string, Entry>();
+
+interface ParsedTopic {
+  projectId: string;
+  sharedRelPath: string;
+}
+
+function parseTopic(topic: string): ParsedTopic | null {
+  if (!topic.startsWith(TOPIC_PREFIX)) return null;
+  const rest = topic.slice(TOPIC_PREFIX.length);
+  const colonIdx = rest.indexOf(":");
+  if (colonIdx <= 0) return null;
+  const projectId = rest.slice(0, colonIdx);
+  const sharedRelPath = rest.slice(colonIdx + 1);
+  if (!sharedRelPath) return null;
+  return { projectId, sharedRelPath };
+}
+
+function buildEmitPath(
+  sharedRelPath: string,
+  filename: string | null,
+  isDirWatch: boolean,
+): string | null {
+  if (!isDirWatch) return normalizeRelPath(sharedRelPath);
+  if (!filename) return null;
+  const base = sharedRelPath.endsWith("/") ? sharedRelPath : sharedRelPath + "/";
+  return normalizeRelPath(base + filename.replace(/\\/g, "/"));
+}
+
+function normalizeRelPath(p: string): string {
+  let out = p.replace(/\/+/g, "/");
+  if (!out.startsWith("/")) out = "/" + out;
+  return out;
+}
+
+function scheduleEmit(topic: string, path: string): void {
+  const entry = entries.get(topic);
+  if (!entry) return;
+  entry.pendingPath = path;
+  if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+  entry.debounceTimer = setTimeout(() => {
+    entry.debounceTimer = null;
+    const finalPath = entry.pendingPath;
+    entry.pendingPath = null;
+    if (finalPath == null) return;
+    bus.emit<SharedDriveBusEvent>(topic, {
+      type: "file_changed",
+      payload: { path: finalPath },
+    });
+  }, DEBOUNCE_MS);
+}
+
+/**
+ * Start watching the path encoded in a `shared-drive:{projectId}:{path}` topic
+ * (or bump the refcount if it's already being watched). Safe to call repeatedly
+ * and safe for malformed topics, missing paths, or paths outside the project's
+ * shared root — those become no-ops that can still be released.
+ */
+export function acquireSharedDriveWatch(topic: string): void {
+  const parsed = parseTopic(topic);
+  if (!parsed) return;
+
+  const existing = entries.get(topic);
+  if (existing) {
+    existing.refCount += 1;
+    return;
   }
 
-  // Clean up any pending debounce timers for this project
-  for (const [key, timer] of debounceTimers) {
-    if (key.startsWith(`${projectId}:`)) {
-      clearTimeout(timer);
-      debounceTimers.delete(key);
+  const entry: Entry = {
+    watcher: null,
+    refCount: 1,
+    debounceTimer: null,
+    pendingPath: null,
+  };
+  entries.set(topic, entry);
+
+  const sharedRoot = workspace.sharedDir(parsed.projectId);
+  const absPath = safePath(sharedRoot, parsed.sharedRelPath);
+  if (!absPath) return;
+
+  let isDir: boolean;
+  try {
+    isDir = statSync(absPath).isDirectory();
+  } catch {
+    return;
+  }
+
+  try {
+    const handler = (_event: string, filename: string | Buffer | null): void => {
+      const name = typeof filename === "string" ? filename : (filename?.toString("utf-8") ?? null);
+      const path = buildEmitPath(parsed.sharedRelPath, name, isDir);
+      if (path) scheduleEmit(topic, path);
+    };
+    const watcher = isDir ? watch(absPath, { recursive: false }, handler) : watch(absPath, handler);
+    watcher.on("error", () => {
+      // fs.watch can error when the watched path is removed; swallow so the
+      // process stays up. The next acquire will re-stat and re-watch.
+    });
+    entry.watcher = watcher;
+  } catch {
+    // Failed to set up the watcher (e.g. path was deleted between stat and
+    // watch). Leave the entry intact so refcount/release still balance.
+  }
+}
+
+/**
+ * Release one reference to a `shared-drive:{projectId}:{path}` topic. When the
+ * last reference is released the underlying `FSWatcher` (if any) is closed.
+ * Safe to call with topics that were never acquired.
+ */
+export function releaseSharedDriveWatch(topic: string): void {
+  const entry = entries.get(topic);
+  if (!entry) return;
+  entry.refCount -= 1;
+  if (entry.refCount > 0) return;
+  if (entry.watcher) {
+    try {
+      entry.watcher.close();
+    } catch {
+      // Already closed.
     }
   }
+  if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+  entries.delete(topic);
 }


### PR DESCRIPTION
## Summary

- Fixes a production crash on Linux: `error: ENOSPC: no space left on device, watch '.../shared/.../node_modules/...'`. Root cause was `fs.watch(sharedRoot, { recursive: true })` in `src/services/shared-drive-watcher.ts` — Linux implements recursive watches by allocating one inotify descriptor per subdirectory, so a single project's `node_modules` or `.venv` blows past the kernel's 8192-watch default.
- Replaces the always-on, project-wide recursive watcher with on-demand, path-scoped, **non-recursive** watches driven by frontend WebSocket subscriptions. New topic format: `shared-drive:{projectId}:{path}`. Refcounted per topic so concurrent subscribers share one `FSWatcher`.
- Total inotify usage now scales with active client subscriptions (≤ 2 per browsing tab) instead of with the size of users' shared drives. macOS unaffected — this only ever manifested on Linux because macOS uses FSEvents.

## Changes

- **`src/services/shared-drive-watcher.ts`** — rewrite. Exports `acquireSharedDriveWatch(topic)` / `releaseSharedDriveWatch(topic)`. Stats the path, sets up a single non-recursive `fs.watch` on the file or directory. 300ms debounce per topic preserved.
- **`src/services/shared-drive-paths.ts`** — new. `safePath` extracted here so both `routes/shared-drive.ts` and the watcher can share the path-traversal guard.
- **`src/server.ts`** — `handleWsMessage` and `handleWsClose` call `acquire`/`release` when the subscribed topic starts with `shared-drive:`. Existing duplicate-subscribe guard ensures balanced acquire/release per ws.
- **`src/runtime/coordinator.ts`** — drops the project-wide `startSharedDriveWatcher` / `stopSharedDriveWatcher` calls.
- **`src/frontend/components/FilePreviewPanel.tsx`** — subscribes to `shared-drive:{id}:{filePath}` instead of the project-wide topic. Unsaved-changes suppression + 500ms debounce + toast preserved verbatim.
- **`src/frontend/components/sidebar/SharedDrivePanel.tsx`** — subscribes to `shared-drive:{id}:{currentPath}`, invalidates `["shared-drive", projectId, currentPath]` on `file_changed`. This is the new home for live listing refresh.
- **`src/frontend/components/ProjectLayout.tsx`** — drops the broad `project:{id}:shared-drive` subscription. Path-scoped subscriptions in the two components above cover both invalidations.

## Tests

- `src/services/shared-drive-watcher.test.ts` (8 tests): file watch emits on modify, directory watch emits on child change, missing path is no-op-but-refcounted, path traversal rejected, refcount keeps watcher alive across partial release, release-before-acquire is a no-op, distinct topics get distinct watchers, malformed topics are ignored.
- `src/server.test.ts` (NEW, 3 tests): subscribing to a `shared-drive:` topic activates the watcher and forwards `file_changed` to the ws; unsubscribe and ws-close both release the watcher cleanly.

Full suite: `1245 pass / 0 fail` across 107 files. Typecheck, lint, format all clean.

## Known limitation

If a frontend client subscribes to a path that does not yet exist on disk, no watch is allocated and no events fire even if the path is later created. In practice this only matters when a `FilePreviewPanel` is open on a path that was deleted (e.g. browser refresh restoring a deleted file from URL/localStorage) — recoverable by reopening the file. Worth a follow-up if it surfaces; the dominant case (file modified in place, directory listing while browsing) works correctly.

## Test plan

- [x] `bun test` — green
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — only pre-existing TanStack Virtual warning
- [x] `bun run format:check` — clean
- [ ] Manual on Linux: `bun add next` inside `~/.shire/projects/<id>/shared/`, confirm server stays up (before fix: ENOSPC within seconds)
- [ ] UI smoke: open shared drive panel, `touch` a file in the watched directory from terminal — file appears in the list
- [ ] UI smoke: open file preview, append to underlying file from terminal — preview refreshes with toast
- [ ] UI smoke: edit unsaved in editor, modify file from terminal — preview does NOT refresh, banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)